### PR TITLE
Rotation workaround for Moddable OS

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -31,5 +31,12 @@
         "keys": {
             "available": 128
         }
+    },
+    "devices": {
+        "esp32/m5stack": {
+            "config": {
+                "rotation": 90
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit explicitly sets the screen rotation that have been erased on the [framework side](https://github.com/Moddable-OpenSource/moddable/releases/tag/OS210826).
https://github.com/Moddable-OpenSource/moddable/commit/91b0b8bfdc4ce119d6c91df1d253f6d9be095b2b#diff-b28b62a707054fa1a133b8f4c86497d875cf002161c36219d3fe132723a3b577