### PR TITLE
Fix tilt angle

### DIFF
--- a/firmware/stackchan/rs30x-driver.ts
+++ b/firmware/stackchan/rs30x-driver.ts
@@ -28,7 +28,7 @@ export class RS30XDriver {
   }
   applyPose(pose: Pose, time: number = 0.5) {
     const panAngle = -pose.yaw * 180 / Math.PI
-    const tiltAngle = -pose.pitch * 180 / Math.PI
+    const tiltAngle = pose.pitch * 180 / Math.PI
     this._pan.setTorqueMode(TorqeMode.ON)
     this._tilt.setTorqueMode(TorqeMode.ON)
     this._pan.setAngleInTime(panAngle, time)


### PR DESCRIPTION
Tilt angle in RS30X-driver was reversed from right-hand coordinate like ROS.
This PR fixes the angle.