### PR TITLE
Fixed certificate error occurs at building docker container

### DIFF
--- a/firmware/Dockerfile
+++ b/firmware/Dockerfile
@@ -1,6 +1,8 @@
 FROM meganetaaan/moddable-esp32:latest
 LABEL maintainer "Shinya Ishikawa<ishikawa.s.1027@gmail.com>"
 
+RUN apt-get update
+RUN apt-get upgrade ca-certificates -y
 RUN curl -SL https://deb.nodesource.com/setup_14.x | bash \
     && apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
Hello. I fixed certificate error occurs at building docker container caused by an expired root certificate.

## Note
This may occurs since 20 SEP 2021.
Let's Encrypt's root certificate on docker container expired. Therefore, an update is required.
cf. 
- https://github.com/nodesource/distributions/issues/1266, 
- https://scotthelme.co.uk/lets-encrypt-old-root-expiration/