### PR TITLE
use specific tag for devcontainer

### DIFF
--- a/firmware/Dockerfile
+++ b/firmware/Dockerfile
@@ -1,4 +1,4 @@
-FROM meganetaaan/moddable-esp32:latest
+FROM meganetaaan/moddable-esp32:OS210826
 LABEL maintainer "Shinya Ishikawa<ishikawa.s.1027@gmail.com>"
 
 RUN curl -SL https://deb.nodesource.com/setup_14.x | bash \


### PR DESCRIPTION
This PR specifies the tag for devcontainer for stable build.