### PR TITLE
Use latest ModdableSDK

### DIFF
--- a/firmware/Dockerfile
+++ b/firmware/Dockerfile
@@ -1,4 +1,4 @@
-FROM meganetaaan/moddable-esp32:OS210826
+FROM meganetaaan/moddable-esp32:moddable-7276ac7
 LABEL maintainer "Shinya Ishikawa<ishikawa.s.1027@gmail.com>"
 
 RUN curl -SL https://deb.nodesource.com/setup_14.x | bash \

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -43,17 +43,5 @@
         "keys": {
             "available": 128
         }
-    },
-    "platforms": {
-        "esp32/m5stack": {
-            "config": {
-                "rotation": 90
-            }
-        },
-        "esp32/m5stack_fire": {
-            "config": {
-                "rotation": 90
-            }
-        }
     }
 }


### PR DESCRIPTION
Recent ModdableSDK improved much since the last release (OS210826), especially IO class pattern based on [TC53](https://www.ecma-international.org/ecma-tc53-seminar-on-a-modern-approach-to-embedded-software/) specification.

I'm going to rewrite Stack-chan's driver using IO class. So I updated the version of [the docker container](https://hub.docker.com/repository/docker/meganetaaan/moddable-esp32)