### PR TITLE
Fix #32 fix startup sequence of m5stack core2

### DIFF
--- a/firmware/Dockerfile
+++ b/firmware/Dockerfile
@@ -1,4 +1,4 @@
-FROM meganetaaan/moddable-esp32:moddable-7276ac7
+FROM meganetaaan/moddable-esp32:moddable-db8f973
 LABEL maintainer "Shinya Ishikawa<ishikawa.s.1027@gmail.com>"
 
 RUN curl -SL https://deb.nodesource.com/setup_14.x | bash \

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -46,14 +46,22 @@ $root@container# npm install
 
 ### Build and Flash (w/o debug function)
 
-```
+```sh
+# For M5Stack Basic/Gray/Fire
 npm run deploy
+
+# For M5Stack CORE2
+npm run deploy:m5stack_core2
 ```
 
 ### Build, Flash and Debug
 
-```
+```sh
+# For M5Stack Basic/Gray/Fire
 npm run debug
+
+# For M5Stack CORE2
+npm run deploy:m5stack_core2
 ```
 
 This command flashes debug build to Stack-chan and launches `xsbug`, the debugger of ModdableSDK.

--- a/firmware/README_ja.md
+++ b/firmware/README_ja.md
@@ -46,14 +46,23 @@ $root@container# npm install
 
 ### ビルドと書き込み(デバッグ機能を使わない場合)
 
-```
+```sh
+# M5Stack Basic/Gray/Fireの場合
 npm run deploy
+
+# M5Stack CORE2の場合
+npm run deploy:m5stack_core2
 ```
+
 
 ### ビルドと書き込み（デバッグする場合）
 
-```
+```sh
+# M5Stack Basic/Gray/Fireの場合
 npm run debug
+
+# M5Stack CORE2の場合
+npm run deploy:m5stack_core2
 ```
 
 このコマンドはデバッグ用にビルドしたファームウェアを書き込むと同時に、ModdableSDKのデバッガである`xsbug`を起動します。

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -10,7 +10,10 @@
     "generate-speech-google": "env GOOGLE_APPLICATION_CREDENTIALS=/workspaces/stack-chan/firmware/scripts/key.json node scripts/generate-speech-google.js",
     "build": "cd stackchan && mcconfig -d -m -p esp32/m5stack -t build",
     "debug": "cd stackchan && mcconfig -d -m -p esp32/m5stack",
-    "deploy": "cd stackchan && mcconfig -m -p esp32/m5stack"
+    "deploy": "cd stackchan && mcconfig -m -p esp32/m5stack",
+    "build:m5stack_core2": "cd stackchan && mcconfig -d -m -p esp32/m5stack_core2 -t build",
+    "debug:m5stack_core2": "cd stackchan && mcconfig -d -m -p esp32/m5stack_core2",
+    "deploy:m5stack_core2": "cd stackchan && mcconfig -m -p esp32/m5stack_core2"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
This PR adds some settings for M5Stack CORE2

- Adds npm scripts.
- Fixes an I2C exception of startup sequence.
  - NOTE: SDK-side fix included. You need to Update the SDK to the latest commit of [public branch](https://github.com/Moddable-OpenSource/moddable/commit/db8f9735c20c07c189d7f4a0574e787d4a6669ea), or rebuild your Docker image.
