### PR TITLE
fix  include manifest_mod.json

### DIFF
--- a/firmware/mods/cheerup/manifest.json
+++ b/firmware/mods/cheerup/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/mods/face_tracker/manifest.json
+++ b/firmware/mods/face_tracker/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/mods/look_at_target/manifest.json
+++ b/firmware/mods/look_at_target/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/mods/mimic_follow/manifest.json
+++ b/firmware/mods/mimic_follow/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/mods/mimic_main/manifest.json
+++ b/firmware/mods/mimic_main/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/mods/sing/manifest.json
+++ b/firmware/mods/sing/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/mods/talk/manifest.json
+++ b/firmware/mods/talk/manifest.json
@@ -1,4 +1,7 @@
 {
+	"include": [
+		"$(MODDABLE)/examples/manifest_mod.json"
+	],
 	"modules": {
 		"*": "./mod"
 	}

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -6,7 +6,6 @@
         "$(MODDABLE)/examples/manifest_base.json",
         "$(MODDABLE)/examples/manifest_piu.json",
         "$(MODDABLE)/examples/manifest_typings.json",
-        "$(MODDABLE)/examples/manifest_mod.json",
         "$(MODDABLE)/modules/network/mdns/manifest.json",
         "$(MODDABLE)/modules/base/modules/manifest.json",
         "$(MODULES)/pins/servo/manifest.json",


### PR DESCRIPTION
Currently  M5stack core2 fail to installing mod . Install command is `mcrun -m -p esp32/m5stack_core2`
`mod_manifest.json` defines baud rate for each device when  install mod, but `manifest.json` of each mod don't include this.

This PR fix  `manifest.json` of each mod to include `mod_manifest.json`.