### PR TITLE
Fix #56 wrong clamping that pins tilt angle to 10

### DIFF
--- a/firmware/stackchan/rs30x-driver.ts
+++ b/firmware/stackchan/rs30x-driver.ts
@@ -24,7 +24,7 @@ export class RS30XDriver {
   }
   applyPose(pose: Pose, time: number = 0.5) {
     const panAngle = -pose.yaw * 180 / Math.PI
-    const tiltAngle = Math.max(Math.min(-pose.pitch * 180 / Math.PI, -25), 10) 
+    const tiltAngle = Math.min(Math.max(-pose.pitch * 180 / Math.PI, -25), 10) 
     this._pan.setTorqueMode(TorqeMode.ON)
     this._tilt.setTorqueMode(TorqeMode.ON)
     this._pan.setAngleInTime(panAngle, time)


### PR DESCRIPTION
Fixes #56 . The usage of  `Math.min` and `Math.max` was reversed in `RS30XDriver`.