### PR TITLE
Fix reversed rotation

### DIFF
--- a/firmware/stackchan/drivers/scservo-driver.ts
+++ b/firmware/stackchan/drivers/scservo-driver.ts
@@ -40,7 +40,7 @@ export class SCServoDriver {
       }
     }
     const y = (-Math.PI * (p1.value.value.angle - 90)) / 180
-    const p = (Math.PI * (p2.value.value.angle - 90)) / 180
+    const p = (-Math.PI * (p2.value.value.angle - 90)) / 180
     return {
       success: true,
       value: {


### PR DESCRIPTION
The pitch of `SCServoDriver#getRotation` was reversed from its coordinate. Fixed.