### PR TITLE
Rotation compatibility with M5Stack Core2

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -82,7 +82,8 @@
                 "serial": {
                     "transmit": 14,
                     "receive": 13
-                }
+                },
+                "rotation": 0
             }
         }
     }

--- a/firmware/stackchan/renderers/face-renderer.ts
+++ b/firmware/stackchan/renderers/face-renderer.ts
@@ -1,3 +1,4 @@
+import config from 'mc/config'
 import Poco, { PocoPrototype } from 'commodetto/Poco'
 import { Outline, CanvasPath } from 'commodetto/outline'
 import deepEqual from 'deepEqual'
@@ -225,7 +226,7 @@ export class Renderer {
   foreground: number
 
   constructor(option?: { poco?: PocoPrototype }) {
-    this._poco = option?.poco ?? new Poco(screen, { rotation: 90 })
+    this._poco = option?.poco ?? new Poco(screen, { rotation: config.rotation })
     this.background = this._poco.makeColor(0, 0, 0)
     this.foreground = this._poco.makeColor(255, 255, 255)
     this.drawLeftEye = useDrawEye(90, 93, 8)


### PR DESCRIPTION
Currently, Display rotation of M5Stack Core2 is not same as M5stack.

![Fmhj8PCaMAAcB4u](https://user-images.githubusercontent.com/11245747/213167883-1d81745e-25c0-4cff-a6f5-00093899783e.jpeg)

This PR adds configuration of rotation for M5Stack Core2 and sets `config.ratation` at Poco constructor.

