### PR TITLE
Force overwrite symlink

### DIFF
--- a/firmware/package.json
+++ b/firmware/package.json
@@ -11,7 +11,7 @@
     "generate-speech-google": "env GOOGLE_APPLICATION_CREDENTIALS=/workspaces/stack-chan/firmware/scripts/key.json node scripts/generate-speech-google.js",
     "generate-apidoc": "typedoc --entryPointStrategy expand --plugin typedoc-plugin-markdown --out docs/api ./stackchan",
     "build": "mcconfig -d -m -p ${npm_config_target=esp32/m5stack} -t build ./stackchan/manifest.json",
-    "postbuild": "ln -s $MODDABLE/build/tmp/${npm_config_target=esp32/m5stack}/debug/stackchan/modules/tsconfig.json ./tsconfig.json",
+    "postbuild": "ln -sf $MODDABLE/build/tmp/${npm_config_target=esp32/m5stack}/debug/stackchan/modules/tsconfig.json ./tsconfig.json",
     "deploy": "mcconfig -d -m -p ${npm_config_target=esp32/m5stack} -t deploy ./stackchan/manifest.json",
     "debug": "mcconfig -d -m -p ${npm_config_target=esp32/m5stack} ./stackchan/manifest.json",
     "mod": "mcrun -d -m -p ${npm_config_target=esp32/m5stack}",


### PR DESCRIPTION
This PR changes the behavior of `posbuild` script to force overwrite symlink for avoiding errors.