### PR TITLE
Application runs without servo

### DIFF
--- a/firmware/stackchan/drivers/none-driver.ts
+++ b/firmware/stackchan/drivers/none-driver.ts
@@ -1,0 +1,20 @@
+import type { Maybe, Rotation } from '../stackchan-util'
+
+export class NoneDriver {
+  constructor(param: unknown) {}
+
+  async setTorque(torque: boolean): Promise<void> {}
+
+  async applyRotation(ori: Rotation, time = 0.5): Promise<void> {}
+
+  async getRotation(): Promise<Maybe<Rotation>> {
+    return {
+      success: true,
+      value: {
+        y: 0.0,
+        p: 0.0,
+        r: 0.0,
+      },
+    }
+  }
+}

--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -6,6 +6,7 @@ import { Robot, Driver, TTS, Renderer } from 'robot'
 import { RS30XDriver } from 'rs30x-driver'
 import { SCServoDriver } from 'scservo-driver'
 import { PWMServoDriver } from 'sg90-driver'
+import { NoneDriver } from 'none-driver'
 import { TTS as LocalTTS } from 'tts-local'
 import { TTS as VoiceVoxTTS } from 'tts-voicevox'
 import { defaultMod, StackchanMod } from 'stackchan-mod'
@@ -24,6 +25,7 @@ const drivers = new Map<string, new (param: unknown) => Driver>([
   ['scservo', SCServoDriver],
   ['pwm', PWMServoDriver],
   ['rs30x', RS30XDriver],
+  ['none', NoneDriver],
 ])
 const ttsEngines = new Map<string, new (param: unknown) => TTS>([
   ['local', LocalTTS],


### PR DESCRIPTION
By setting `none` to `driver.type` key in [manifest_local.json](https://github.com/meganetaaan/stack-chan/blob/dev/v1.0/firmware/stackchan/manifest_local.json#L9), application runs as face avater like [m5stack-avatar](https://github.com/meganetaaan/m5stack-avatar).

This feature help us to enjoy `stack-chan` without assembling board😄 

