### PR TITLE
[FR]touch for M5Stack Core2

### DIFF
--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -11,6 +11,7 @@ import { TTS as LocalTTS } from 'tts-local'
 import { TTS as VoiceVoxTTS } from 'tts-voicevox'
 import { defaultMod, StackchanMod } from 'stackchan-mod'
 import { Renderer as SimpleRenderer } from 'face-renderer'
+import Touch from 'touch'
 
 // trace(`modules of mod: ${JSON.stringify(Modules.archive)}\n`)
 // trace(`modules of host: ${JSON.stringify(Modules.host)}\n`)
@@ -70,11 +71,13 @@ const tts = new TTS({
   ...config.tts
 })
 const button = globalThis.button
+const touch = (!global.screen.touch && config.Touch) ? new Touch : undefined
 const robot = new Robot({
   driver,
   renderer,
   tts,
   button,
+  touch
 })
 
 onRobotCreated?.(robot, globalThis.device)

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -39,7 +39,8 @@
             "./drivers/*",
             "./speech/*",
             "./stackchan-util",
-            "./stk-server"
+            "./stk-server",
+            "./touch"
         ]
     },
     "preload": [
@@ -47,7 +48,8 @@
         "tts-local",
         "tts-voicevox",
         "face-renderer",
-        "stk-server"
+        "stk-server",
+        "touch"
     ],
     "ble": {
         "*": [

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -3,6 +3,7 @@ import { Vector3, Pose, Rotation, Maybe, noop, randomBetween } from 'stackchan-u
 import { type FaceContext, type Emotion, defaultFaceContext } from 'face-renderer'
 import structuredClone from 'structuredClone'
 import Digital from 'embedded:io/digital'
+import Touch from 'touch'
 
 const INTERVAL_FACE = 1000 / 30
 const INTERVAL_POSE = 1000 / 10
@@ -54,6 +55,7 @@ type RobotConstructorParam<T extends string> = {
       right: Pose
     }
   }
+  touch?: Touch
 }
 
 export class Robot {
@@ -74,6 +76,7 @@ export class Robot {
   #tts: TTS
   #driver: Driver
   #button: { [key in ButtonName]: Button }
+  #touch:Touch
   #isMoving: boolean
   #renderer: Renderer
   #updateFaceHandler: Timer
@@ -85,6 +88,7 @@ export class Robot {
     this.#isMoving = false
     this.#power = 0
     this.#button = params.button
+    this.#touch = params.touch
     this.#pose = params.pose ?? {
       body: {
         position: {
@@ -174,6 +178,15 @@ export class Robot {
   get button() {
     return this.#button
   }
+
+    /**
+   * get Touch
+   *
+   * @returns Touch instances
+   */
+    get touch() {
+      return this.#touch
+    }
 
   /**
    * get Pose

--- a/firmware/stackchan/touch.ts
+++ b/firmware/stackchan/touch.ts
@@ -1,0 +1,38 @@
+import config from 'mc/config'
+import Timer from 'timer'
+import Time from 'time'
+
+export default class Touch {
+  onTouchBegan: (x: number, y: number, ticks: number) => void
+  onTouchMoved: (x: number, y: number, ticks: number) => void
+  onTouchEnded: (x: number, y: number, ticks: number) => void
+
+  constructor() {
+    let touch = new config.Touch()
+    touch.points = [{}]
+
+    Timer.repeat(() => {
+      const points = touch.points
+      touch.read(points)
+      const point = points[0]
+      switch (point.state) {
+        case 0:
+        case 3:
+          if (point.down) {
+            delete point.down
+            this.onTouchEnded?.(point.x, point.y, Time.ticks)
+            delete point.x
+            delete point.y
+          }
+          break
+        case 1:
+        case 2:
+          if (!point.down) {
+            point.down = true
+            this.onTouchBegan?.(point.x, point.y, Time.ticks)
+          } else this.onTouchMoved?.(point.x, point.y, Time.ticks)
+          break
+      }
+    }, 15)
+  }
+}


### PR DESCRIPTION
In current default branch `dev/v1.0`,  face rendering was changed to `commodetto` from `Piu` (#91). Therefore, touch instance was not created at [piu.js](https://github.com/Moddable-OpenSource/moddable/blob/public/build/devices/esp32/setup/piu.js#L58l) and `robot.button` don't works in M5Stack Core2.

This PR sets touch instance to `robot` and makes `button` works. In addition to this, `robot.touch` provides  TouchEvent handlers `onTouchBegan`, `onTouchMoved`, and `onTouchEnded`.

These handlers helps us to implement touch interactions.


