### PR TITLE
npm run doctor shows  stack-chan environment info

### DIFF
--- a/firmware/package.json
+++ b/firmware/package.json
@@ -18,7 +18,7 @@
     "debug": "mcconfig -d -m -p ${npm_config_target=esp32/m5stack} ./stackchan/manifest.json",
     "mod": "mcrun -d -m -p ${npm_config_target=esp32/m5stack}",
     "setup": "xs-dev setup",
-    "doctor": "xs-dev doctor",
+    "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",
     "scan": "xs-dev scan"
   },
   "type": "module",


### PR DESCRIPTION
This PR adds  `npm run doctor` to show  following additional information of stack-chan environment. These information help us to investigate issues.
* Git commit hash
* Path to stack-chan repository

```
root@docker-desktop:/workspaces/stack-chan/firmware# npm run doctor

> stack-chan@0.2.1 doctor /workspaces/stack-chan/firmware
> echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor

stack-chan environment info:
cfc19242e6b13ebfa2ce1858bb9f5e96d1bc0c2d
/workspaces/stack-chan
xs-dev environment info:
  CLI Version                0.20.0                                                   
  OS                         Linux                                                    
  Arch                       x64                                                      
  NodeJS Version             v14.21.3 (/usr/bin/node)                                 
  Python Version             3.8.10 (/opt/esp/python_env/idf4.4_py3.8_env/bin/python) 
  Moddable SDK Version       3.7.0 (/root/Projects/moddable)                          
  Supported target devices   lin, esp32                                               
  ESP32 IDF Directory        /opt/esp/idf                                             
```

I tested this with Mac / Windows / Linux(Docker container).