### PR TITLE
Depricate Docker on Windows(WSL) and MacOS

### DIFF
--- a/firmware/docs/getting-started.md
+++ b/firmware/docs/getting-started.md
@@ -44,12 +44,12 @@ $ npm run setup -- --device=esp32
 
 The script internally uses [`xs-dev`](https://github.com/HipsterBrown/xs-dev) to automate the setup of ModdableSDK and ESP-IDF.
 
-### Using Docker images
+### Using Docker images (for Linux only)
 
 This repository provides a Dockerfile build environment.
 You can build, write and debug firmware inside a Docker container.
 
-Note: This has been tested on Linux (Ubuntu 20.04); it may not work properly on Windows (WSL) or MacOS.
+Note: This has been tested and confirmed to work on Linux (Ubuntu 20.04). It is not recommended for use on Windows (WSL) or MacOS, as there have been reported [issues](https://github.com/meganetaaan/stack-chan/issues/144) with connecting to devices from the container side.
 
 #### From terminal
 

--- a/firmware/docs/getting-started_ja.md
+++ b/firmware/docs/getting-started_ja.md
@@ -44,12 +44,12 @@ $ npm run setup -- --device=esp32
 
 内部で[`xs-dev`](https://github.com/HipsterBrown/xs-dev)を使ってModdableSDKやESP-IDFのセットアップを自動化しています。
 
-### Dockerイメージを使う
+### Dockerイメージを使う（Linuxのみ）
 
 このリポジトリはDockerfileによるビルド環境を提供しています。
 Dockerコンテナの中でファームウェアのビルド、書き込みとデバッグが可能です。
 
-注意：Linux（Ubuntu20.04）で動作確認しています。Windows（WSL）やMacOSでは正しく動作しない可能性があります。
+注意：Linux（Ubuntu20.04）で動作確認しています。Windows（WSL）やMacOSでは、コンテナ側からのデバイスへの接続がうまくいかない[問題](https://github.com/meganetaaan/stack-chan/issues/144)が報告されているため、非推奨です。
 
 #### ターミナルから
 


### PR DESCRIPTION
Now using the docker image of Stack-chan on Windows (WSL) or MacOS is not recommended due to reported in #144 with connecting to devices from the container side.