### PR TITLE
fix monologue saying key

### DIFF
--- a/firmware/mods/monologue/mod.js
+++ b/firmware/mods/monologue/mod.js
@@ -7,7 +7,7 @@ const keys = Object.keys(speeches)
 async function sayMonologue(robot) {
   const idx = Math.floor(randomBetween(0, keys.length))
   const key = keys[idx]
-  await robot.say(config.tts.type=='local'? key:speeches[key])
+  await robot.say(config.tts.type == 'local' ? key : speeches[key])
 }
 
 function onRobotCreated(robot) {

--- a/firmware/mods/monologue/mod.js
+++ b/firmware/mods/monologue/mod.js
@@ -1,12 +1,13 @@
 import { speeches } from 'speeches_monologue'
 import { randomBetween } from 'stackchan-util'
+import config from 'mc/config'
 
 const keys = Object.keys(speeches)
 
 async function sayMonologue(robot) {
   const idx = Math.floor(randomBetween(0, keys.length))
   const key = keys[idx]
-  await robot.say(key)
+  await robot.say(config.tts.type=='local'? key:speeches[key])
 }
 
 function onRobotCreated(robot) {


### PR DESCRIPTION
monologueのmodにおいて、`robot.say`にキー（sentense1など）が渡されていたのでバリューを渡すようにします