### PR TITLE
Fix #156 specify sampleRate for dynamic TTS with VOICEVOX

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -93,6 +93,9 @@
                     "pwmPan": 19,
                     "pwmTilt": 27
                 },
+                "tts": {
+                    "sampleRate": 24000
+                },
                 "serial": {
                     "transmit": 14,
                     "receive": 13

--- a/firmware/stackchan/speech/tts-voicevox.ts
+++ b/firmware/stackchan/speech/tts-voicevox.ts
@@ -90,7 +90,6 @@ export class TTS {
         audio: {
           out: audio,
           stream: 0,
-          sampleRate: 12000,
         },
         bufferDuration: 600,
         request: {

--- a/firmware/typings/wavstreamer.d.ts
+++ b/firmware/typings/wavstreamer.d.ts
@@ -13,7 +13,7 @@ declare module "wavstreamer" {
     path: string,
     audio: {
       out: AudioOut,
-      sampleRate: number,
+      sampleRate?: number,
       stream: number,
     },
     bufferDuration?: number,


### PR DESCRIPTION
This PR adds capabilities to modify sampleRate other than 24000 for TTS with VOICEVOX.
This is a workaround for #156, specifing the default sampleRate to 11025 for m5stack basic.