### PR TITLE
Use lower case for Headers

### DIFF
--- a/firmware/stackchan/speech/tts-voicevox.ts
+++ b/firmware/stackchan/speech/tts-voicevox.ts
@@ -102,8 +102,8 @@ export class TTS {
         request: {
           method: 'POST',
           headers: new Map([
-            ['Content-Type', 'application/json'],
-            ['Content-Length', `${file.length}`],
+           ['content-type', 'application/json'],
+           ['content-length', `${file.length}`],
           ]),
           onWritable(count) {
             this.write(file.read(ArrayBuffer, count))


### PR DESCRIPTION
We should use lower case for header fields
https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2