### PR TITLE
Fix advertising

### DIFF
--- a/firmware/stackchan/services/preference-server.ts
+++ b/firmware/stackchan/services/preference-server.ts
@@ -1,4 +1,4 @@
-import { UARTServer } from 'uartserver'
+import { UARTServer, SERVICE_UUID } from 'uartserver'
 import Preference from 'preference'
 import { DOMAIN } from 'consts'
 
@@ -29,7 +29,9 @@ export class PreferenceServer extends UARTServer {
     this.#handleConnected?.()
   }
   onDisconnected() {
-    super.onDisconnected()
+    this.startAdvertising({
+      advertisingData: { flags: 6, completeName: this.deviceName, completeUUID128List: [SERVICE_UUID] },
+    })
     this.#handleDisconnected?.()
   }
   onCharacteristicNotifyEnabled(characteristic) {

--- a/firmware/typings/uartserver.d.ts
+++ b/firmware/typings/uartserver.d.ts
@@ -5,7 +5,10 @@ declare module 'uartserver' {
     onConnected(): void
     onDisconnected(): void
     onRX(data: ArrayBuffer): void
+    startAdvertising(params: unknown): void
   }
 
-  export { UARTServer }
+  const SERVICE_UUID: string
+
+  export { UARTServer, SERVICE_UUID }
 }


### PR DESCRIPTION
ブラウザからｽﾀｯｸﾁｬﾝの設定画面へのBLE接続ができない不具合を修正します。

Moddableの`modules/network/ble/uart/uartserver.js`をそのまま使う場合、`startAdvertising`時のflagが4に設定されるために他のデバイスからの発見ができなくなるようです。
開発中は同等の機能を持つ`examples/network/ble/uart-server/main.js`をコピーして使っていましたが、こちらはflagは6になり発見可能でした。
Moddable側の不具合か、そもそもuart-clientとuart-serverならば一対一接続ができるのかは未確認です。

修正として、自前のクラス`preference-server`側で正しい引数を与えて`startAdvertising`を呼ぶようにしました。