### PR TITLE
Fix/set time on wifi

### DIFF
--- a/firmware/stackchan/services/network-service.ts
+++ b/firmware/stackchan/services/network-service.ts
@@ -50,7 +50,8 @@ export class NetworkService {
               trace(`Got time from: ${config.sntp}\n`)
               Time.set(value)
               onConnected?.()
-            } else if (SNTP.error === (message as -1 | 1 | 2)) { // workaround for the type mistake
+            } else if (SNTP.error === (message as -1 | 1 | 2)) {
+              // workaround for the type mistake
               onError?.('Failed to get time')
             }
           })

--- a/firmware/stackchan/services/network-service.ts
+++ b/firmware/stackchan/services/network-service.ts
@@ -1,6 +1,10 @@
 import WiFi from 'wifi'
-const MAX_SCANS = 3
+import Net from 'net'
+import Time from 'time'
+import config from 'mc/config'
+import SNTP from 'sntp'
 
+const MAX_SCANS = 3
 export class NetworkService {
   #ssid?: string
   #password?: string
@@ -25,11 +29,31 @@ export class NetworkService {
     this.#wifi = new WiFi({ ssid: this.#ssid, password: this.#password }, (msg) => {
       trace(`WiFi ${msg}\n`)
       switch (msg) {
+        case WiFi.connected:
+          trace(`Connected to: ${Net.get('SSID')}\n`)
+          break
+
         case WiFi.gotIP:
+          trace(`Got IP address: ${Net.get('IP')}\n`)
           this.#connecting = false
           this.#connectionEstablished = true
           this.#retry = 0
-          onConnected?.()
+
+          // Setting time for TLS connection
+          if (!config.sntp || Date.now() > 1672722071_000) {
+            trace(`Time already configured, skipping\n`)
+            onConnected?.()
+            break
+          }
+          new SNTP({ host: config.sntp }, function (message, value) {
+            if (SNTP.time === message) {
+              trace(`Got time from: ${config.sntp}\n`)
+              Time.set(value)
+              onConnected?.()
+            } else if (SNTP.error === (message as -1 | 1 | 2)) { // workaround for the type mistake
+              onError?.('Failed to get time')
+            }
+          })
           break
         case WiFi.disconnected:
           this.#connecting = false


### PR DESCRIPTION
デバッガ`xsbug`を接続していない場合、現在時刻の情報をNTPで取得する必要があります。
時刻が合っていないとHTTPS接続（TLSコネクションの確立）に失敗します。