### PR TITLE
fix install button selector

### DIFF
--- a/web/flash/index.html
+++ b/web/flash/index.html
@@ -11,7 +11,7 @@
   <script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const button = document.querySelector('.button-flash')
+      const button = document.querySelector('esp-web-install-button')
       const select = document.querySelector('.select-target')
       select.addEventListener('change', (event) => {
         const target = event.target.value


### PR DESCRIPTION
[Flash firmware](https://meganetaaan.github.io/stack-chan/web/flash/)にて初期値のM5stack以外を選択してインストールした際に起動しない問題が発生しています。

選択を切り替えた際のmanifestファイルを指定するタグが`esp-web-install-button`タグでなく配下の`button`タグになっているため切り替え処理を修正しました。