### PR TITLE
Bundle CoreS3 image

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -98,7 +98,8 @@
         "devices": [
             "com.m5stack",
             "com.m5stack.fire",
-            "com.m5stack.core2"
+            "com.m5stack.core2",
+            "com.m5stack.cores3"
         ]
     },
     "platforms": {


### PR DESCRIPTION
This PR adds `m5stack_cores3` target to the bundle family which is left from https://github.com/meganetaaan/stack-chan/pull/184