### PR TITLE
Wait 100ms till CoreS3 touch IC is ready

### DIFF
--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -17,7 +17,7 @@ import { Renderer as SimpleRenderer } from 'simple-face'
 import { Renderer as DogFaceRenderer } from 'dog-face'
 import { NetworkService } from 'network-service'
 import Touch from 'touch'
-import { loadPreferences } from 'stackchan-util'
+import { loadPreferences, asyncWait } from 'stackchan-util'
 
 function createRobot() {
   const drivers = new Map<string, new (param: unknown) => Driver>([
@@ -99,6 +99,7 @@ async function checkAndConnectWiFi() {
 }
 
 async function main() {
+  await asyncWait(100)
   await checkAndConnectWiFi().catch((msg) => {
     trace(`WiFi connection failed: ${msg}`)
   })


### PR DESCRIPTION
M5Stack CoreS3ではタッチICの初期化が完了する前にI2Cを介してチップIDなどのレジスタにアクセスしようとすると0が返されてエラーになる場合がありました。Moddable側で対処する必要がありますが、暫定措置としてメイン関数に非同期の待ち時間を追加します。

---

In the M5Stack CoreS3, if you try to access the chip ID and other registers via I2C before the initialization of the touch IC is complete, it may return 0 and cause an error. It is necessary to address this issue on the Moddable side, but as a temporary measure, we will add an asynchronous waiting time to the main function.