### PR TITLE
Fix BLE module build

### DIFF
--- a/firmware/stackchan/ble/manifest_ble.json
+++ b/firmware/stackchan/ble/manifest_ble.json
@@ -1,7 +1,10 @@
 {
   "include": [
+    "$(MODDABLE)/examples/manifest_typings.json",
     "$(MODULES)/network/ble/manifest_server.json",
-    "$(MODULES)/network/ble/manifest_client.json"
+    "$(MODULES)/network/ble/manifest_client.json",
+    "../utilities/manifest_utility.json",
+    "../manifest_typings.json"
   ],
   "modules": {
     "*": [


### PR DESCRIPTION
manifestの依存関係の記述が足りておらず、BLEモジュールを単独でビルドできない不具合を解消します。

---

This PR resolves the issue where the BLE module cannot be built standalone due to insufficient dependency descriptions in the manifest.