### PR TITLE
Add an optional `model` property for ElevenLabsTTS

### DIFF
--- a/firmware/stackchan/speeches/tts-elevenlabs.ts
+++ b/firmware/stackchan/speeches/tts-elevenlabs.ts
@@ -9,6 +9,7 @@ export type TTSProperty = {
   onPlayed: (number) => void
   onDone: () => void
   token: string
+  model?: string
 }
 
 export class TTS {
@@ -16,12 +17,14 @@ export class TTS {
   onPlayed: (number) => void
   onDone: () => void
   token: string
+  model: string
   streaming: boolean
   constructor(props: TTSProperty) {
     this.onPlayed = props.onPlayed
     this.onDone = props.onDone
     this.audio = new AudioOut({ streams: 1, bitsPerSample: 16, sampleRate: 44100 })
     this.token = props.token
+    this.model = props.model ?? 'eleven_monolingual_v1'
   }
   async stream(text: string): Promise<void> {
     if (this.streaming) {
@@ -34,6 +37,7 @@ export class TTS {
       let streamer = new ElevenLabsStreamer({
         key: this.token,
         voice: 'AZnzlk1XvdvUeBnXmlld',
+        model: this.model,
         latency: 2,
         text,
         audio: {

--- a/firmware/typings/elevenlabsstreamer.d.ts
+++ b/firmware/typings/elevenlabsstreamer.d.ts
@@ -5,6 +5,7 @@ declare module "elevenlabsstreamer" {
         voice?: string,
         latency?: number,
         text: string,
+        model?: string,
         audio: {
             out: AudioOut,
             sampleRate?: number,


### PR DESCRIPTION
ElevenLabs APIでは音声合成に使用するモデルを`model`プロパティで[指定できます](https://docs.elevenlabs.io/speech-synthesis/models)。
このPRはElevenLabsTTSにモデルを指定するためのプロパティ`model`を追加します。

---

In the ElevenLabs API, you can specify the model to use for speech synthesis with the `model` property [as documented here](https://docs.elevenlabs.io/speech-synthesis/models). This PR adds the `model` property to ElevenLabsTTS to specify the model.
