### PR TITLE
more parameters for elevenlabs

### DIFF
--- a/firmware/stackchan/speeches/tts-elevenlabs.ts
+++ b/firmware/stackchan/speeches/tts-elevenlabs.ts
@@ -5,11 +5,22 @@ import calculatePower from 'calculate-power'
 
 /* global trace, SharedArrayBuffer */
 
+type voiceSettings = {
+  similarity_boost: number
+  stability: number
+  style?: number
+  use_speaker_boost?: boolean
+}
+
 export type TTSProperty = {
   onPlayed: (number) => void
   onDone: () => void
   token: string
+  voice?: string
+  latency?: number
+  format?: string
   model?: string
+  voice_settings?: voiceSettings
 }
 
 export class TTS {
@@ -18,13 +29,21 @@ export class TTS {
   onDone: () => void
   token: string
   model: string
+  voice: string
+  latency: number
+  format: string
+  voice_settings: voiceSettings
   streaming: boolean
   constructor(props: TTSProperty) {
     this.onPlayed = props.onPlayed
     this.onDone = props.onDone
     this.audio = new AudioOut({ streams: 1, bitsPerSample: 16, sampleRate: 44100 })
     this.token = props.token
+    this.latency = props.latency ?? 2
+    this.format = props.format ?? 'mp3_44100_64'
     this.model = props.model ?? 'eleven_monolingual_v1'
+    this.voice = props.voice ?? 'AZnzlk1XvdvUeBnXmlld'
+    this.voice_settings = props.voice_settings
   }
   async stream(text: string): Promise<void> {
     if (this.streaming) {
@@ -36,9 +55,11 @@ export class TTS {
     return new Promise((resolve, reject) => {
       let streamer = new ElevenLabsStreamer({
         key: this.token,
-        voice: 'AZnzlk1XvdvUeBnXmlld',
+        voice: this.voice,
         model: this.model,
-        latency: 2,
+        latency: this.latency,
+        format: this.format,
+        voice_settings: this.voice_settings,
         text,
         audio: {
           out: audio,

--- a/firmware/typings/elevenlabsstreamer.d.ts
+++ b/firmware/typings/elevenlabsstreamer.d.ts
@@ -4,8 +4,15 @@ declare module "elevenlabsstreamer" {
         key: string,
         voice?: string,
         latency?: number,
+        format?: string,
         text: string,
         model?: string,
+        voice_settings?: {
+            similarity_boost: number,
+            stability: number,
+            style?: number,
+            use_speaker_boost?: boolean
+        }
         audio: {
             out: AudioOut,
             sampleRate?: number,


### PR DESCRIPTION
https://github.com/Moddable-OpenSource/moddable/commit/e95cde090ea079e79779246eea8611b0f8628cd4 でElevenLabsのTTSに対して指定できるパラメータを拡張しました。
本PRは同様に`tts-elevenlabs`でもパラメータを指定できるようにします。

また、`output_format`のデフォルト値を`mp3_44100_64 `に変更することにより転送量が減るため、TTSが若干安定するようになります。