### PR TITLE
Add dialogue claude3

### DIFF
--- a/firmware/stackchan/dialogues/manifest_dialogue.json
+++ b/firmware/stackchan/dialogues/manifest_dialogue.json
@@ -4,11 +4,10 @@
     "$(MODDABLE)/modules/data/headers/manifest.json"
   ],
   "modules": {
-    "*": [
-      "./*"
-    ]
+    "*": ["./*"]
   },
-  "preload": [
-    "dialugue-chatgpt"
-  ]
+  "preload": ["dialugue-chatgpt"],
+  "data": {
+    "*": ["$(MODULES)/crypt/data/ca233"]
+  }
 }

--- a/firmware/tests/dialogues/dialogues-chatgpt/main.ts
+++ b/firmware/tests/dialogues/dialogues-chatgpt/main.ts
@@ -1,0 +1,13 @@
+import { ChatGPTDialogue } from 'dialogue-chatgpt'
+
+const token = 'YOUR_API_KEY_HERE'
+
+const dialogue = new ChatGPTDialogue({ 
+    apiKey: token
+ })
+
+const result = await dialogue.post("こんにちは");
+
+if(result.success){
+    trace(result.value)
+}

--- a/firmware/tests/dialogues/dialogues-chatgpt/manifest.json
+++ b/firmware/tests/dialogues/dialogues-chatgpt/manifest.json
@@ -1,0 +1,20 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/utilities/manifest_utility.json",
+    "../../../stackchan/dialogues/manifest_dialogue.json",
+    "../../../stackchan/manifest_typings.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
+    }
+  },
+  "data": {
+    "*": ["$(MODULES)/crypt/data/ca233"]
+  }
+}

--- a/firmware/tests/dialogues/dialogues-claude3/main.ts
+++ b/firmware/tests/dialogues/dialogues-claude3/main.ts
@@ -1,0 +1,12 @@
+import { Claude3Dialogue } from 'dialogue-claude3'
+
+const token = 'YOUR_API_KEY_HERE'
+
+const dialogue = new Claude3Dialogue({ 
+    apiKey: token
+ })
+
+const result = await dialogue.post("こんにちは");
+if(result.success){
+    trace(result.value)
+}

--- a/firmware/tests/dialogues/dialogues-claude3/manifest.json
+++ b/firmware/tests/dialogues/dialogues-claude3/manifest.json
@@ -1,0 +1,17 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/utilities/manifest_utility.json",
+    "../../../stackchan/dialogues/manifest_dialogue.json",
+    "../../../stackchan/manifest_typings.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
+    }
+  }
+}


### PR DESCRIPTION
Claude3 の [message API](https://docs.anthropic.com/claude/reference/messages_post)対応になります。

* [ChatGPTDialogue](https://github.com/meganetaaan/stack-chan/blob/dev/v1.0/firmware/stackchan/dialogues/dialogue-chatgpt.ts)をベースに作成しており重複コードが多いですが、共通化は未実施です
* ｽﾀｯｸﾁｬﾝでの動作確認は [mods/ai_stackchan_api](https://github.com/meganetaaan/stack-chan/blob/dev/v1.0/firmware/mods/ai_stackchan_api/mod.js#L2)で`ChatGPTDialogue` を置き換えて確認しています
* また、PC上で単独で動作確認できるようにtestアプリをChatGPTDialogueと合わせて追加しています