### PR TITLE
Fix #246 web manifest for flashing to M5Stack CoreS3

### DIFF
--- a/web/flash/manifest_esp32_m5stack_cores3.json
+++ b/web/flash/manifest_esp32_m5stack_cores3.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "builds": [
     {
-      "chipFamily": "ESP32",
+      "chipFamily": "ESP32-S3",
       "parts": [
         {
           "path": "tech.moddable.stackchan/com.m5stack.cores3/bootloader.bin",
-          "offset": 4096
+          "offset": 0
         },
         {
           "path": "tech.moddable.stackchan/com.m5stack.cores3/partition-table.bin",


### PR DESCRIPTION
This PR addresses issue #246. It corrects incorrect parameters in the manifest.json file for the esp-web-tools that were affecting the M5Stack CoreS3 settings. I have verified locally that it is now possible to write to the CoreS3 target using the web interface.