### PR TITLE
optional chaining for globalThis.Host.Button

### DIFF
--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -103,7 +103,7 @@ async function checkAndConnectWiFi() {
 }
 
 async function main() {
-  if (globalThis.Host.Button && !globalThis.button) {
+  if (globalThis.Host?.Button && !globalThis.button) {
     // wrapper button class for simulator
     class SimButton {
       #button


### PR DESCRIPTION
from [discord q-and-a](https://discord.com/channels/1095725099925110847/1226532743479951370/1237233623258759229) 

In #251, My confirmation of M5stack was omitted.
This fix prevent access to unavailable object `globalThis.Host.Button`.

