### PR TITLE
Add npm run flash-erase

### DIFF
--- a/firmware/docs/flashing-firmware.md
+++ b/firmware/docs/flashing-firmware.md
@@ -195,6 +195,39 @@ $ npm run mod ./mods/look_around/manifest.json
 Installing mod...complete
 ```
 
+## (Optional)erase flash
+
+After writing the MOD, if you want to revert to the behavior before the MOD was written, you can erase the written MOD with the following command.
+
+> [!NOTE]  
+> When you execute the command, it erases not only the MOD area but the entire flash region.  
+> Please note that if you are using Preferences to write settings, those settings will also be erased.  
+> Additionally, after executing the command, you will need to write to the host again.  
+
+```console
+$ npm run erase-flash
+
+> stack-chan@0.2.1 erase-flash
+> esptool.py erase_flash
+
+esptool.py v4.8.dev4
+Found 2 serial ports
+Serial port /dev/cu.usbserial-01F05597
+Connecting....
+Detecting chip type... Unsupported detection protocol, switching and trying again...
+Connecting.........
+Detecting chip type... ESP32
+Chip is ESP32-D0WDQ6-V3 (revision v3.0)
+Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
+Crystal is 40MHz
+MAC: 8c:aa:b5:81:6c:1c
+Uploading stub...
+Running stub...
+Stub running...
+Erasing flash (this may take a while)...
+Chip erase completed successfully in 25.4s
+Hard reset
+
 ## Next Step
 
 - [mods/README.md](../mods/README.md): The list of example mods

--- a/firmware/docs/flashing-firmware.md
+++ b/firmware/docs/flashing-firmware.md
@@ -200,7 +200,7 @@ Installing mod...complete
 After writing the MOD, if you want to revert to the behavior before the MOD was written, you can erase the written MOD with the following command.
 
 > [!NOTE]  
-> When you execute the command, it erases not only the MOD area but the entire flash region.  
+> When you execute the command, it erases not only the MOD area but the entire flash area.  
 > Please note that if you are using Preferences to write settings, those settings will also be erased.  
 > Additionally, after executing the command, you will need to write to the host again.  
 

--- a/firmware/docs/flashing-firmware_ja.md
+++ b/firmware/docs/flashing-firmware_ja.md
@@ -199,6 +199,40 @@ $ npm run mod ./mods/look_around/manifest.json
 Installing mod...complete
 ```
 
+## (オプショナル)フラッシュ領域の消去
+
+MODを描き込み後、MODを書き込みする前の挙動に戻したい時は、次のコマンドで書き込んだMODを消去することができます。
+
+> [!NOTE]  
+> コマンドを実行するとMODの領域だけでなく、フラッシュ領域全体を消去します。  
+> Preferenceを使って設定値を書き込んでいる場合、その設定も消去されることに注意してください。  
+> また、コマンド実行後は再度ホストの書き込みが必要になります。  
+
+```console
+$ npm run erase-flash
+
+> stack-chan@0.2.1 erase-flash
+> esptool.py erase_flash
+
+esptool.py v4.8.dev4
+Found 2 serial ports
+Serial port /dev/cu.usbserial-01F05597
+Connecting....
+Detecting chip type... Unsupported detection protocol, switching and trying again...
+Connecting.........
+Detecting chip type... ESP32
+Chip is ESP32-D0WDQ6-V3 (revision v3.0)
+Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
+Crystal is 40MHz
+MAC: 8c:aa:b5:81:6c:1c
+Uploading stub...
+Running stub...
+Stub running...
+Erasing flash (this may take a while)...
+Chip erase completed successfully in 25.4s
+Hard resetting via RTS pin...
+```
+
 ## 次のステップ
 
 - [mods/README_ja.md](../mods/README_ja.md): 同梱のサンプル MOD の紹介です。

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -20,7 +20,8 @@
     "mod": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcrun -d -m -p $npm_config_target",
     "setup": "xs-dev setup",
     "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",
-    "scan": "xs-dev scan"
+    "scan": "xs-dev scan",
+    "erase-flash": "esptool.py erase_flash"
   },
   "type": "module",
   "repository": {


### PR DESCRIPTION
#104 の代替案ないし派生となります。

mod領域のみを消去したいケースもありますが、NVSの設定値の次第ではNVS領域も含めて全て消去したいケースもあるかと思います。

本PRでは`npm run flash-erase`を追加し、全領域を削除を可能とします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `"erase-flash"` script command for the firmware project, allowing users to easily erase the flash memory of the ESP32 device, enhancing firmware update and recovery processes.

- **Documentation**
	- Added detailed instructions on using the new erase command in the English and Japanese documentation, including important implications and examples of the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->