### PR TITLE
update xs-dev  0.30.3-> 0.30.5

### DIFF
--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -26,7 +26,7 @@
         "typedoc-plugin-markdown": "^3.14.0",
         "typescript": "^4.8.4",
         "web-audio-engine": "^0.13.4",
-        "xs-dev": "^0.30.3",
+        "xs-dev": "^0.30.5",
         "yargs": "^17.6.2"
       }
     },
@@ -5192,9 +5192,9 @@
       "dev": true
     },
     "node_modules/xs-dev": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/xs-dev/-/xs-dev-0.30.3.tgz",
-      "integrity": "sha512-T6wd9GLZ76ZLi3fW7t/E3GHmyGf56mAAC5j0a+qR2mHmm2NyFqI+JFd/CGs3Gd43KlelXgbpMzYBi0SSK1V0/w==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/xs-dev/-/xs-dev-0.30.5.tgz",
+      "integrity": "sha512-Je5pSoXgdMp8lI1Ys+XgPxho/zlGwVszAMLE/tyrIQtZCM67yyrQah34vGTeYPwY4pD/1+0z0zHSr555oLa/dw==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^19.0.3",

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -58,7 +58,7 @@
     "typedoc-plugin-markdown": "^3.14.0",
     "typescript": "^4.8.4",
     "web-audio-engine": "^0.13.4",
-    "xs-dev": "^0.30.3",
+    "xs-dev": "^0.30.5",
     "yargs": "^17.6.2"
   }
 }


### PR DESCRIPTION
Moddableの最新化に伴いESP-IDFが5.2.2になりましたが、xs-devが古い5.1.2のままのためCIでビルドに失敗します。

本PRでは以下変更を取り込んだxs-dev最新版を使用することでビルドを成功するようにします
https://github.com/HipsterBrown/xs-dev/pull/165