### PR TITLE
update xs-dev 0.30.3-> 0.32.0

### DIFF
--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -26,7 +26,7 @@
         "typedoc-plugin-markdown": "^3.14.0",
         "typescript": "^4.8.4",
         "web-audio-engine": "^0.13.4",
-        "xs-dev": "^0.30.3",
+        "xs-dev": "^0.32.0",
         "yargs": "^17.6.2"
       }
     },
@@ -5192,9 +5192,9 @@
       "dev": true
     },
     "node_modules/xs-dev": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/xs-dev/-/xs-dev-0.30.3.tgz",
-      "integrity": "sha512-T6wd9GLZ76ZLi3fW7t/E3GHmyGf56mAAC5j0a+qR2mHmm2NyFqI+JFd/CGs3Gd43KlelXgbpMzYBi0SSK1V0/w==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/xs-dev/-/xs-dev-0.32.0.tgz",
+      "integrity": "sha512-MldlraXbHVGdrKBScM61hhL/2Ak0IOU02Z4yMqeOWROej7RftNhHygKhktYUybiTRrUTPHIZAEOOXVEK5X5gSw==",
       "dev": true,
       "dependencies": {
         "@octokit/rest": "^19.0.3",

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -58,7 +58,7 @@
     "typedoc-plugin-markdown": "^3.14.0",
     "typescript": "^4.8.4",
     "web-audio-engine": "^0.13.4",
-    "xs-dev": "^0.30.3",
+    "xs-dev": "^0.32.0",
     "yargs": "^17.6.2"
   }
 }


### PR DESCRIPTION
#258 作成時よりModdable4.9.5がリリースされ、ESP-IDFも5.3が必要となったため、それに対応したxs-devにバージョンアップします