### PR TITLE
OpenAI APIの証明書更新

### DIFF
--- a/firmware/stackchan/dialogues/manifest_dialogue.json
+++ b/firmware/stackchan/dialogues/manifest_dialogue.json
@@ -8,6 +8,6 @@
   },
   "preload": ["dialugue-chatgpt"],
   "data": {
-    "*": ["$(MODULES)/crypt/data/ca233"]
+    "*": ["$(MODULES)/crypt/data/ca236"]
   }
 }


### PR DESCRIPTION
先月ごろに証明書更新に伴い証明書ファイルを変更します。
Claude3についても同様に`ca236`への変更が必要であり、testアプリで動作確認をしています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated data resource path to enhance application interaction with the associated cryptographic module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->