### PR TITLE
Make tests/speeches configurable from `config`

### DIFF
--- a/firmware/tests/speeches/tts-elevenlabs/main.ts
+++ b/firmware/tests/speeches/tts-elevenlabs/main.ts
@@ -1,7 +1,11 @@
+import config from 'mc/config'
 import { TTS, TTSProperty } from 'tts-elevenlabs'
 import Timer from 'timer'
 
-const token = 'YOUR_API_KEY_HERE'
+const token = config.token
+
+if (!token || token == 'YOUR_API_KEY_HERE') throw new Error('API token is missing.')
+
 const property: TTSProperty = {
   token,
   onPlayed: (num) => {

--- a/firmware/tests/speeches/tts-elevenlabs/manifest.json
+++ b/firmware/tests/speeches/tts-elevenlabs/manifest.json
@@ -1,17 +1,18 @@
 {
-    "include": [
-        "$(MODDABLE)/examples/manifest_base.json",
-        "$(MODDABLE)/examples/manifest_typings.json",
-        "../../../stackchan/speeches/manifest_speech.json"
-    ],
-    "modules": {
-        "*": [
-            "./main"
-        ]
-    },
-    "defines": {
-        "main": {
-            "async": 1
-        }
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/speeches/manifest_speech.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
     }
+  },
+  "config": {
+    "token": "YOUR_API_KEY_HERE"
+  }
 }

--- a/firmware/tests/speeches/tts-openai/main.ts
+++ b/firmware/tests/speeches/tts-openai/main.ts
@@ -1,7 +1,11 @@
+import config from 'mc/config'
 import { TTS, TTSProperty } from 'tts-openai'
 import Timer from 'timer'
 
-const token = 'YOUR_API_KEY_HERE'
+const token = config.token
+
+if (!token || token == 'YOUR_API_KEY_HERE') throw new Error('API token is missing.')
+
 const property: TTSProperty = {
   token,
   onPlayed: (num) => {

--- a/firmware/tests/speeches/tts-openai/manifest.json
+++ b/firmware/tests/speeches/tts-openai/manifest.json
@@ -1,17 +1,18 @@
 {
-    "include": [
-        "$(MODDABLE)/examples/manifest_base.json",
-        "$(MODDABLE)/examples/manifest_typings.json",
-        "../../../stackchan/speeches/manifest_speech.json"
-    ],
-    "modules": {
-        "*": [
-            "./main"
-        ]
-    },
-    "defines": {
-        "main": {
-            "async": 1
-        }
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/speeches/manifest_speech.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
     }
+  },
+  "config": {
+    "token": "YOUR_API_KEY_HERE"
+  }
 }

--- a/firmware/tests/speeches/tts-voicevox-web/main.ts
+++ b/firmware/tests/speeches/tts-voicevox-web/main.ts
@@ -1,7 +1,10 @@
+import config from 'mc/config'
 import { TTS, TTSProperty } from 'tts-voicevox-web'
 import Timer from 'timer'
 
-const token = 'YOUR_API_KEY_HERE'
+const token = config.token
+
+if (!token || token == 'YOUR_API_KEY_HERE') throw new Error('API token is missing.')
 
 const property: TTSProperty = {
   token,

--- a/firmware/tests/speeches/tts-voicevox-web/manifest.json
+++ b/firmware/tests/speeches/tts-voicevox-web/manifest.json
@@ -1,17 +1,18 @@
 {
-    "include": [
-        "$(MODDABLE)/examples/manifest_base.json",
-        "$(MODDABLE)/examples/manifest_typings.json",
-        "../../../stackchan/speeches/manifest_speech.json"
-    ],
-    "modules": {
-        "*": [
-            "./main"
-        ]
-    },
-    "defines": {
-        "main": {
-            "async": 1
-        }
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/speeches/manifest_speech.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
     }
+  },
+  "config": {
+    "token": "YOUR_API_KEY_HERE"
+  }
 }

--- a/firmware/tests/speeches/tts-voicevox/main.ts
+++ b/firmware/tests/speeches/tts-voicevox/main.ts
@@ -1,7 +1,9 @@
+import config from 'mc/config'
 import { TTS, TTSProperty } from 'tts-voicevox'
 import Timer from 'timer'
 
-const host = '127.0.0.1'
+const host = config.host
+if (!host) throw new Error('host is missing.')
 
 const property: TTSProperty = {
   host,

--- a/firmware/tests/speeches/tts-voicevox/manifest.json
+++ b/firmware/tests/speeches/tts-voicevox/manifest.json
@@ -1,17 +1,18 @@
 {
-    "include": [
-        "$(MODDABLE)/examples/manifest_base.json",
-        "$(MODDABLE)/examples/manifest_typings.json",
-        "../../../stackchan/speeches/manifest_speech.json"
-    ],
-    "modules": {
-        "*": [
-            "./main"
-        ]
-    },
-    "defines": {
-        "main": {
-            "async": 1
-        }
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/speeches/manifest_speech.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
     }
+  },
+  "config": {
+    "host": "127.0.0.1"
+  }
 }


### PR DESCRIPTION
[#254](https://github.com/stack-chan/stack-chan/pull/254#issuecomment-2298783997) の対応同様に`tests/speeches`のテストアプリについてもconfig経由でAPI KEYや接続先ホストを指定できるようにします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security by transitioning from hardcoded API tokens to dynamic imports from a configuration module.
	- Introduced a new `config` section in manifest files for API key and host configuration.

- **Bug Fixes**
	- Added validation checks to ensure API tokens and hosts are correctly configured before usage, improving application robustness. 

- **Documentation**
	- Improved readability and consistency in JSON manifest structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->