### PR TITLE
add documentation for mods/monologue

### DIFF
--- a/firmware/mods/monologue/README_ja.md
+++ b/firmware/mods/monologue/README_ja.md
@@ -1,0 +1,42 @@
+# ぽしょぽしょ独り言ｽﾀｯｸﾁｬﾝ
+
+ｽﾀｯｸﾁｬﾝが独り言を喋るデモです。A ボタンを押すと設定した音声をランダムに発話します。
+TTS（音声合成）の使用は事前生成とリモートの２つの方法があります。
+
+TTS についての詳細は[TTS（音声合成）の使用](../../docs/text-to-speech_ja.md)を参照してください。
+
+## 事前生成
+
+* `assets`ディレクトリに音声ファイルを格納します。
+* `speeches_monologue.js`の変数`speeches`の key に格納した音声ファイル名を記載します。
+  * 変数`speeches`のvalueは任意値でも問題ありません。
+
+例）音声ファイル`niceToMeetYou`、`hello`、`konnichiwa`、`nihao`を格納した場合
+
+```javascript
+// speeches.js
+export const speeches = {
+  niceToMeetYou: 'Hello. I am Stach-chan. Nice to meet you.',
+  hello: 'Hello World.',
+  konnichiwa: 'Konnichiwa.',
+  nihao: 'Nee hao.',
+}
+```
+
+## リモート
+
+* ホストファームウェアを書き込む時に `manifest_local.json`の`config.tts`を使用する TTS エンジンに合わせて設定します。
+* `speeches_monologue.js`の変数`speeches`の value に発話する文章を記載します。
+  * 変数`speeches`のkeyは任意値でも問題ありません。
+
+例）`niceToMeetYou`、`hello`、`konnichiwa`、`nihao`を発話する場合
+
+```javascript
+// speeches.js
+export const speeches = {
+  sentense1: 'Hello. I am Stach-chan. Nice to meet you.',
+  sentense2: 'Hello World.',
+  sentense3: 'Konnichiwa.',
+  sentense4: 'Nee hao.',
+}
+```


### PR DESCRIPTION
This PR adds documentation for [mods/monologue](https://github.com/stack-chan/stack-chan/tree/dev/v1.0/firmware/mods/monologue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Japanese README for the "ぽしょぽしょ独り言ｽﾀｯｸﾁｬﾝ" feature, providing guidance on implementing Text-to-Speech (TTS) with both pre-generated audio files and remote TTS engines.
	- Added examples for setting up audio files and configuring TTS phrases for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->