### PR TITLE
[CI]actions/setup cache moddable and esp32

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,6 +30,7 @@ runs:
         LATEST_TAG_ID=$(echo $RESPONSE | jq -r '.[0].id')
         echo "Latest release tag_name of Moddable: $LATEST_TAG_NAME (id:$LATEST_TAG_ID)"
         echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_TAG_ID" >> $GITHUB_ENV
+      shell: bash
     - name: Restore cache of Moddale and ESP32
       if: inputs.target-branch == ''
       id: restore-cache-moddable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,26 @@ runs:
     - run: npm ci
       working-directory: ./firmware
       shell: bash
+    - name: check latest release tag of Moddable
+      if: inputs.target-branch == ''
+      run: |
+        API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/releases"
+        RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" $API_URL)
+        LATEST_TAG_NAME=$(echo $RESPONSE | jq -r '.[0].tag_name')
+        LATEST_TAG_ID=$(echo $RESPONSE | jq -r '.[0].id')
+        echo "Latest release tag_name of Moddable: $LATEST_TAG_NAME (id:$LATEST_TAG_ID)"
+        echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_TAG_ID" >> $GITHUB_ENV
+    - name: Restore cache of Moddale and ESP32
+      if: inputs.target-branch == ''
+      id: restore-cache-moddable
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          /home/runner/.local/share
+          /home/runner/.espressif
+        key: ${{ env.moddable_cache_key }}
     - name: install Moddable
+      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         if [ -z "${{ inputs.target-branch }}" ]; then
@@ -32,8 +51,18 @@ runs:
       working-directory: ./firmware
       shell: bash
     - name: install ESP32
+      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         source $HOME/.local/share/xs-dev-export.sh && npm run setup -- --device=esp32
       working-directory: ./firmware
       shell: bash
+    - name: Save cache of Moddale and ESP32
+      if: inputs.target-branch == ''
+      id: save-cache-moddable
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          /home/runner/.local/share
+          /home/runner/.espressif
+        key: ${{ env.moddable_cache_key }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,17 +31,17 @@ runs:
         echo "Latest release tag_name of Moddable: $LATEST_TAG_NAME (id:$LATEST_TAG_ID)"
         echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_TAG_ID" >> $GITHUB_ENV
       shell: bash
-    - name: cache oModdale and ESP32
+    - name: Restore cache of Moddale and ESP32
       if: inputs.target-branch == ''
-      id: cache-moddable
-      uses: actions/cache@v4
+      id: restore-cache-moddable
+      uses: actions/cache/restore@v4
       with:
         path: |
           /home/runner/.local/share
           /home/runner/.espressif
         key: ${{ env.moddable_cache_key }}
     - name: install Moddable
-      if: steps.cache-moddable.outputs.cache-hit != 'true'
+      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         if [ -z "${{ inputs.target-branch }}" ]; then
@@ -52,10 +52,18 @@ runs:
       working-directory: ./firmware
       shell: bash
     - name: install ESP32
-      if: steps.cache-moddable.outputs.cache-hit != 'true'
+      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         source $HOME/.local/share/xs-dev-export.sh && npm run setup -- --device=esp32
       working-directory: ./firmware
       shell: bash
-
+    - name: Save cache of Moddale and ESP32
+      if: inputs.target-branch == '' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      id: save-cache-moddable
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          /home/runner/.local/share
+          /home/runner/.espressif
+        key: ${{ env.moddable_cache_key }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,7 +59,7 @@ runs:
       working-directory: ./firmware
       shell: bash
     - name: Save cache of Moddale and ESP32
-      if: inputs.target-branch == ''
+      if: inputs.target-branch == '' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
       id: save-cache-moddable
       uses: actions/cache/save@v4
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,17 +31,17 @@ runs:
         echo "Latest release tag_name of Moddable: $LATEST_TAG_NAME (id:$LATEST_TAG_ID)"
         echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_TAG_ID" >> $GITHUB_ENV
       shell: bash
-    - name: Restore cache of Moddale and ESP32
+    - name: cache oModdale and ESP32
       if: inputs.target-branch == ''
-      id: restore-cache-moddable
-      uses: actions/cache/restore@v4
+      id: cache-moddable
+      uses: actions/cache@v4
       with:
         path: |
           /home/runner/.local/share
           /home/runner/.espressif
         key: ${{ env.moddable_cache_key }}
     - name: install Moddable
-      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      if: steps.cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         if [ -z "${{ inputs.target-branch }}" ]; then
@@ -52,18 +52,10 @@ runs:
       working-directory: ./firmware
       shell: bash
     - name: install ESP32
-      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      if: steps.cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         source $HOME/.local/share/xs-dev-export.sh && npm run setup -- --device=esp32
       working-directory: ./firmware
       shell: bash
-    - name: Save cache of Moddale and ESP32
-      if: inputs.target-branch == '' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
-      id: save-cache-moddable
-      uses: actions/cache/save@v4
-      with:
-        path: |
-          /home/runner/.local/share
-          /home/runner/.espressif
-        key: ${{ env.moddable_cache_key }}
+

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,7 +25,7 @@ runs:
       if: inputs.target-branch == ''
       run: |
         API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/releases"
-        RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" $API_URL)
+        RESPONSE=$(curl -s $API_URL)
         LATEST_TAG_NAME=$(echo $RESPONSE | jq -r '.[0].tag_name')
         LATEST_TAG_ID=$(echo $RESPONSE | jq -r '.[0].id')
         echo "Latest release tag_name of Moddable: $LATEST_TAG_NAME (id:$LATEST_TAG_ID)"


### PR DESCRIPTION
#123 の対策案です

`cache`actionを使って、xs-devでインストールするModdableおよびESP32(ESP-IDF)をキャッシュしています。
キャッシュキーはxs-devのインストールに合わせて[Moddableの最新Releaseタグ](https://github.com/Moddable-OpenSource/moddable/releases)としており、新しいReleaseがあるとキャッシュが更新されるようになります。

3~4分かかるsetup処理が30秒程度に短縮される見込みです。
参考までに自リポジトリでキャッシュ動作した時の結果です
https://github.com/stc1988/stack-chan/actions/runs/10634353822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a step to check for the latest release tag of the Moddable framework, improving version management.
	- Added caching mechanisms for Moddable and ESP32 dependencies to enhance workflow efficiency.

- **Bug Fixes**
	- Improved conditional execution of steps based on the `target-branch` input, reducing unnecessary installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->