### PR TITLE
mods/chatgpt から未使用の`api-key.js`を削除

### DIFF
--- a/firmware/mods/chatgpt/.gitignore
+++ b/firmware/mods/chatgpt/.gitignore
@@ -1,1 +1,0 @@
-./api-key.js

--- a/firmware/mods/chatgpt/README.md
+++ b/firmware/mods/chatgpt/README.md
@@ -56,6 +56,30 @@ INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:50021 (Press CTRL+C to quit)
 ```
 
+## Changing the host settings
+
+Add or modify the necessary settings in the `config` of `manifest_local.json` for the host.
+
+- ai.token: ChatGPT token
+- tts.host: The IP address of the PC where the Speech Synthesis Server is running.
+
+```
+{
+    "include": [
+        "./manifest.json"
+    ],
+    "config": {
+        "ai": {
+            "token": "ChatGPT token"
+        },
+        "tts": {
+            "type": "voicevox",
+            "host": "IP address",
+            "port": 50021
+        }
+    }
+}
+
 ## Writing the host
 
 Write the host for Stack-chan.
@@ -71,19 +95,11 @@ Reference: [Moddable's official documentation](https://github.com/Moddable-OpenS
 
 ## Writing the mod
 
-Write the ChatGPT integration mod.
-
-1. Add your ChatGPT API key to `api-key.js`.
-
-```
-const API_KEY = 'YOUR_API_KEY_HERE'
-export default API_KEY
-```
-
-2. Write the mod with the following command:
+Write the mod with the following command:
 
 ```console
-$ npm run mod ./mods/chatgpt/manifest.json
+# Choose target from esp32/m5stack or esp32/m5stack_core2
+$ npm run mod --target=esp32/m5stack mods/chatgpt/manifest.json
 ```
 
 ## Changing character settings (system messages)

--- a/firmware/mods/chatgpt/README.md
+++ b/firmware/mods/chatgpt/README.md
@@ -63,7 +63,7 @@ Add or modify the necessary settings in the `config` of `manifest_local.json` fo
 - ai.token: ChatGPT token
 - tts.host: The IP address of the PC where the Speech Synthesis Server is running.
 
-```
+```json
 {
     "include": [
         "./manifest.json"

--- a/firmware/mods/chatgpt/README_ja.md
+++ b/firmware/mods/chatgpt/README_ja.md
@@ -56,7 +56,32 @@ INFO:     Application startup complete.
 INFO:     Uvicorn running on http://0.0.0.0:50021 (Press CTRL+C to quit)
 ```
 
-## ホスト書き込み
+## ホストの設定を変更する
+
+ホストの`manifest_local.json`の`config`に必要な設定を追加・変更します。
+
+- ai.token: ChatGPTのトークン
+- tts.host: 音声合成サーバーが動作しているPCのIPアドレス
+
+```
+{
+    "include": [
+        "./manifest.json"
+    ],
+    "config": {
+        "ai": {
+            "token": "ChatGPTのトークン"
+        },
+        "tts": {
+            "type": "voicevox",
+            "host": "音声合成サーバーのIPアドレス",
+            "port": 50021
+        }
+    }
+}
+```
+
+## ホストの書き込み
 
 ｽﾀｯｸﾁｬﾝのホストを書き込みます。
 このときｽﾀｯｸﾁｬﾝを無線LANネットワークに接続するために、SSIDとパスワードを指定します。
@@ -71,19 +96,11 @@ $ npm run deploy --target=esp32/m5stack
 
 ## mod書き込み
 
-ChatGPT連携のmodを書き込みます。
-
-1. ChatGPTのAPIキーを`api-key.js`に記述します。
-
-```
-const API_KEY = 'YOUR_API_KEY_HERE'
-export default API_KEY
-```
-
-2. 次のコマンドでmodを書き込みます。
+次のコマンドでmodを書き込みます。
 
 ```console
-$ npm run mod ./mods/chatgpt/manifest.json
+# targetは esp32/m5stack または esp32/m5stack_core2 から指定
+$ npm run mod --target=esp32/m5stack mods/chatgpt/manifest.json
 ```
 
 ## キャラクター設定（systemメッセージ）の変更

--- a/firmware/mods/chatgpt/README_ja.md
+++ b/firmware/mods/chatgpt/README_ja.md
@@ -63,7 +63,7 @@ INFO:     Uvicorn running on http://0.0.0.0:50021 (Press CTRL+C to quit)
 - ai.token: ChatGPTのトークン
 - tts.host: 音声合成サーバーが動作しているPCのIPアドレス
 
-```
+```json
 {
     "include": [
         "./manifest.json"

--- a/firmware/mods/chatgpt/api-key.js
+++ b/firmware/mods/chatgpt/api-key.js
@@ -1,2 +1,0 @@
-const API_KEY = 'YOUR_API_KEY_HERE'
-export default API_KEY

--- a/firmware/mods/chatgpt/manifest.json
+++ b/firmware/mods/chatgpt/manifest.json
@@ -4,8 +4,7 @@
 	],
 	"modules": {
 		"*": [
-			"./mod",
-			"./api-key"
+			"./mod"
 		]
 	},
 	"data": {


### PR DESCRIPTION
ChatGPTへのAPI KEYの設定は現在`manifest_local.json`などconfig経由の実装であるため、`api-key.js`を削除します。
合わせてドキュメントの記載も更新しています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced updated configuration instructions for integrating ChatGPT with a Speech Synthesis Server.
	- Added a new section on changing host settings in the documentation.
	- Expanded JSON configuration examples for clarity.

- **Bug Fixes**
	- Streamlined instructions for writing modifications, removing unnecessary steps for entering the API key.

- **Documentation**
	- Enhanced clarity and usability of README files, including English and Japanese versions.
	- Updated commands for writing modifications to clarify target specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->