### PR TITLE
fix sampleRate of tests/speeches/tts-voicevox

### DIFF
--- a/firmware/tests/speeches/tts-voicevox/main.ts
+++ b/firmware/tests/speeches/tts-voicevox/main.ts
@@ -8,7 +8,7 @@ if (!host) throw new Error('host is missing.')
 const property: TTSProperty = {
   host,
   port: 50021,
-  sampleRate: 11025,
+  sampleRate: 24000,
   speakerId: 1,
   onPlayed: (num) => {
     trace(`played ${num}\n`)


### PR DESCRIPTION
テストアプリ確認時に発声に違和感があったのでデフォルトの`config`に合わせて`24000`に変更します。

１点[tts-voivox](https://github.com/stc1988/stack-chan/blob/dd057e43c65f6b1bd4ede20c1256755d5662c207/firmware/tests/speeches/tts-voicevox/main.ts)で気になったのですが、

`this.audio = new AudioOut({ streams: 1, bitsPerSample: 16, sampleRate: props.sampleRate ?? 11025 })` でsampleRateのデフォルト値を設定していますが、`TTSProperty`では必須となっているので`11025`を設定することはなさそうです。
必須としてデフォルト値を無くすか、任意とするかどちらがよいでしょうか


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced audio output quality for the text-to-speech functionality by increasing the sample rate from 11025 Hz to 24000 Hz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->