### PR TITLE
TTSの一部のインスタンス引数の必須を見直す

### DIFF
--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -27,8 +27,8 @@ export type Driver = {
  */
 export type TTS = {
   stream: (text: string) => Promise<void>
-  onPlayed: (volume: number) => void
-  onDone: () => void
+  onPlayed?: (volume: number) => void
+  onDone?: () => void
 }
 
 /**

--- a/firmware/stackchan/speeches/tts-elevenlabs.ts
+++ b/firmware/stackchan/speeches/tts-elevenlabs.ts
@@ -13,8 +13,8 @@ type voiceSettings = {
 }
 
 export type TTSProperty = {
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   token: string
   voice?: string
   latency?: number
@@ -25,8 +25,8 @@ export type TTSProperty = {
 
 export class TTS {
   audio: AudioOut
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   token: string
   model: string
   voice: string

--- a/firmware/stackchan/speeches/tts-local.ts
+++ b/firmware/stackchan/speeches/tts-local.ts
@@ -5,25 +5,17 @@ import calculatePower from 'calculate-power'
 
 /* global trace, SharedArrayBuffer */
 
-export type TTSProperty =
-  | {
-      onPlayed: (number) => void
-      onDone: () => void
-      sampleRate?: number
-    }
-  | {
-      onPlayed: (number) => void
-      onDone: () => void
-      host: string
-      port: number
-      sampleRate?: number
-    }
+export type TTSProperty = {
+  onPlayed?: (number) => void
+  onDone?: () => void
+  sampleRate?: number
+}
 
 export class TTS {
   streamer?: ResourceStreamer
   audio?: AudioOut
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   constructor(props: TTSProperty) {
     this.onPlayed = props.onPlayed
     this.onDone = props.onDone

--- a/firmware/stackchan/speeches/tts-openai.ts
+++ b/firmware/stackchan/speeches/tts-openai.ts
@@ -6,8 +6,8 @@ import calculatePower from 'calculate-power'
 /* global trace, SharedArrayBuffer */
 
 export type TTSProperty = {
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   token: string
   model?: string
   voice?: string
@@ -16,8 +16,8 @@ export type TTSProperty = {
 
 export class TTS {
   audio: AudioOut
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   token: string
   model: string
   voice: string

--- a/firmware/stackchan/speeches/tts-remote.ts
+++ b/firmware/stackchan/speeches/tts-remote.ts
@@ -8,8 +8,8 @@ import calculatePower from 'calculate-power'
 declare const device: any
 
 export type TTSProperty = {
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   host: string
   port: number
   sampleRate?: number
@@ -19,8 +19,8 @@ let streamer
 export class TTS {
   streamer?: WavStreamer
   audio?: AudioOut
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   host: string
   port: number
   constructor(props: TTSProperty) {

--- a/firmware/stackchan/speeches/tts-voicevox-web.ts
+++ b/firmware/stackchan/speeches/tts-voicevox-web.ts
@@ -10,8 +10,8 @@ import { URL } from 'url'
 declare const device: any
 
 export type TTSProperty = {
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   token: string
   sampleRate?: number
   speakerId?: number
@@ -19,8 +19,8 @@ export type TTSProperty = {
 
 export class TTS {
   audio: AudioOut
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   token: string
   streaming: boolean
   speakerId: number

--- a/firmware/stackchan/speeches/tts-voicevox.ts
+++ b/firmware/stackchan/speeches/tts-voicevox.ts
@@ -14,18 +14,18 @@ const QUERY_PATH = config.file.root + 'query.json'
 declare const device: any
 
 export type TTSProperty = {
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   host: string
   port: number
-  sampleRate: number
-  speakerId: number
+  sampleRate?: number
+  speakerId?: number
 }
 
 export class TTS {
   audio: AudioOut
-  onPlayed: (number) => void
-  onDone: () => void
+  onPlayed?: (number) => void
+  onDone?: () => void
   // TODO: Add type definition for HTTPClient
   client: HTTPClient
   host: string


### PR DESCRIPTION
#281 の対応です。

全般的に`onPlayed`、`onDone`を任意として以下個別に対応してます
* `firmware/stackchan/speeches/tts-local.ts`
  * `host`、`port`を指定するケースはないため削除
*  `firmware/stackchan/speeches/tts-voicevox.ts`
   *  `sampleRate`、`speakerId`を任意とする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the `TTS` class and `TTSProperty` type by making the `onPlayed` and `onDone` properties optional.
	- Simplified structure of `TTSProperty`, allowing for greater usability and reduced constraints when creating instances.

- **Bug Fixes**
	- Addressed issues related to required properties, enabling smoother implementations without the need for unnecessary callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->