### PR TITLE
Use NoneDriver for simulator

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -106,17 +106,26 @@
     },
     "mac/m5stack": {
       "config": {
-        "rotation": 0
+        "rotation": 0,
+        "driver": {
+          "type": "none"
+        }
       }
     },
     "lin/m5stack": {
       "config": {
-        "rotation": 0
+        "rotation": 0,
+        "driver": {
+          "type": "none"
+        }
       }
     },
     "win/m5stack": {
       "config": {
-        "rotation": 0
+        "rotation": 0,
+        "driver": {
+          "type": "none"
+        }
       }
     }
   }


### PR DESCRIPTION
シミュレーターがシリアル通信に対応していないため、stackchanをビルドすると起動直後にDriver例外が発生します。

```
cd stack-chan/firmware
mcconfig -m -d -p lin/m5stack ./stackchan/manifest.json
```

シミュレーターで動かす場合は `NoneDriver` を使うことで例外を抑制して、ドライバー以外の開発をPCでもできるようにします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration settings for the "m5stack" component across mac, lin, and win platforms.
	- Introduced a "driver" object in configurations to provide detailed driver specifications.

These updates improve the overall structure and clarity of the component settings, ensuring better performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->