### PR TITLE
dialogue-* でリクエストの度にヘッダーを生成する

### DIFF
--- a/firmware/stackchan/dialogues/dialogue-chatgpt.ts
+++ b/firmware/stackchan/dialogues/dialogue-chatgpt.ts
@@ -55,20 +55,17 @@ type ChatGPTDialogueProps = {
 }
 
 export class ChatGPTDialogue {
+  #apiKey
   #model: string
   #context: Array<ChatContent>
-  #headers: Headers
   #history: Array<ChatContent>
   #maxHistory: number
   constructor({ apiKey, model = DEFAULT_MODEL, context = DEFAULT_CONTEXT }: ChatGPTDialogueProps) {
+    this.#apiKey = apiKey
     this.#model = model
     this.#context = context
     this.#history = []
     this.#maxHistory = 6
-    this.#headers = new Headers([
-      ['Content-Type', 'application/json'],
-      ['Authorization', `Bearer ${apiKey}`],
-    ])
   }
   clear() {
     this.#history.splice(0)
@@ -109,7 +106,10 @@ export class ChatGPTDialogue {
     }
     return fetch(API_URL, {
       method: 'POST',
-      headers: this.#headers,
+      headers: new Headers([
+        ['Content-Type', 'application/json'],
+        ['Authorization', `Bearer ${this.#apiKey}`],
+      ]),
       body: JSON.stringify(body),
     })
       .then((response) => {

--- a/firmware/stackchan/dialogues/dialogue-claude.ts
+++ b/firmware/stackchan/dialogues/dialogue-claude.ts
@@ -60,13 +60,14 @@ type ClaudeDialogueProps = {
 }
 
 export class ClaudeDialogue {
+  #apiKey: string
   #model: string
   #context: Array<ChatContent>
   #system: string
-  #headers: Headers
   #history: Array<ChatContent>
   #maxHistory: number
   constructor({ apiKey, model = DEFAULT_MODEL, context = DEFAULT_CONTEXT }: ClaudeDialogueProps) {
+    this.#apiKey = apiKey
     this.#model = model
     this.#system = context
       .filter((c) => c.role === 'system')
@@ -82,11 +83,6 @@ export class ClaudeDialogue {
     }
     this.#history = []
     this.#maxHistory = 6
-    this.#headers = new Headers([
-      ['Content-Type', 'application/json'],
-      ['x-api-key', `${apiKey}`],
-      ['anthropic-version', '2023-06-01'],
-    ])
   }
   clear() {
     this.#history.splice(0)
@@ -129,7 +125,11 @@ export class ClaudeDialogue {
     }
     return fetch(API_URL, {
       method: 'POST',
-      headers: this.#headers,
+      headers: new Headers([
+        ['Content-Type', 'application/json'],
+        ['x-api-key', `${this.#apiKey}`],
+        ['anthropic-version', '2023-06-01'],
+      ]),
       body: JSON.stringify(body),
     })
       .then((response) => {

--- a/firmware/stackchan/dialogues/dialogue-gemini.ts
+++ b/firmware/stackchan/dialogues/dialogue-gemini.ts
@@ -72,7 +72,6 @@ export class GeminiDialogue {
   #model: string
   #context: Array<Content>
   #system: Content
-  #headers: Headers
   #history: Array<Content>
   #maxHistory: number
   constructor({ apiKey, model = DEFAULT_MODEL, context = DEFAULT_CONTEXT }: GeminiDialogueProps) {
@@ -89,7 +88,6 @@ export class GeminiDialogue {
     this.#apiKey = apiKey
     this.#history = []
     this.#maxHistory = 6
-    this.#headers = new Headers([['Content-Type', 'application/json']])
   }
   clear() {
     this.#history.splice(0)
@@ -134,7 +132,7 @@ export class GeminiDialogue {
     }
     return fetch(`${API_URL_BASE}${this.#model}:generateContent?key=${this.#apiKey}`, {
       method: 'POST',
-      headers: this.#headers,
+      headers: new Headers([['Content-Type', 'application/json']]),
       body: JSON.stringify(body),
     })
       .then((response) => {


### PR DESCRIPTION
インスタンス生成時に生成されたヘッダーをリクエスト時に使用していますが、`fetch`内部では、`content-length`が未指定時は[bodyのサイズから自動的に設定される](https://github.com/Moddable-OpenSource/moddable/blob/public/examples/io/tcp/fetch/fetch.js#L202-L208)ようになっています。
そのため、２回目以降リクエスト時は初回リクエスト時の`content-length`が設定されてしまいリクエストに失敗します。

そこで、本体ではリクエストの度にヘッダーを生成するようにします