### PR TITLE
add npm script of updating ModdableSDK

### DIFF
--- a/firmware/docs/getting-started.md
+++ b/firmware/docs/getting-started.md
@@ -29,7 +29,7 @@ Install [ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/ge
 There are three ways to do this
 
 - Using the CLI (recommended)
-- Using a Docker image
+<!-- - Using a Docker image -->
 - Set up manually
 
 ### Using xs-dev (recommended)
@@ -44,6 +44,7 @@ $ npm run setup -- --device=esp32
 
 The script internally uses [`xs-dev`](https://github.com/HipsterBrown/xs-dev) to automate the setup of ModdableSDK and ESP-IDF.
 
+<!-- 
 ### Using Docker images (for Linux only)
 
 This repository provides a Dockerfile build environment.
@@ -71,10 +72,30 @@ You can open the project in a container with the following commands
 * Open the command palette (ctrl+shift+p)
 * Run `>Remote-Containers: Reopen in Container`
 
+ -->
+ 
 ### Manual
 
 Follow the instructions on the [official website (English)](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/Moddable%20SDK%20-%20Getting%20Started.md) to install ModdableSDK and ESP-IDF.
 If you cannot setup CLI or Docker properly, please do this.
+
+## (Optional)Updating ModdableSDK
+
+With the update of this repository, it may be necessary to update the ModdableSDK to add new features or resolve bugs.
+
+### Using xs-dev (recommended)
+
+Stack-Chan has also npm scripting of the update procedure.
+Run the following command in the `stack-chan/firmware` directory.
+
+```console
+$ npm run update
+$ npm run update -- --device=esp32
+```
+
+### Manual
+
+Follow the instructions on the [official website (English)](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/Moddable%20SDK%20-%20Getting%20Started.md) to update ModdableSDK and ESP-IDF.
 
 ## Test the environment
 

--- a/firmware/docs/getting-started.md
+++ b/firmware/docs/getting-started.md
@@ -77,7 +77,7 @@ You can open the project in a container with the following commands
 ### Manual
 
 Follow the instructions on the [official website (English)](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/Moddable%20SDK%20-%20Getting%20Started.md) to install ModdableSDK and ESP-IDF.
-If you cannot setup CLI or Docker properly, please do this.
+If you cannot set up the CLI or Docker properly, please use this manual method.
 
 ## (Optional)Updating ModdableSDK
 

--- a/firmware/docs/getting-started_ja.md
+++ b/firmware/docs/getting-started_ja.md
@@ -29,7 +29,7 @@ $ npm i
 次の3通りの方法があります。
 
 - CLIを使う（推奨）
-- Dockerイメージを使う
+<!-- - Dockerイメージを使う -->
 - 手動でセットアップする
 
 ### xs-devを使う（推奨）
@@ -44,6 +44,7 @@ $ npm run setup -- --device=esp32
 
 内部で[`xs-dev`](https://github.com/HipsterBrown/xs-dev)を使ってModdableSDKやESP-IDFのセットアップを自動化しています。
 
+<!-- Dockerイメージがメンテされてないため一時的コメントアウトする(https://github.com/stack-chan/stack-chan/issues/239)
 ### Dockerイメージを使う（Linuxのみ）
 
 このリポジトリはDockerfileによるビルド環境を提供しています。
@@ -70,11 +71,30 @@ VSCodeのDevContainer用設定を同梱しています。
 
 * コマンドパレットを開く(ctrl+shift+p)
 * `>Remote-Containers: Reopen in Container`を実行する
+ -->
 
 ### 手動で行う
 
 [公式サイトの手順（英語）](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/Moddable%20SDK%20-%20Getting%20Started.md)に従ってModdableSDKとESP-IDFをインストールします。
 CLIやDockerがうまくセットアップできない場合はこちらを行ってください。
+
+## (オプション)ModdableSDKのアップデート
+
+本リポジトリの更新に伴う機能追加や不具合解消のため、ModdableSDKのアップデートが必要となる場合があります。
+
+### xs-devを使う（推奨）
+
+ｽﾀｯｸﾁｬﾝはアップデート手順もnpmスクリプト化しています。
+`stack-chan/firmware`ディレクトリで次のコマンドを実行します。
+
+```console
+$ npm run update
+$ npm run update -- --device=esp32
+```
+
+### 手動で行う
+
+[公式サイトの手順（英語）](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/Moddable%20SDK%20-%20Getting%20Started.md)に従ってModdableSDKとESP-IDFをアップデートします。
 
 ## 環境のテスト
 

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -18,6 +18,7 @@
     "debug": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target ./stackchan/manifest_local.json",
     "mod": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcrun -d -m -p $npm_config_target",
     "setup": "xs-dev setup",
+	"update": "xs-dev update",
     "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",
     "scan": "xs-dev scan",
     "erase-flash": "esptool.py erase_flash"

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -18,7 +18,7 @@
     "debug": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target ./stackchan/manifest_local.json",
     "mod": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcrun -d -m -p $npm_config_target",
     "setup": "xs-dev setup",
-	"update": "xs-dev update",
+    "update": "xs-dev update",
     "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",
     "scan": "xs-dev scan",
     "erase-flash": "esptool.py erase_flash"


### PR DESCRIPTION
#296　の対応です。
`npm run update` で`xs-dev`を使ってModdableおよびESP32をアップデートできます。

アップデート方法の手順もドキュメントに追記していますが、Dockerを使った環境構築は #239 で現状使用できない(使う場合は手動アップデートと同じ手順の実施が必要)であるため、一時的にドキュメントからコメントアウトで非表示としています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated getting started guides to emphasize CLI setup over Docker images.
	- Added optional update instructions for ModdableSDK, including recommended and manual methods.
- **New Features**
	- Introduced a new script command for updating the firmware using `xs-dev`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->