### PR TITLE
Fix npm run mod  probrem

### DIFF
--- a/firmware/package.json
+++ b/firmware/package.json
@@ -16,7 +16,7 @@
     "bundle": "mcbundle -d -m ./stackchan/manifest.json",
     "deploy": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target -t deploy ./stackchan/manifest_local.json",
     "debug": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target ./stackchan/manifest_local.json",
-    "mod": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcrun -d -m -p $npm_config_target",
+    "mod": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcrun -d -m -p \\$npm_config_target",
     "setup": "xs-dev setup",
     "update": "xs-dev update",
     "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",


### PR DESCRIPTION
Fix npm run mod
Add escape to variable references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the command in the `mod` script to improve compatibility across different shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->