### PR TITLE
OpenAIのPreference項目をWebページに追加

### DIFF
--- a/web/preference/index.html
+++ b/web/preference/index.html
@@ -67,6 +67,7 @@
           'tts.host',
           'tts.port',
           'tts.token',
+          'tts.voice',
           'ai.token',
           'ai.context',
         ]
@@ -173,6 +174,7 @@
             <option value="voicevox">VOICEVOX</option>
             <option value="elevenlabs">ElevenLabs</option>
             <option value="google-tts">Google TTS</option>
+            <option value="openai">OpenAI</option>
             <option value="local">Local</option>
           </select>
         </div>
@@ -183,6 +185,10 @@
         <div class="form-group">
           <label for="tts.port">Port:</label>
           <input type="number" name="tts.port" id="tts.port" placeholder="50021">
+        </div>
+        <div class="form-group">
+          <label for="tts.voice">Voice:</label>
+          <input type="text" name="tts.voice" id="tts.voice" placeholder="ally">
         </div>
         <div class="form-group">
           <label for="tts.token">Token:</label>


### PR DESCRIPTION
- `tts.type` の選択肢に `openai` を追加 
- `voice` の設定を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input field for selecting a voice option for text-to-speech (TTS).
	- Added "OpenAI" as an option in the TTS service selection dropdown.
- **Enhancements**
	- Improved the settings form for BLE-connected devices by including the voice setting in the submission payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->