### PR TITLE
pre-commitフックを追加

### DIFF
--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -16,6 +16,7 @@
         "@microsoft/tsdoc": "^0.15.0",
         "@moddable/typings": "^5.0.0",
         "cross-env-default": "^5.1.3-1",
+        "lefthook": "^1.8.2",
         "node-fetch": "^3.3.0",
         "typedoc": "^0.26.7",
         "typedoc-plugin-markdown": "^4.2.7",
@@ -2766,6 +2767,169 @@
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.8.2.tgz",
+      "integrity": "sha512-lMXbcFHNDr+gzy/7ghuJDVB/Yyycj+ZL/7pN3Gm/s5Xqrc9+5sj3IrDAPylcEJ1cKCbUnXbwESrhhqpcYv4d4g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.8.2",
+        "lefthook-darwin-x64": "1.8.2",
+        "lefthook-freebsd-arm64": "1.8.2",
+        "lefthook-freebsd-x64": "1.8.2",
+        "lefthook-linux-arm64": "1.8.2",
+        "lefthook-linux-x64": "1.8.2",
+        "lefthook-openbsd-arm64": "1.8.2",
+        "lefthook-openbsd-x64": "1.8.2",
+        "lefthook-windows-arm64": "1.8.2",
+        "lefthook-windows-x64": "1.8.2"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.8.2.tgz",
+      "integrity": "sha512-g41SoFUv8SzHpG1NOPkHUEPhC1tJM5FF3Vo+HESmLmL9cDfd7JncHFPy59rVnC9Q8nOS0rvoik5HTq+3/wcfww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.8.2.tgz",
+      "integrity": "sha512-IlCm4PrA/aAZ1MChiExYTbladC87GaxmYHOMHCeChLecqn+lypAuiYLgf7w5r2s3MjH5rbXImfU925NRKi6RXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.8.2.tgz",
+      "integrity": "sha512-f7AIvuIEXUUR1ZutIFxjYKFDAVUBrdsLm+cbwOCjdfpJh7j2Fjg6nKXbDcglPXlX9Ix+nw9pHbJE2DAgzkI1Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.8.2.tgz",
+      "integrity": "sha512-DSDL64fRLSNSWOa1y2bGXwXPiwU1fbAXpj63j6jeQ0jkgu6k+3XL/PBXKh80cI6MvCKz/KQKCtIencXZZ2Ua4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.8.2.tgz",
+      "integrity": "sha512-sJ95X+ZH8ayIE7ApiGEq5ZF9KGA+eKiocJU+536bLbAIHw5WjGmv2x3llFqUxH/zAmLe3k542oZ4d84wEO0EGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.8.2.tgz",
+      "integrity": "sha512-2eirc61M0WjlbSHamAgGf9iWsQTYz4IT6PAPm66vUaeG34+5D66xFicIV6pK2niRGUOPtNs8Kt4lboKtW+ba5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.8.2.tgz",
+      "integrity": "sha512-ZMop7htaSwP3MiL06WHUV36EX05N33o0WzNzC8NO5KEubn8Z74vbXcaq6qYezmgi+erkG6dtTnlbcZy5PFvFIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.8.2.tgz",
+      "integrity": "sha512-jXFoxmpYXO6ZafgQJVvk3MYlRgOBJD3n7H8A1Bj1E2yrLzOhKevUKlTNwZTxQdxlnvoo33yD6SjVSujZavEGpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.8.2.tgz",
+      "integrity": "sha512-hsQUSk6kmB8E0UMD3Mk6ROoa7qv6XmigfPsn9tFjmbZ2aO+kpBfWitZ5v+gcjNp44yaECs3YTMIfv3QFwXlRCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.8.2.tgz",
+      "integrity": "sha512-YypbMhvgAtkL7y+O3OlF81vwua7X4jloBz5hO3fILAuzaGAiPE1VbeuqRweV8VuKK4L/ZVVKqmpesygBUNDp9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -21,7 +21,9 @@
     "update": "xs-dev update",
     "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",
     "scan": "xs-dev scan",
-    "erase-flash": "esptool.py erase_flash"
+    "erase-flash": "esptool.py erase_flash",
+    "install-hook": "lefthook install",
+    "uninstall-hook": "lefthook uninstall"
   },
   "type": "module",
   "repository": {

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -49,6 +49,7 @@
     "@microsoft/tsdoc": "^0.15.0",
     "@moddable/typings": "^5.0.0",
     "cross-env-default": "^5.1.3-1",
+    "lefthook": "^1.8.2",
     "node-fetch": "^3.3.0",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.7",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,8 +3,8 @@ pre-commit:
   commands:
     lint:
       root: firmware/
-      run: npm run lint:fix
+      run: npm run lint -- --staged --no-errors-on-unmatched
     format:
       root: firmware/
-      run: npm run format:fix
+      run: npm run format -- --staged --no-errors-on-unmatched
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,10 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      root: firmware/
+      run: npm run lint:fix
+    format:
+      root: firmware/
+      run: npm run format:fix
+


### PR DESCRIPTION
https://github.com/stack-chan/stack-chan/issues/301 の対応です。
`husky` より後発の `lefthook` を採用してみました。

- `npm run install-hook` でpre-commitフックをインストール、`npm run uninstall-hook`でアンインストールします。
- pre-commitフックでは、ステージされたファイルに対してlintとformatをかけ、エラーの場合にはコミットが失敗します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new scripts for installing and uninstalling Git hooks.
	- Added a pre-commit hook for automated linting and formatting of the codebase.

- **Chores**
	- Updated development dependencies to include `lefthook` for improved Git hook management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->