### PR TITLE
btutilsの型定義を`@moddable/typings`のものを使用する

### DIFF
--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -14,7 +14,7 @@
         "@ffmpeg/ffmpeg": "^0.11.6",
         "@google-cloud/text-to-speech": "^4.0.3",
         "@microsoft/tsdoc": "^0.15.0",
-        "@moddable/typings": "^5.0.0",
+        "@moddable/typings": "^5.4.1",
         "cross-env-default": "^5.1.3-1",
         "lefthook": "^1.8.2",
         "node-fetch": "^3.3.0",
@@ -408,10 +408,11 @@
       "dev": true
     },
     "node_modules/@moddable/typings": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-5.0.0.tgz",
-      "integrity": "sha512-GQcmjPu042xdup/bFQ6i/8H9jSkYBSXhmv9dqodgxlG9BT7C6eOuHpieqMvz+6YXhgsM8Ueo+N5TFLuGNye/Xw==",
-      "dev": true
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-5.4.1.tgz",
+      "integrity": "sha512-j50T6zhKOPYbvIRokzIqWNev+Vmc6noZ9Xtqp/NhIHpXkYIT38plzaaezx8ug2eKUk18yowSMRHPhMmnQvTB6A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@octokit/auth-token": {
       "version": "4.0.0",

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -49,7 +49,7 @@
     "@ffmpeg/ffmpeg": "^0.11.6",
     "@google-cloud/text-to-speech": "^4.0.3",
     "@microsoft/tsdoc": "^0.15.0",
-    "@moddable/typings": "^5.0.0",
+    "@moddable/typings": "^5.4.1",
     "cross-env-default": "^5.1.3-1",
     "lefthook": "^1.8.2",
     "node-fetch": "^3.3.0",

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "*": [
         "./node_modules/@moddable/typings/*",
+        "./node_modules/@moddable/typings/ble/*",
         "./typings/*",
         "./stackchan/*",
         "./stackchan/ble/*",

--- a/firmware/typings/btutils.d.ts
+++ b/firmware/typings/btutils.d.ts
@@ -1,9 +1,0 @@
-/**
- * @note type definitions of `btutils` exists in moddable/typings/ble.d.ts but cannot import
- */
-declare module 'btutils' {
-  export class Bytes extends ArrayBuffer {
-    constructor(bytes: string | ArrayBufferLike, littleEndian?: boolean)
-    equals(bytes: Bytes): boolean
-  }
-}


### PR DESCRIPTION
Moddable側でのbleの型定義更新に伴い、本リポジトリで定義してたものを削除します。
#312 の修正にもなります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
	- Upgraded `@moddable/typings` package from version `^5.0.0` to `^5.4.1`

- **Configuration Changes**
	- Added path mapping for `@moddable/typings/ble/*` in TypeScript configuration

- **Type Definitions**
	- Removed `Bytes` class type definition from `btutils` module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->