### PR TITLE
OpenAI TTSでinstructionsを指定できるようにする

### DIFF
--- a/firmware/stackchan/speeches/tts-openai.ts
+++ b/firmware/stackchan/speeches/tts-openai.ts
@@ -12,6 +12,7 @@ export type TTSProperty = {
   model?: string
   voice?: string
   speed?: number
+  instructions?: string
 }
 
 export class TTS {
@@ -22,6 +23,7 @@ export class TTS {
   model: string
   voice: string
   speed: number
+  instructions: string
   streaming: boolean
   constructor(props: TTSProperty) {
     this.onPlayed = props.onPlayed
@@ -31,6 +33,7 @@ export class TTS {
     this.model = props.model ?? 'tts-1'
     this.voice = props.voice ?? 'alloy'
     this.speed = props.speed ?? 1
+    this.instructions = props.instructions ?? ''
   }
   async stream(text: string): Promise<void> {
     if (this.streaming) {
@@ -47,6 +50,7 @@ export class TTS {
         model: this.model,
         voice: this.voice,
         speed: this.speed,
+        instructions: this.instructions,
         response_format: 'wav',
         audio: {
           out: audio,

--- a/firmware/typings/openaistreamer.d.ts
+++ b/firmware/typings/openaistreamer.d.ts
@@ -7,6 +7,7 @@ declare module "openaistreamer" {
         voice: string,
         response_format?: string,
         speed?: number
+        instructions?: string
         audio: {
             out: AudioOut,
             sampleRate?: number,


### PR DESCRIPTION
[Moddable 5.6.0](https://github.com/Moddable-OpenSource/moddable/releases/tag/5.6.0)で、modelが`gpt-4o-mini-tts`の時に使用できるパラメータである`instructions`を対応しました。

これを指定することで、OpenAI TTSの音声における口調やイントネーションといった指示をできるようになります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced text-to-speech functionality with an option to include additional instructions, offering greater flexibility and control during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->