### PR TITLE
set device specific seed to robot

### DIFF
--- a/firmware/biome.json
+++ b/firmware/biome.json
@@ -8,7 +8,10 @@
   "files": {
     "include": ["stackchan", "mods", "tests", "scripts"],
     "ignoreUnknown": false,
-    "ignore": ["stackchan/speeches/calculate-power.js"]
+    "ignore": [
+      "stackchan/speeches/calculate-power.js",
+      "stackchan/utilities/esp32/mac-address.js"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -1,5 +1,5 @@
 import Timer from 'timer'
-import { Vector3, type Pose, Rotation, type Maybe, noop, randomBetween, getDeviceSeed } from 'stackchan-util'
+import { Vector3, type Pose, Rotation, type Maybe, noop, randomBetween, generateDeviceSeed } from 'stackchan-util'
 import { type FaceContext, type Emotion, createFaceContext, type FaceDecorator } from 'renderer-base'
 import type Digital from 'embedded:io/digital'
 import type Touch from 'touch'
@@ -103,7 +103,7 @@ export class Robot {
   #balloon: FaceDecorator
   updating: boolean
   constructor(params: RobotConstructorParam<ButtonName>) {
-    this.seed = getDeviceSeed()
+    this.seed = generateDeviceSeed()
     this.useRenderer(params.renderer)
     this.useDriver(params.driver)
     this.useTTS(params.tts)

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -1,5 +1,5 @@
 import Timer from 'timer'
-import { Vector3, type Pose, Rotation, type Maybe, noop, randomBetween } from 'stackchan-util'
+import { Vector3, type Pose, Rotation, type Maybe, noop, randomBetween, getDeviceSeed } from 'stackchan-util'
 import { type FaceContext, type Emotion, createFaceContext, type FaceDecorator } from 'renderer-base'
 import type Digital from 'embedded:io/digital'
 import type Touch from 'touch'
@@ -84,6 +84,7 @@ export class Robot {
       right: Pose
     }
   }
+  seed: number
   #power: number
   #tts: TTS
   #driver: Driver
@@ -102,6 +103,7 @@ export class Robot {
   #balloon: FaceDecorator
   updating: boolean
   constructor(params: RobotConstructorParam<ButtonName>) {
+    this.seed = getDeviceSeed()
     this.useRenderer(params.renderer)
     this.useDriver(params.driver)
     this.useTTS(params.tts)

--- a/firmware/stackchan/utilities/esp32/mac-address.c
+++ b/firmware/stackchan/utilities/esp32/mac-address.c
@@ -1,0 +1,22 @@
+#include "xsPlatform.h"
+#include "xs.h"
+#include "mc.xs.h"
+#include "esp_err.h"
+#include "esp_system.h"
+
+void xs_get_mac_address(xsMachine* the) {
+    uint8_t macaddr[6];
+
+    int32_t err = esp_efuse_mac_get_default(macaddr);
+    if (err) xsUnknownError("failed to get mac address");
+
+    char *out;
+    xsResult = xsStringBuffer(NULL, 18);
+    out = xsToString(xsResult);
+    twoHex(macaddr[0], out); out += 2; *out++ = ':';
+    twoHex(macaddr[1], out); out += 2; *out++ = ':';
+    twoHex(macaddr[2], out); out += 2; *out++ = ':';
+    twoHex(macaddr[3], out); out += 2; *out++ = ':';
+    twoHex(macaddr[4], out); out += 2; *out++ = ':';
+    twoHex(macaddr[5], out); out += 2; *out++ = 0;
+}

--- a/firmware/stackchan/utilities/esp32/mac-address.js
+++ b/firmware/stackchan/utilities/esp32/mac-address.js
@@ -1,0 +1,2 @@
+function getMacAddress() @ "xs_get_mac_address";
+export default getMacAddress;

--- a/firmware/stackchan/utilities/manifest_utility.json
+++ b/firmware/stackchan/utilities/manifest_utility.json
@@ -9,5 +9,27 @@
   "modules": {
     "*": ["./*"]
   },
-  "preload": ["consts", "stackchan-util"]
+  "preload": ["consts", "stackchan-util", "mac-address"],
+  "platforms": {
+    "esp32": {
+      "modules": {
+        "mac-address": "esp32/mac-address"
+      }
+    },
+    "mac": {
+      "modules": {
+        "mac-address": "sim/mac-address"
+      }
+    },
+    "lin": {
+      "modules": {
+        "mac-address": "sim/mac-address"
+      }
+    },
+    "win": {
+      "modules": {
+        "mac-address": "sim/mac-address"
+      }
+    }
+  }
 }

--- a/firmware/stackchan/utilities/sim/mac-address.js
+++ b/firmware/stackchan/utilities/sim/mac-address.js
@@ -1,0 +1,6 @@
+import Net from 'net'
+
+function getMacAddress() {
+  return Net.get('MAC')
+}
+export default getMacAddress

--- a/firmware/stackchan/utilities/stackchan-util.ts
+++ b/firmware/stackchan/utilities/stackchan-util.ts
@@ -8,7 +8,7 @@ function HashCodeFromString(str: string): number {
    * @returns a hash code as a number.
    * This function uses a simple hash algorithm that shifts the hash value
    * and adds the character code of each character in the string.
-   * The result is a 32-bit signed integer.
+   * The result is a 32-bit unsigned integer.
    */
   let hash = 0
   if (str.length === 0) return hash
@@ -22,7 +22,7 @@ function HashCodeFromString(str: string): number {
   return Math.abs(hash)
 }
 
-export function getDeviceSeed(): number {
+export function generateDeviceSeed(): number {
   /**
    * Generates a seed value based on the device's MAC address.
    * @returns a seed value as a number.
@@ -32,7 +32,7 @@ export function getDeviceSeed(): number {
   return hash
 }
 
-export function getDeviceSpecificColor(seed: number): [number[], number[]] {
+export function generateDeviceSpecificColor(seed: number): [number[], number[]] {
   /**
    * Generates a color based on a seed value.
    * @param seed - the seed value to be used for color generation.

--- a/firmware/stackchan/utilities/stackchan-util.ts
+++ b/firmware/stackchan/utilities/stackchan-util.ts
@@ -45,8 +45,10 @@ export function colorsFromSeed(seed: number): [number[], number[]] {
    * @param seed - the seed value to be used for color generation.
    * @returns an array of two colors, each represented as an array of RGB values.
    */
-  const primary = hslToRgb(((seed >>> 24) * 360) / 255, 1, 0.1 + (((seed >>> 16) & 0xff) * 0.8) / 255)
-  const secondary = hslToRgb((((seed >>> 8) & 0xff) * 360) / 255, 1, 0.1 + ((seed & 0xff) * 0.8) / 255)
+  const lightness1 = 0.1 + (((seed >>> 16) & 0xff) * 0.8) / 255
+  const lightness2 = lightness1 < 0.5 ? lightness1 + 0.4 : lightness1 - 0.4
+  const primary = hslToRgb(((seed >>> 24) * 360) / 255, 1, lightness1)
+  const secondary = hslToRgb((((seed >>> 8) & 0xff) * 360) / 255, 1, Math.max(0.1, Math.min(0.9, lightness2)))
   return [primary, secondary]
 }
 

--- a/firmware/stackchan/utilities/stackchan-util.ts
+++ b/firmware/stackchan/utilities/stackchan-util.ts
@@ -32,7 +32,7 @@ export function generateDeviceSeed(): number {
   return hash
 }
 
-export function generateDeviceSpecificColor(seed: number): [number[], number[]] {
+export function colorsFromSeed(seed: number): [number[], number[]] {
   /**
    * Generates a color based on a seed value.
    * @param seed - the seed value to be used for color generation.

--- a/firmware/stackchan/utilities/stackchan-util.ts
+++ b/firmware/stackchan/utilities/stackchan-util.ts
@@ -27,9 +27,16 @@ export function generateDeviceSeed(): number {
    * Generates a seed value based on the device's MAC address.
    * @returns a seed value as a number.
    */
-  const mac = getMacAddress()
-  const hash = HashCodeFromString(mac)
-  return hash
+  try {
+    const mac = getMacAddress()
+    if (!mac || typeof mac !== 'string') {
+      throw new Error('Invalid MAC address returned')
+    }
+    return HashCodeFromString(mac)
+  } catch (error) {
+    trace(`Failed to get MAC address: ${error}, using fallback seed\n`)
+    return HashCodeFromString(`fallback-${Date.now()}`)
+  }
 }
 
 export function colorsFromSeed(seed: number): [number[], number[]] {

--- a/firmware/stackchan/utilities/stackchan-util.ts
+++ b/firmware/stackchan/utilities/stackchan-util.ts
@@ -16,10 +16,10 @@ function HashCodeFromString(str: string): number {
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i)
     hash = (hash << 5) - hash + char
-    hash = hash & hash
+    hash = hash >>> 0 // Convert to 32-bit unsigned integer
   }
 
-  return Math.abs(hash)
+  return hash
 }
 
 export function generateDeviceSeed(): number {

--- a/firmware/stackchan/utilities/stackchan-util.ts
+++ b/firmware/stackchan/utilities/stackchan-util.ts
@@ -1,4 +1,47 @@
 import Timer from 'timer'
+import getMacAddress from 'mac-address'
+
+function HashCodeFromString(str: string): number {
+  /**
+   * Generates a hash code from a string.
+   * @param str - the string to be hashed.
+   * @returns a hash code as a number.
+   * This function uses a simple hash algorithm that shifts the hash value
+   * and adds the character code of each character in the string.
+   * The result is a 32-bit signed integer.
+   */
+  let hash = 0
+  if (str.length === 0) return hash
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i)
+    hash = (hash << 5) - hash + char
+    hash = hash & hash
+  }
+
+  return Math.abs(hash)
+}
+
+export function getDeviceSeed(): number {
+  /**
+   * Generates a seed value based on the device's MAC address.
+   * @returns a seed value as a number.
+   */
+  const mac = getMacAddress()
+  const hash = HashCodeFromString(mac)
+  return hash
+}
+
+export function getDeviceSpecificColor(seed: number): [number[], number[]] {
+  /**
+   * Generates a color based on a seed value.
+   * @param seed - the seed value to be used for color generation.
+   * @returns an array of two colors, each represented as an array of RGB values.
+   */
+  const primary = hslToRgb(((seed >>> 24) * 360) / 255, 1, 0.1 + (((seed >>> 16) & 0xff) * 0.8) / 255)
+  const secondary = hslToRgb((((seed >>> 8) & 0xff) * 360) / 255, 1, 0.1 + ((seed & 0xff) * 0.8) / 255)
+  return [primary, secondary]
+}
 
 export async function asyncWait(ms) {
   return new Promise((resolve) => {

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -71,6 +71,9 @@
       "calculate-power": [
         "./typings/calculate-power"
       ],
+      "mac-address": [
+        "./typings/mac-address"
+      ],
       "default-mods/on-robot-created": [
         "./stackchan/default-mods/on-robot-created"
       ]

--- a/firmware/typings/mac-address.d.ts
+++ b/firmware/typings/mac-address.d.ts
@@ -1,0 +1,4 @@
+declare module "mac-address" {
+  function getMacAddress(): string;
+  export default getMacAddress;
+}


### PR DESCRIPTION
MACアドレスに基づいた32bit整数シード値を`robot`に保持するようにします。
これをパラメータとすることで個体ごとの固有の処理が可能となります。

- ESP32ではWifi未接続時に`Net.get("MAC")`よりMACアドレスを取得できない制約があるため、直接ESP-IDFから取得するようにしています。
- シード値の活用例として、[Moddableではじめる！あなただけのｽﾀｯｸﾁｬﾝ ！！](https://rt-net.jp/humanoid/archives/5584#toc5) を参考に、シード値から`primary`, `secondary`の色を生成する`colorsFromSeed `を追加しています。modから使用するには以下のように使用します

``` js
import { colorsFromSeed } from 'stackchan-util'

export function onRobotCreated(robot) {
  const [primaryColor, secondaryColor] = colorsFromSeed(robot.seed)

  robot.setColor('primary', primaryColor[0], primaryColor[1], primaryColor[2])
  robot.setColor('secondary', secondaryColor[0], secondaryColor[1], secondaryColor[2])
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve the device's MAC address across multiple platforms.
  - Introduced a unique device seed generation and deterministic color generation based on the MAC address.
  - Exposed the device seed as a public property in the main robot interface.

- **Chores**
  - Updated configuration and manifest files to support platform-specific module loading and improved module resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->