### PR TITLE
add support  for  M5Atom S3 simulator

### DIFF
--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -135,8 +135,8 @@ async function main() {
   if (globalThis.Host?.Button && !globalThis.button) {
     globalThis.button = {
       a: new SimButton(globalThis.Host.Button.a),
-      b: new SimButton(globalThis.Host.Button.b),
-      c: new SimButton(globalThis.Host.Button.c),
+      ...(globalThis.Host.Button.b && { b: new SimButton(globalThis.Host.Button.b) }),
+      ...(globalThis.Host.Button.c && { c: new SimButton(globalThis.Host.Button.c) }),
     }
   }
   await asyncWait(100)

--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -133,10 +133,11 @@ async function checkAndConnectWiFi() {
 
 async function main() {
   if (globalThis.Host?.Button && !globalThis.button) {
+    const { a, b, c } = globalThis.Host.Button
     globalThis.button = {
-      a: new SimButton(globalThis.Host.Button.a),
-      ...(globalThis.Host.Button.b && { b: new SimButton(globalThis.Host.Button.b) }),
-      ...(globalThis.Host.Button.c && { c: new SimButton(globalThis.Host.Button.c) }),
+      ...(a && { a: new SimButton(a) }),
+      ...(b && { b: new SimButton(b) }),
+      ...(c && { c: new SimButton(c) }),
     }
   }
   await asyncWait(100)

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -183,6 +183,36 @@
           "type": "none"
         }
       }
+    },
+    "mac/m5atom_s3": {
+      "config": {
+        "renderer": {
+          "type": "small-face"
+        },
+        "driver": {
+          "type": "none"
+        }
+      }
+    },
+    "lin/m5atom_s3": {
+      "config": {
+        "renderer": {
+          "type": "small-face"
+        },
+        "driver": {
+          "type": "none"
+        }
+      }
+    },
+    "win/m5atom_s3": {
+      "config": {
+        "renderer": {
+          "type": "small-face"
+        },
+        "driver": {
+          "type": "none"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
[Moddable5.8.0](https://github.com/Moddable-OpenSource/moddable/releases/tag/5.8.0)ではM5Atom S3 のシミュレーターが対応されたので、#327 に合わせてシミュレータを利用できるようにします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "m5atom_s3" device on macOS, Linux, and Windows platforms.

- **Bug Fixes**
  - Improved button handling to prevent issues when certain buttons are not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->