### PR TITLE
cache from latest commit

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,7 +25,7 @@ runs:
       if: inputs.target-branch == ''
       run: |
         API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/commits/public"
-        RESPONSE=$(curl -s $API_URL)
+        RESPONSE=$(curl -s -H "Authorization: Bearer ${{ github.token }}" $API_URL)
         LATEST_COMMIT=$(echo $RESPONSE | jq -r '.sha')
         echo "Latest commit of Moddable: $LATEST_COMMIT"
         echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_COMMIT" >> $GITHUB_ENV

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/commits/public"
         RESPONSE=$(curl -s -H "Authorization: Bearer ${{ github.token }}" $API_URL)
-        LATEST_COMMIT=$(echo $RESPONSE | jq -r '.sha')
+        LATEST_COMMIT=$(echo $RESPONSE | jq -r '.sha' | cut -c1-12)
         echo "Latest commit of Moddable: $LATEST_COMMIT"
         echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_COMMIT" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,12 +24,11 @@ runs:
     - name: check latest release tag of Moddable
       if: inputs.target-branch == ''
       run: |
-        API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/releases"
+        API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/commits/public"
         RESPONSE=$(curl -s $API_URL)
-        LATEST_TAG_NAME=$(echo $RESPONSE | jq -r '.[0].tag_name')
-        LATEST_TAG_ID=$(echo $RESPONSE | jq -r '.[0].id')
-        echo "Latest release tag_name of Moddable: $LATEST_TAG_NAME (id:$LATEST_TAG_ID)"
-        echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_TAG_ID" >> $GITHUB_ENV
+        LATEST_COMMIT=$(echo $RESPONSE | jq -r '.sha')
+        echo "Latest commit of Moddable: $LATEST_COMMIT"
+        echo "moddable_cache_key=${{ runner.os }}-moddable-$LATEST_COMMIT" >> $GITHUB_ENV
       shell: bash
     - name: Restore cache of Moddale and ESP32
       if: inputs.target-branch == ''


### PR DESCRIPTION
GitHub APIから取得したrelease情報をjqでパースに失敗するようになりCIが動かない状態です。
暫定的にキャッシュキーを最新のコミットハッシュにします。

ここ最近では、publicへのコミットとリリースのタイミングがほぼ同期しているため問題はない見込みです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to check for the latest commit on the "public" branch instead of the latest release tag.
  * Output messages now reference the latest commit rather than the latest release tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->