### PR TITLE
use embedded:io/pwm instead of pins/servo for PWMServoDriver

### DIFF
--- a/firmware/stackchan/drivers/manifest_driver.json
+++ b/firmware/stackchan/drivers/manifest_driver.json
@@ -2,7 +2,6 @@
   "include": [
     "$(MODDABLE)/examples/manifest_base.json",
     "$(MODDABLE)/examples/manifest_typings.json",
-    "$(MODULES)/pins/servo/manifest.json",
     "$(MODDABLE)/modules/io/manifest.json",
     "../utilities/manifest_utility.json"
   ],

--- a/firmware/stackchan/drivers/manifest_driver.json
+++ b/firmware/stackchan/drivers/manifest_driver.json
@@ -3,6 +3,7 @@
     "$(MODDABLE)/examples/manifest_base.json",
     "$(MODDABLE)/examples/manifest_typings.json",
     "$(MODULES)/pins/servo/manifest.json",
+    "$(MODDABLE)/modules/io/manifest.json",
     "../utilities/manifest_utility.json"
   ],
   "modules": {

--- a/firmware/stackchan/drivers/sg90-driver.ts
+++ b/firmware/stackchan/drivers/sg90-driver.ts
@@ -1,8 +1,33 @@
-import Servo from 'pins/servo'
+import PWM from 'embedded:io/pwm'
 import type { Maybe, Rotation } from 'stackchan-util'
 import Timer from 'timer'
 
 const INTERVAL = 16.5
+
+class Servo {
+  #pwm: PWM
+  #min: number
+  #max: number
+
+  constructor(param: { pin: number; min?: number; max?: number }) {
+    const TAREGET_PERIOD = 18
+    this.#pwm = new PWM({
+      pin: param.pin,
+      hz: Math.floor(1000 / TAREGET_PERIOD),
+    })
+
+    const min = param.min ?? 500
+    const max = param.max ?? 2400
+    const range = 2 ** this.#pwm.resolution - 1
+    this.#min = Math.ceil((min / 1000 / TAREGET_PERIOD) * range)
+    this.#max = Math.floor((max / 1000 / TAREGET_PERIOD) * range)
+  }
+
+  write(degrees: number): void {
+    const value = Math.round(this.#min + (degrees / 180) * (this.#max - this.#min))
+    this.#pwm.write(value)
+  }
+}
 
 function easeInOutSine(ratio) {
   return -(Math.cos(Math.PI * ratio) - 1) / 2

--- a/firmware/stackchan/utilities/manifest_utility.json
+++ b/firmware/stackchan/utilities/manifest_utility.json
@@ -4,7 +4,8 @@
     "$(MODULES)/files/preference/manifest.json",
     "$(MODULES)/base/structuredClone/manifest.json",
     "$(MODULES)/base/deepEqual/manifest.json",
-    "$(MODDABLE)/examples/manifest_typings.json"
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../manifest_typings.json"
   ],
   "modules": {
     "*": ["./*"]

--- a/firmware/tests/drivers/pwm/main.ts
+++ b/firmware/tests/drivers/pwm/main.ts
@@ -1,0 +1,12 @@
+import { PWMServoDriver } from 'sg90-driver'
+
+const driver = new PWMServoDriver({
+  pwmPan: 16,
+  pwmTilt: 17,
+})
+
+driver.applyRotation({
+  r: 0,
+  p: 0,
+  y: 0,
+})

--- a/firmware/tests/drivers/pwm/manifest.json
+++ b/firmware/tests/drivers/pwm/manifest.json
@@ -1,0 +1,10 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../../stackchan/drivers/manifest_driver.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  }
+}


### PR DESCRIPTION
[examples/io/pwm/servo-sweep](https://github.com/Moddable-OpenSource/moddable/tree/public/examples/io/pwm/servo-sweep) を参考にioクラスでServoクラスを作り直しました。

また、本件動作確認する中で、testアプリが動作しないようになっていたため、manifestファイルのincludeの見直しもしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new PWM-based servo driver, allowing improved servo control.
  * Added a basic test script for the PWM servo driver to verify functionality.

* **Chores**
  * Updated manifest files to include new dependencies and configuration paths for I/O modules and typings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->