### PR TITLE
Update xs-dev to version 1.0.2

### DIFF
--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -22,7 +22,7 @@
         "typedoc-plugin-markdown": "^4.2.7",
         "typescript": "^5.8.3",
         "web-audio-engine": "^0.13.4",
-        "xs-dev": "^0.37.0",
+        "xs-dev": "^1.0.2",
         "yargs": "^17.6.2"
       }
     },
@@ -4478,9 +4478,9 @@
       }
     },
     "node_modules/xs-dev": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/xs-dev/-/xs-dev-0.37.0.tgz",
-      "integrity": "sha512-NdZsbHLT/ub+ELTR8zVrorswc5EKDyb4sgcHEoCGz4jpFMMlmq5DW42mNw03iN89Y8SHcSHIR2aD0dqkd87qKw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xs-dev/-/xs-dev-1.0.2.tgz",
+      "integrity": "sha512-QxkfOhiApuL0By511XfzdylorQFBpSoRxp3qcyPxqUFQ0GcrA/jgId6HgGjzUjdarYDX7DFOQOTeXUz+OsL9fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -57,7 +57,7 @@
     "typedoc-plugin-markdown": "^4.2.7",
     "typescript": "^5.8.3",
     "web-audio-engine": "^0.13.4",
-    "xs-dev": "^0.37.0",
+    "xs-dev": "^1.0.2",
     "yargs": "^17.6.2"
   }
 }


### PR DESCRIPTION
Bump xs-dev dependency from ^0.37.0 to ^1.0.2 in package.json and package-lock.json to use the latest features and fixes.

[v0.37.1](https://github.com/HipsterBrown/xs-dev/releases/tag/v0.37.1)以降でCI環境のビルドが失敗するようになったので、その対策版となる[v1.0.2](https://github.com/HipsterBrown/xs-dev/releases/tag/v1.0.2)に更新します。

また、[v0.38.1](https://github.com/HipsterBrown/xs-dev/releases/tag/v0.38.1)からModdable SDK本体が依存するESP-IDFバージョンを示すようになり、xs-devも自動的に追従するようになりました。
これによって、Moddable SDK本体更新に伴うxs-devの更新が必須となるケースもなくなりそうです


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded development tooling to the latest major version to improve stability, build performance, and cross-environment compatibility.
  - Aligns the toolchain with current standards, includes upstream fixes, and prepares the project for future enhancements.
  - No impact on features, UI, or device behavior; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->