### PR TITLE
DynamixelドライバーのESP-IDF5対応

### DIFF
--- a/firmware/stackchan/drivers/dynamixel-driver.ts
+++ b/firmware/stackchan/drivers/dynamixel-driver.ts
@@ -32,6 +32,8 @@ class PControl {
     const result = await this.servo.readPresentPosition()
     if (result.success && result.value > 4096) {
       this._offset = 4096
+    } else if (!result.success) {
+      trace(`${this.name} ... failed to read initial position for offset detection\n`)
     }
     this.goalPosition = 2048
     await this.servo.setOperatingMode(OPERATING_MODE.CURRENT_BASED_POSITION)

--- a/firmware/stackchan/drivers/dynamixel-driver.ts
+++ b/firmware/stackchan/drivers/dynamixel-driver.ts
@@ -14,6 +14,7 @@ class PControl {
   gain: number
   saturation: number
   goalPosition: number
+  _offset: number
   _lastGoalPosition: number
   presentPosition: number
   constructor(servo: Dynamixel, gain, saturation, name = 'servo') {
@@ -23,10 +24,15 @@ class PControl {
     this.name = name
     this.goalPosition = 0
     this.presentPosition = 0
+    this._offset = 0
     this._lastGoalPosition = 0
   }
 
   async init() {
+    const result = await this.servo.readPresentPosition()
+    if (result.success && result.value > 4096) {
+      this._offset = 4096
+    }
     this.goalPosition = 2048
     await this.servo.setOperatingMode(OPERATING_MODE.CURRENT_BASED_POSITION)
     await this.servo.setTorque(true)
@@ -36,7 +42,7 @@ class PControl {
     // trace(`${this.name} ... update\n`)
     if (this._lastGoalPosition !== this.goalPosition) {
       trace(`${this.name} ... updating goal position to ${this.goalPosition}\n`)
-      await this.servo.setGoalPosition(this.goalPosition)
+      await this.servo.setGoalPosition(this.goalPosition + this._offset)
       this._lastGoalPosition = this.goalPosition
     }
 
@@ -45,9 +51,9 @@ class PControl {
       trace(`${this.name} ... failed to update\n`)
       return
     }
-    this.presentPosition = result.value
-
-    const current = Math.min(Math.abs(this.goalPosition - this.presentPosition) * this.gain, this.saturation)
+    this.presentPosition = result.value - this._offset
+    const position = this.presentPosition
+    const current = Math.min(Math.abs(this.goalPosition - position) * this.gain, this.saturation)
     // trace(`servo ${this.name} ... (${position}, ${this.goalPosition}, ${this.gain}, ${this.saturation}, ${current})\n`)
     await this.servo.setGoalCurrent(current)
   }

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -206,10 +206,10 @@ class Dynamixel {
     // Dynamixel.packetHandler = new PacketHandler({
     packetHandler?.close()
     packetHandler = new PacketHandler({
-      receive: config.serial?.receive ?? 16,
-      transmit: config.serial?.transmit ?? 17,
-      baud,
-      port: 2,
+      receive: config.serial?.receive ?? 6,
+      transmit: config.serial?.transmit ?? 7,
+      baud: baud ?? 1_000_000,
+      port: 1,
     })
   }
   #id: number
@@ -229,10 +229,10 @@ class Dynamixel {
     this.#txBuf = new Uint8Array(64)
     if (packetHandler == null) {
       packetHandler = new PacketHandler({
-        receive: config.serial?.receive ?? 16,
-        transmit: config.serial?.transmit ?? 17,
+        receive: config.serial?.receive ?? 6,
+        transmit: config.serial?.transmit ?? 7,
         baud: baudrate,
-        port: 2,
+        port: 1,
       })
     }
     if (packetHandler.hasCallbackOf(id)) {

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -208,7 +208,7 @@ class Dynamixel {
     packetHandler = new PacketHandler({
       receive: config.serial?.receive ?? 6,
       transmit: config.serial?.transmit ?? 7,
-      baud: baud ?? 1_000_000,
+      baud: baud,
       port: 1,
     })
   }

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -110,15 +110,16 @@
       },
       "config": {
         "driver": {
-          "pwmPan": 19,
-          "pwmTilt": 27
+          "type": "dynamixel",
+          "panId": 1,
+          "tiltId": 2
         },
         "tts": {
           "sampleRate": 24000
         },
         "serial": {
-          "transmit": 17,
-          "receive": 18
+          "transmit": 7,
+          "receive": 6
         },
         "virtualButton": true
       }


### PR DESCRIPTION
ESP-IDF5系以降でDynamixelドライバーが動作しなくなる問題があるため、[RT版](https://github.com/rt-net/stack-chan)からの更新内容の取り込みとなります。
合わせてCoreS3のサーボの設定をRT版に合わせています。

一方で、#307 の問題は未解決のため、CoreS3で動作させるためにはPSRAMを無効にする必要があります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved motor positioning accuracy with automatic offset detection and application to eliminate positioning drift.

* **Chores**
  * Switched the motor driver configuration from PWM to Dynamixel-compatible control and updated serial pin assignments for the ESP32 target.
  * Adjusted serial communication defaults to improve connectivity and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->