### PR TITLE
シミュレーター向けにembedded:io/pwmを追加

### DIFF
--- a/firmware/stackchan/utilities/manifest_utility.json
+++ b/firmware/stackchan/utilities/manifest_utility.json
@@ -19,17 +19,20 @@
     },
     "mac": {
       "modules": {
-        "mac-address": "sim/mac-address"
+        "mac-address": "sim/mac-address",
+        "embedded:io/pwm": "sim/pwm"
       }
     },
     "lin": {
       "modules": {
-        "mac-address": "sim/mac-address"
+        "mac-address": "sim/mac-address",
+        "embedded:io/pwm": "sim/pwm"
       }
     },
     "win": {
       "modules": {
-        "mac-address": "sim/mac-address"
+        "mac-address": "sim/mac-address",
+        "embedded:io/pwm": "sim/pwm"
       }
     }
   }

--- a/firmware/stackchan/utilities/sim/pwm.js
+++ b/firmware/stackchan/utilities/sim/pwm.js
@@ -1,6 +1,7 @@
+//  PWM Stub for Simulator
 class PWM {
   close() {}
-  write() {}
+  write(_value) {}
   get hz() {
     return 0
   }

--- a/firmware/stackchan/utilities/sim/pwm.js
+++ b/firmware/stackchan/utilities/sim/pwm.js
@@ -1,0 +1,20 @@
+class PWM {
+  close() {}
+  write() {}
+  get hz() {
+    return 0
+  }
+  get resolution() {
+    return 0
+  }
+
+  get format() {
+    return 'number'
+  }
+
+  set format(value) {
+    if ('number' !== value) throw new RangeError()
+  }
+}
+
+export default PWM


### PR DESCRIPTION
#337 対応時にシミュレーター環境では`embedded:io/pwm`が定義されてないのを見逃してしまいビルドが通りません。
本対応では、シミュレーター向けにembedded:io/pwmを追加します。実際に使うことは無いのでクラス定義のみになります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PWM simulation support for macOS, Linux, and Windows. Includes write capability and configurable properties for frequency, resolution, and output format (format accepts only "number").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->