### PR TITLE
Refine servo command scheduling

### DIFF
--- a/firmware/scripts/ts-test-loader.mjs
+++ b/firmware/scripts/ts-test-loader.mjs
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.endsWith('.ts')) {
+    return defaultResolve(specifier, context, defaultResolve)
+  }
+  return defaultResolve(specifier, context, defaultResolve)
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.ts')) {
+    const source = await readFile(fileURLToPath(url), 'utf8')
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        esModuleInterop: true,
+      },
+      fileName: fileURLToPath(url),
+    })
+    return {
+      format: 'module',
+      source: outputText,
+      shortCircuit: true,
+    }
+  }
+  return defaultLoad(url, context, defaultLoad)
+}

--- a/firmware/stackchan/drivers/__tests__/single-wait-slot.test.ts
+++ b/firmware/stackchan/drivers/__tests__/single-wait-slot.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import SingleWaitSlot from '../internal/single-wait-slot.ts'
+
+test('SingleWaitSlot releases the slot after timeout', async () => {
+  let scheduled: (() => void) | null = null
+  const handles: unknown[] = []
+  const slot = new SingleWaitSlot<number[]>(
+    (handler) => {
+      scheduled = handler
+      const handle = Symbol('timer')
+      handles.push(handle)
+      return handle
+    },
+    () => {
+      handles.push('cleared')
+    },
+  )
+
+  const promise = slot.wait(10)
+  assert.equal(slot.isWaiting, true)
+  assert.ok(scheduled, 'timer handler should be scheduled')
+  scheduled?.()
+
+  const result = await promise
+  assert.equal(result, undefined)
+  assert.equal(slot.isWaiting, false)
+  assert.equal(handles.length, 1)
+  assert.equal(typeof handles[0], 'symbol')
+})
+
+test('SingleWaitSlot clears timer when resolving explicitly', async () => {
+  let scheduled: (() => void) | null = null
+  let clearedHandle: unknown = null
+  const timerHandle = Symbol('timer')
+  const slot = new SingleWaitSlot<number[]>(
+    (handler) => {
+      scheduled = handler
+      return timerHandle
+    },
+    (handle) => {
+      clearedHandle = handle
+    },
+  )
+
+  const promise = slot.wait(10)
+  assert.equal(slot.isWaiting, true)
+  assert.ok(scheduled, 'timer handler should be scheduled')
+
+  slot.resolve([1, 2, 3])
+
+  const result = await promise
+  assert.deepEqual(result, [1, 2, 3])
+  assert.equal(slot.isWaiting, false)
+  assert.equal(clearedHandle, timerHandle)
+
+  // resolving again should be ignored
+  slot.resolve([4, 5, 6])
+  assert.equal(slot.isWaiting, false)
+})

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -1,5 +1,7 @@
 import Serial from 'embedded:io/serial'
 import Timer from 'timer'
+
+import SingleWaitSlot from './internal/single-wait-slot'
 import config from 'mc/config'
 
 type Maybe<T> =
@@ -215,16 +217,14 @@ class Dynamixel {
   #id: number
   #onCommandRead: (values: Uint8Array) => void
   #txBuf: Uint8Array
-  #promises: Array<[(values: Uint8Array) => void, Timer]>
+  #waitSlot: SingleWaitSlot<Uint8Array>
+  #queueTail: Promise<void>
   constructor({ id, baudrate = 1_000_000 }: DynamixelConstructorParam) {
     this.#id = id
-    this.#promises = []
+    this.#waitSlot = new SingleWaitSlot<Uint8Array>(Timer.set, Timer.clear)
+    this.#queueTail = Promise.resolve()
     this.#onCommandRead = (values) => {
-      if (this.#promises.length > 0) {
-        const [resolver, timeoutId] = this.#promises.shift()
-        Timer.clear(timeoutId)
-        resolver(values)
-      }
+      this.#waitSlot.resolve(values)
     }
     this.#txBuf = new Uint8Array(64)
     if (packetHandler == null) {
@@ -247,7 +247,11 @@ class Dynamixel {
     return this.#id
   }
 
-  async #sendCommand(instruction: Instruction, address?: Address, ...parameters: number[]): Promise<Uint8Array> {
+  async #dispatchCommand(
+    instruction: Instruction,
+    address?: Address,
+    ...parameters: number[]
+  ): Promise<Uint8Array | undefined> {
     this.#txBuf[0] = 0xff
     this.#txBuf[1] = 0xff
     this.#txBuf[2] = 0xfd
@@ -289,14 +293,22 @@ class Dynamixel {
     for (let i = 0; i < idx; i++) {
       packetHandler.write(this.#txBuf[i])
     }
-    return new Promise((resolve) => {
-      const id = Timer.set(() => {
-        this.#promises.shift()
-        trace(`timeout. ${this.#promises.length}\n`)
-        resolve(undefined)
-      }, 200)
-      this.#promises.push([resolve, id])
+    return this.#waitSlot.wait(200, () => {
+      trace('timeout.\n')
     })
+  }
+
+  async #sendCommand(
+    instruction: Instruction,
+    address?: Address,
+    ...parameters: number[]
+  ): Promise<Uint8Array | undefined> {
+    const run = this.#queueTail.then(() => this.#dispatchCommand(instruction, address, ...parameters))
+    this.#queueTail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
   }
 
   /**
@@ -439,6 +451,9 @@ class Dynamixel {
    */
   async readModelNumber(): Promise<number> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.MODEL_NUMBER, 2)
+    if (values == null || values.length < 4) {
+      throw new Error('response corrupted')
+    }
     return el(values[0], values[1])
   }
 
@@ -448,7 +463,7 @@ class Dynamixel {
    */
   async readFirmwareVersion(): Promise<Maybe<{ version: number }>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.VERSION_OF_FIRMWARE, 1)
-    if (values != null && values[1] === 0) {
+    if (values != null && values.length >= 3 && values[1] === 0) {
       return {
         success: true,
         value: {
@@ -468,6 +483,9 @@ class Dynamixel {
    */
   async readOffsetAngle(): Promise<number> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.HOMING_OFFSET, 2)
+    if (values == null || values.length < 4) {
+      throw new Error('response corrupted')
+    }
     const isCcw = Boolean(values[0] & 0x8000)
     let offset = ((values[1] & 0x7fff) << 8) | values[0]
     if (isCcw) {
@@ -482,7 +500,7 @@ class Dynamixel {
    */
   async readPresentCurrent(): Promise<Maybe<{ current: number }>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_CURRENT, 2)
-    if (values != null) {
+    if (values != null && values.length >= 4) {
       if (values[1] !== 0) {
         return {
           success: false,
@@ -509,7 +527,7 @@ class Dynamixel {
    */
   async readPresentVelocity(): Promise<Maybe<number>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_VELOCITY, 4)
-    if (values != null) {
+    if (values != null && values.length >= 4) {
       if (values[1] !== 0) {
         return {
           success: false,
@@ -533,7 +551,7 @@ class Dynamixel {
    */
   async readPresentPosition(): Promise<Maybe<number>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_POSITION, 4)
-    if (values != null) {
+    if (values != null && values.length >= 4) {
       if (values[1] !== 0) {
         return {
           success: false,

--- a/firmware/stackchan/drivers/internal/single-wait-slot.ts
+++ b/firmware/stackchan/drivers/internal/single-wait-slot.ts
@@ -1,0 +1,51 @@
+export type TimerHandle = unknown
+export type SetTimer = (handler: () => void, timeout: number) => TimerHandle
+export type ClearTimer = (handle: TimerHandle) => void
+
+export default class SingleWaitSlot<T> {
+  #setTimer: SetTimer
+  #clearTimer: ClearTimer
+  #resolve: ((value: T | undefined) => void) | null = null
+  #timerHandle: TimerHandle | null = null
+
+  constructor(setTimer: SetTimer, clearTimer: ClearTimer) {
+    this.#setTimer = setTimer
+    this.#clearTimer = clearTimer
+  }
+
+  get isWaiting(): boolean {
+    return this.#resolve != null
+  }
+
+  wait(timeout: number, onTimeout?: () => void): Promise<T | undefined> {
+    if (this.#resolve != null) {
+      throw new Error('wait slot is already in use')
+    }
+    return new Promise((resolve) => {
+      this.#resolve = (value) => {
+        this.#resolve = null
+        resolve(value)
+      }
+      this.#timerHandle = this.#setTimer(() => {
+        const resolver = this.#resolve
+        this.#resolve = null
+        this.#timerHandle = null
+        onTimeout?.()
+        resolver?.(undefined)
+      }, timeout)
+    })
+  }
+
+  resolve(value: T): void {
+    if (this.#resolve == null) {
+      return
+    }
+    if (this.#timerHandle != null) {
+      this.#clearTimer(this.#timerHandle)
+      this.#timerHandle = null
+    }
+    const resolver = this.#resolve
+    this.#resolve = null
+    resolver(value)
+  }
+}

--- a/firmware/stackchan/drivers/rs30x.ts
+++ b/firmware/stackchan/drivers/rs30x.ts
@@ -2,6 +2,8 @@ import Serial from 'embedded:io/serial'
 import config from 'mc/config'
 import Timer from 'timer'
 
+import SingleWaitSlot from './internal/single-wait-slot'
+
 // type aliases
 type TORQUE_OFF = 0
 type TORQUE_ON = 1
@@ -173,18 +175,16 @@ class RS30X {
   #id: number
   #onCommandRead: (values: number[]) => void
   #txBuf: Uint8Array
-  #promises: Array<[(values: number[]) => void, Timer]>
+  #waitSlot: SingleWaitSlot<number[]>
+  #queueTail: Promise<void>
   #offset: number
   constructor({ id }: RS30XConstructorParam) {
     this.#id = id
-    this.#promises = []
+    this.#waitSlot = new SingleWaitSlot<number[]>(Timer.set, Timer.clear)
+    this.#queueTail = Promise.resolve()
     this.#offset = 0
     this.#onCommandRead = (values) => {
-      if (this.#promises.length > 0) {
-        const [resolver, timeoutId] = this.#promises.shift()
-        Timer.clear(timeoutId)
-        resolver(values)
-      }
+      this.#waitSlot.resolve(values)
     }
     this.#txBuf = new Uint8Array(64)
     if (packetHandler == null) {
@@ -211,7 +211,7 @@ class RS30X {
     return this.#id
   }
 
-  async #sendCommand(...values: number[]): Promise<number[] | undefined> {
+  async #dispatchCommand(...values: number[]): Promise<number[] | undefined> {
     this.#txBuf[0] = 0xfa
     this.#txBuf[1] = 0xaf
     this.#txBuf[2] = this.#id
@@ -231,14 +231,18 @@ class RS30X {
     for (let i = 0; i < idx; i++) {
       packetHandler.write(this.#txBuf[i])
     }
-    return new Promise((resolve, _reject) => {
-      const id = Timer.set(() => {
-        this.#promises.shift()
-        trace(`timeout. ${this.#promises.length}\n`)
-        resolve(undefined)
-      }, 100)
-      this.#promises.push([resolve, id])
+    return this.#waitSlot.wait(100, () => {
+      trace('timeout.\n')
     })
+  }
+
+  async #sendCommand(...values: number[]): Promise<number[] | undefined> {
+    const run = this.#queueTail.then(() => this.#dispatchCommand(...values))
+    this.#queueTail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
   }
 
   async setMaxTorque(maxTorque: number): Promise<void> {

--- a/firmware/stackchan/drivers/scservo.ts
+++ b/firmware/stackchan/drivers/scservo.ts
@@ -2,6 +2,8 @@ import Serial from 'embedded:io/serial'
 import config from 'mc/config'
 import Timer from 'timer'
 
+import SingleWaitSlot from './internal/single-wait-slot'
+
 type Maybe<T> =
   | {
       success: true
@@ -162,18 +164,16 @@ class SCServo {
   #id: number
   #onCommandRead: (values: number[]) => void
   #txBuf: Uint8Array
-  #promises: Array<[(values: number[]) => void, Timer]>
+  #waitSlot: SingleWaitSlot<number[]>
+  #queueTail: Promise<void>
   #offset: number
   constructor({ id }: SCServoConstructorParam) {
     this.#id = id
-    this.#promises = []
+    this.#waitSlot = new SingleWaitSlot<number[]>(Timer.set, Timer.clear)
+    this.#queueTail = Promise.resolve()
     this.#offset = 0
     this.#onCommandRead = (values) => {
-      if (this.#promises.length > 0) {
-        const [resolver, timeoutId] = this.#promises.shift()
-        Timer.clear(timeoutId)
-        resolver(values)
-      }
+      this.#waitSlot.resolve(values)
     }
     this.#txBuf = new Uint8Array(64)
     if (packetHandler == null) {
@@ -196,7 +196,7 @@ class SCServo {
     return this.#id
   }
 
-  async #sendCommand(command: Command, address: Address, ...values: number[]): Promise<number[]> {
+  async #dispatchCommand(command: Command, address: Address, ...values: number[]): Promise<number[] | undefined> {
     this.#txBuf[0] = 0xff
     this.#txBuf[1] = 0xff
     this.#txBuf[2] = this.#id
@@ -214,14 +214,18 @@ class SCServo {
     for (let i = 0; i < idx; i++) {
       packetHandler.write(this.#txBuf[i])
     }
-    return new Promise((resolve, _reject) => {
-      const id = Timer.set(() => {
-        this.#promises.shift()
-        trace(`timeout. ${this.#promises.length}\n`)
-        resolve(undefined)
-      }, 40)
-      this.#promises.push([resolve, id])
+    return this.#waitSlot.wait(40, () => {
+      trace('timeout.\n')
     })
+  }
+
+  async #sendCommand(command: Command, address: Address, ...values: number[]): Promise<number[] | undefined> {
+    const run = this.#queueTail.then(() => this.#dispatchCommand(command, address, ...values))
+    this.#queueTail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
   }
 
   async #lock(): Promise<unknown> {
@@ -239,6 +243,9 @@ class SCServo {
    */
   async readOffsetAngle(): Promise<number> {
     const values = await this.#sendCommand(COMMAND.READ, ADDRESS.OFFSET, 2)
+    if (values == null || values.length < 2) {
+      throw new Error('response corrupted')
+    }
     const isCcw = Boolean(values[0] & 0x8000)
     let offset = ((values[0] & 0x7fff) << 8) | values[1]
     if (isCcw) {

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -3,6 +3,7 @@
     "allowJs": true,
     "baseUrl": "./",
     "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
     "module": "es2022",
     "lib": [
       "es2024"


### PR DESCRIPTION
## Summary
- add a reusable single wait slot helper and loader support for TypeScript tests
- serialize RS30X, SCServo, and Dynamixel command handling with a single pending slot and stricter response validation
- cover timeout cleanup with a node:test suite and enable `.ts` imports for the test harness

## Testing
- node --test --loader ./scripts/ts-test-loader.mjs stackchan/drivers/__tests__/single-wait-slot.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f34b2aa8832cbdc05d4f7a22e4ae)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for internal synchronization and wait handling mechanisms to improve overall system reliability

* **Chores**
  * Updated TypeScript configuration to better support internal testing infrastructure and module imports
  * Refactored internal servo driver command handling to improve request serialization, concurrency patterns, and response validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->