### PR TITLE
Refactor servo packet handling to reuse buffers

### DIFF
--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -2,6 +2,8 @@
 /tmp/
 /scripts/key.json
 /docs/api
+/dist/
+/dist-tests/
 
 # Bundle file
 /stackchan/tech.moddable.stackchan*

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -12,6 +12,8 @@
     "generate-speech-voicevox": "node scripts/generate-speech-voicevox.js",
     "generate-speech-google": "cross-env GOOGLE_APPLICATION_CREDENTIALS=scripts/key.json node scripts/generate-speech-google.js",
     "generate-apidoc": "typedoc --entryPointStrategy expand --plugin typedoc-plugin-markdown --out docs/api ./stackchan",
+    "test": "npm run test:unit",
+    "test:unit": "rm -rf dist-tests && tsc --project tsconfig.test.json && node --test dist-tests/tests/unit",
     "build": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target -t build ./stackchan/manifest_local.json",
     "bundle": "mcbundle -d -m ./stackchan/manifest.json",
     "deploy": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target -t deploy ./stackchan/manifest_local.json",

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -2,6 +2,8 @@ import Serial from 'embedded:io/serial'
 import Timer from 'timer'
 import config from 'mc/config'
 
+import { PayloadBuffer } from './payload-buffer'
+
 type Maybe<T> =
   | {
       success: true
@@ -86,8 +88,9 @@ const RX_STATE = {
 type RxState = (typeof RX_STATE)[keyof typeof RX_STATE]
 
 class PacketHandler extends Serial {
-  #callbacks: Map<number, (bytes: Uint8Array) => void>
+  #callbacks: Map<number, (buffer: Uint8Array, length: number) => void>
   #rxBuffer: Uint8Array
+  #payloadBuffer: PayloadBuffer
   #idx: number
   #state: RxState
   #id: number
@@ -131,13 +134,17 @@ class PacketHandler extends Serial {
               const id = rxBuf[4]
               const command = rxBuf[7] as Instruction
               if (command === INSTRUCTION.WRITE || command === INSTRUCTION.READ) {
-                // trace(`got echo.  ... ${rxBuf.slice(0, this.#idx)} ignoring\n`)
+                // trace(`got echo.  ... ${rxBuf.subarray(0, this.#idx)} ignoring\n`)
               } else if (command === INSTRUCTION.STATUS) {
-                // trace(`got response for ${id}. triggering callback ... ${rxBuf.slice(0, this.#idx)} \n`)
-                this.#callbacks.get(id)?.(rxBuf.slice(7, this.#idx - 1))
+                // trace(`got response for ${id}. triggering callback ... ${rxBuf.subarray(0, this.#idx)} \n`)
+                const payloadLength = this.#idx - 8
+                const payload = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 7)
+                this.#callbacks.get(id)?.(payload, payloadLength)
               } else {
-                // trace(`something wrong for ${id}. ${rxBuf.slice(0, this.#idx)} \n`)
-                this.#callbacks.get(id)?.(rxBuf.slice(7, this.#idx - 1))
+                // trace(`something wrong for ${id}. ${rxBuf.subarray(0, this.#idx)} \n`)
+                const payloadLength = this.#idx - 8
+                const payload = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 7)
+                this.#callbacks.get(id)?.(payload, payloadLength)
               }
               this.#idx = 0
               this.#state = RX_STATE.SEEK
@@ -157,15 +164,16 @@ class PacketHandler extends Serial {
       format: 'number',
       onReadable,
     })
-    this.#callbacks = new Map<number, () => void>()
+    this.#callbacks = new Map<number, (buffer: Uint8Array, length: number) => void>()
     this.#rxBuffer = new Uint8Array(64)
+    this.#payloadBuffer = new PayloadBuffer(32)
     this.#idx = 0
     this.#state = RX_STATE.SEEK
   }
   hasCallbackOf(id: number): boolean {
     return this.#callbacks.has(id)
   }
-  registerCallback(id: number, callback: (bytes: Uint8Array) => void) {
+  registerCallback(id: number, callback: (buffer: Uint8Array, length: number) => void) {
     this.#callbacks.set(id, callback)
   }
   removeCallback(id: number) {
@@ -213,17 +221,20 @@ class Dynamixel {
     })
   }
   #id: number
-  #onCommandRead: (values: Uint8Array) => void
+  #onCommandRead: (buffer: Uint8Array, length: number) => void
   #txBuf: Uint8Array
-  #promises: Array<[(values: Uint8Array) => void, Timer]>
+  #promises: Array<[(values: Uint8Array | undefined) => void, Timer]>
+  #responseBuffer: PayloadBuffer
   constructor({ id, baudrate = 1_000_000 }: DynamixelConstructorParam) {
     this.#id = id
     this.#promises = []
-    this.#onCommandRead = (values) => {
+    this.#responseBuffer = new PayloadBuffer(32)
+    this.#onCommandRead = (values, length) => {
       if (this.#promises.length > 0) {
         const [resolver, timeoutId] = this.#promises.shift()
         Timer.clear(timeoutId)
-        resolver(values)
+        const payload = this.#responseBuffer.copyFrom(values, length)
+        resolver(payload)
       }
     }
     this.#txBuf = new Uint8Array(64)
@@ -247,7 +258,11 @@ class Dynamixel {
     return this.#id
   }
 
-  async #sendCommand(instruction: Instruction, address?: Address, ...parameters: number[]): Promise<Uint8Array> {
+  async #sendCommand(
+    instruction: Instruction,
+    address?: Address,
+    ...parameters: number[]
+  ): Promise<Uint8Array | undefined> {
     this.#txBuf[0] = 0xff
     this.#txBuf[1] = 0xff
     this.#txBuf[2] = 0xfd
@@ -280,7 +295,7 @@ class Dynamixel {
     this.#txBuf[idx++] = (crc >> 8) & 0xff
     /*
     trace('writing: ')
-    for (const n of this.#txBuf.slice(0, idx)) {
+    for (const n of this.#txBuf.subarray(0, idx)) {
       trace(Number(n).toString(16).padStart(2, '0'))
       trace(' ')
     }
@@ -439,6 +454,9 @@ class Dynamixel {
    */
   async readModelNumber(): Promise<number> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.MODEL_NUMBER, 2)
+    if (values == null || values.length < 2) {
+      throw new Error('failed to read model number')
+    }
     return el(values[0], values[1])
   }
 
@@ -448,7 +466,7 @@ class Dynamixel {
    */
   async readFirmwareVersion(): Promise<Maybe<{ version: number }>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.VERSION_OF_FIRMWARE, 1)
-    if (values != null && values[1] === 0) {
+    if (values != null && values.length >= 3 && values[1] === 0) {
       return {
         success: true,
         value: {
@@ -468,6 +486,9 @@ class Dynamixel {
    */
   async readOffsetAngle(): Promise<number> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.HOMING_OFFSET, 2)
+    if (values == null || values.length < 2) {
+      throw new Error('failed to read offset angle')
+    }
     const isCcw = Boolean(values[0] & 0x8000)
     let offset = ((values[1] & 0x7fff) << 8) | values[0]
     if (isCcw) {
@@ -482,7 +503,7 @@ class Dynamixel {
    */
   async readPresentCurrent(): Promise<Maybe<{ current: number }>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_CURRENT, 2)
-    if (values != null) {
+    if (values != null && values.length >= 4) {
       if (values[1] !== 0) {
         return {
           success: false,
@@ -509,7 +530,7 @@ class Dynamixel {
    */
   async readPresentVelocity(): Promise<Maybe<number>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_VELOCITY, 4)
-    if (values != null) {
+    if (values != null && values.length >= 4) {
       if (values[1] !== 0) {
         return {
           success: false,
@@ -533,7 +554,7 @@ class Dynamixel {
    */
   async readPresentPosition(): Promise<Maybe<number>> {
     const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_POSITION, 4)
-    if (values != null) {
+    if (values != null && values.length >= 4) {
       if (values[1] !== 0) {
         return {
           success: false,

--- a/firmware/stackchan/drivers/payload-buffer.ts
+++ b/firmware/stackchan/drivers/payload-buffer.ts
@@ -1,0 +1,21 @@
+export class PayloadBuffer {
+  #buffer: Uint8Array
+
+  constructor(initialSize = 0) {
+    this.#buffer = new Uint8Array(initialSize)
+  }
+
+  ensureCapacity(size: number): void {
+    if (this.#buffer.length < size) {
+      this.#buffer = new Uint8Array(size)
+    }
+  }
+
+  copyFrom(source: Uint8Array, length: number, offset = 0): Uint8Array {
+    this.ensureCapacity(length)
+    for (let i = 0; i < length; i++) {
+      this.#buffer[i] = source[offset + i]
+    }
+    return this.#buffer.subarray(0, length)
+  }
+}

--- a/firmware/stackchan/drivers/rs30x.ts
+++ b/firmware/stackchan/drivers/rs30x.ts
@@ -2,6 +2,8 @@ import Serial from 'embedded:io/serial'
 import config from 'mc/config'
 import Timer from 'timer'
 
+import { PayloadBuffer } from './payload-buffer'
+
 // type aliases
 type TORQUE_OFF = 0
 type TORQUE_ON = 1
@@ -68,10 +70,10 @@ function el(h: number, l: number) {
  * @returns checksum number
  */
 // file local methods
-function checksum(arr: number[] | Uint8Array): number {
+function checksum(buffer: Uint8Array, start: number, end: number): number {
   let sum = 0
-  for (const n of arr) {
-    sum ^= n
+  for (let i = start; i < end; i++) {
+    sum ^= buffer[i]
   }
   return sum
 }
@@ -84,8 +86,9 @@ const RX_STATE = {
 type RxState = (typeof RX_STATE)[keyof typeof RX_STATE]
 
 class PacketHandler extends Serial {
-  #callbacks: Map<number, (bytes: number[]) => void>
+  #callbacks: Map<number, (buffer: Uint8Array, length: number) => void>
   #rxBuffer: Uint8Array
+  #payloadBuffer: PayloadBuffer
   #idx: number
   #state: RxState
   #count = 0
@@ -120,16 +123,18 @@ class PacketHandler extends Serial {
             this.#count -= 1
             if (this.#count === 0) {
               // trace('received packet!\n')
-              const cs = checksum(rxBuf.slice(2, this.#idx - 1)) & 0xff
+              const cs = checksum(rxBuf, 2, this.#idx - 1) & 0xff
               const id = rxBuf[2]
               const header = el(rxBuf[0], rxBuf[1])
               if (header === PACKET_TYPE.COMMAND) {
-                // trace(`got echo.  ... ${rxBuf.slice(0, this.#idx)} ignoring\n`)
+                // trace(`got echo.  ... ${rxBuf.subarray(0, this.#idx)} ignoring\n`)
               } else if (cs === rxBuf[this.#idx - 1] && this.#callbacks.has(id)) {
                 // trace(`got response for ${id}. triggering callback \n`)
-                this.#callbacks.get(id)?.(Array.from(rxBuf.slice(7, this.#idx - 1)))
+                const payloadLength = this.#idx - 8
+                const payload = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 7)
+                this.#callbacks.get(id)?.(payload, payloadLength)
               } else {
-                trace(`unknown packet for ${id} ... ${rxBuf.slice(0, this.#idx)}. ignoring\n`)
+                trace(`unknown packet for ${id} ... ${rxBuf.subarray(0, this.#idx)}. ignoring\n`)
               }
               this.#idx = 0
               this.#state = RX_STATE.SEEK
@@ -148,15 +153,16 @@ class PacketHandler extends Serial {
       format: 'number',
       onReadable,
     })
-    this.#callbacks = new Map<number, () => void>()
+    this.#callbacks = new Map<number, (buffer: Uint8Array, length: number) => void>()
     this.#rxBuffer = new Uint8Array(64)
+    this.#payloadBuffer = new PayloadBuffer(32)
     this.#idx = 0
     this.#state = RX_STATE.SEEK
   }
   hasCallbackOf(id: number): boolean {
     return this.#callbacks.has(id)
   }
-  registerCallback(id: number, callback: (bytes: number[]) => void) {
+  registerCallback(id: number, callback: (buffer: Uint8Array, length: number) => void) {
     this.#callbacks.set(id, callback)
   }
   removeCallback(id: number) {
@@ -171,19 +177,22 @@ type RS30XConstructorParam = {
 let packetHandler: PacketHandler = null
 class RS30X {
   #id: number
-  #onCommandRead: (values: number[]) => void
+  #onCommandRead: (buffer: Uint8Array, length: number) => void
   #txBuf: Uint8Array
-  #promises: Array<[(values: number[]) => void, Timer]>
+  #promises: Array<[(values: Uint8Array | undefined) => void, Timer]>
+  #responseBuffer: PayloadBuffer
   #offset: number
   constructor({ id }: RS30XConstructorParam) {
     this.#id = id
     this.#promises = []
     this.#offset = 0
-    this.#onCommandRead = (values) => {
+    this.#responseBuffer = new PayloadBuffer(32)
+    this.#onCommandRead = (values, length) => {
       if (this.#promises.length > 0) {
         const [resolver, timeoutId] = this.#promises.shift()
         Timer.clear(timeoutId)
-        resolver(values)
+        const payload = this.#responseBuffer.copyFrom(values, length)
+        resolver(payload)
       }
     }
     this.#txBuf = new Uint8Array(64)
@@ -211,7 +220,7 @@ class RS30X {
     return this.#id
   }
 
-  async #sendCommand(...values: number[]): Promise<number[] | undefined> {
+  async #sendCommand(...values: number[]): Promise<Uint8Array | undefined> {
     this.#txBuf[0] = 0xfa
     this.#txBuf[1] = 0xaf
     this.#txBuf[2] = this.#id
@@ -220,9 +229,9 @@ class RS30X {
       this.#txBuf[idx] = v
       idx++
     }
-    this.#txBuf[idx] = checksum(this.#txBuf.slice(2, idx))
+    this.#txBuf[idx] = checksum(this.#txBuf, 2, idx)
     idx++
-    // trace(`writing: ${this.#txBuf.slice(0, idx)}\n`)
+    // trace(`writing: ${this.#txBuf.subarray(0, idx)}\n`)
     // trace('sending: [')
     // for (let i = 0; i < idx; i++) {
     //   trace('0x' + this.#txBuf[i].toString(16).padStart(2, '0') + ', ')

--- a/firmware/stackchan/drivers/scservo.ts
+++ b/firmware/stackchan/drivers/scservo.ts
@@ -2,6 +2,8 @@ import Serial from 'embedded:io/serial'
 import config from 'mc/config'
 import Timer from 'timer'
 
+import { PayloadBuffer } from './payload-buffer'
+
 type Maybe<T> =
   | {
       success: true
@@ -59,8 +61,9 @@ const RX_STATE = {
 type RxState = (typeof RX_STATE)[keyof typeof RX_STATE]
 
 class PacketHandler extends Serial {
-  #callbacks: Map<number, (bytes: number[]) => void>
+  #callbacks: Map<number, (buffer: Uint8Array, length: number) => void>
   #rxBuffer: Uint8Array
+  #payloadBuffer: PayloadBuffer
   #idx: number
   #state: RxState
   #count: number
@@ -94,16 +97,18 @@ class PacketHandler extends Serial {
             this.#count -= 1
             if (this.#count === 0) {
               // trace('received packet!\n')
-              const cs = checksum(rxBuf.slice(0, this.#idx - 1)) & 0xff
+              const cs = checksum(rxBuf, this.#idx - 1) & 0xff
               const id = rxBuf[2]
               const command = rxBuf[4] as Command
               if (command === COMMAND.READ || command === COMMAND.WRITE) {
-                // trace(`got echo.  ... ${rxBuf.slice(0, this.#idx)} ignoring\n`)
+                // trace(`got echo.  ... ${rxBuf.subarray(0, this.#idx)} ignoring\n`)
               } else if (cs === rxBuf[this.#idx - 1] && this.#callbacks.has(id)) {
                 // trace(`got response for ${id}. triggering callback \n`)
-                this.#callbacks.get(id)(Array.from(rxBuf.slice(5, this.#idx - 1)))
+                const payloadLength = this.#idx - 6
+                const payload = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 5)
+                this.#callbacks.get(id)(payload, payloadLength)
               } else {
-                trace(`unknown packet for ${id} ... ${rxBuf.slice(0, this.#idx)}. ignoring\n`)
+                trace(`unknown packet for ${id} ... ${rxBuf.subarray(0, this.#idx)}. ignoring\n`)
               }
               this.#idx = 0
               this.#state = RX_STATE.SEEK
@@ -122,15 +127,16 @@ class PacketHandler extends Serial {
       format: 'number',
       onReadable,
     })
-    this.#callbacks = new Map<number, () => void>()
+    this.#callbacks = new Map<number, (buffer: Uint8Array, length: number) => void>()
     this.#rxBuffer = new Uint8Array(64)
+    this.#payloadBuffer = new PayloadBuffer(32)
     this.#idx = 0
     this.#state = RX_STATE.SEEK
   }
   hasCallbackOf(id: number): boolean {
     return this.#callbacks.has(id)
   }
-  registerCallback(id: number, callback: (bytes: number[]) => void) {
+  registerCallback(id: number, callback: (buffer: Uint8Array, length: number) => void) {
     this.#callbacks.set(id, callback)
   }
   removeCallback(id: number) {
@@ -143,10 +149,10 @@ class PacketHandler extends Serial {
  * @param arr packet array except checksum
  * @returns checksum number
  */
-function checksum(arr: number[] | Uint8Array): number {
+function checksum(buffer: Uint8Array, length: number): number {
   let sum = 0
-  for (const n of arr.slice(2)) {
-    sum += n
+  for (let i = 2; i < length; i++) {
+    sum += buffer[i]
   }
   const cs = ~(sum & 0xff)
   // trace(`>>>checksum is ${new Uint8Array([cs])[0]}: ${arr}\n`)
@@ -160,19 +166,22 @@ type SCServoConstructorParam = {
 let packetHandler: PacketHandler = null
 class SCServo {
   #id: number
-  #onCommandRead: (values: number[]) => void
+  #onCommandRead: (buffer: Uint8Array, length: number) => void
   #txBuf: Uint8Array
-  #promises: Array<[(values: number[]) => void, Timer]>
+  #promises: Array<[(values: Uint8Array | undefined) => void, Timer]>
+  #responseBuffer: PayloadBuffer
   #offset: number
   constructor({ id }: SCServoConstructorParam) {
     this.#id = id
     this.#promises = []
     this.#offset = 0
-    this.#onCommandRead = (values) => {
+    this.#responseBuffer = new PayloadBuffer(32)
+    this.#onCommandRead = (values, length) => {
       if (this.#promises.length > 0) {
         const [resolver, timeoutId] = this.#promises.shift()
         Timer.clear(timeoutId)
-        resolver(values)
+        const payload = this.#responseBuffer.copyFrom(values, length)
+        resolver(payload)
       }
     }
     this.#txBuf = new Uint8Array(64)
@@ -196,7 +205,7 @@ class SCServo {
     return this.#id
   }
 
-  async #sendCommand(command: Command, address: Address, ...values: number[]): Promise<number[]> {
+  async #sendCommand(command: Command, address: Address, ...values: number[]): Promise<Uint8Array | undefined> {
     this.#txBuf[0] = 0xff
     this.#txBuf[1] = 0xff
     this.#txBuf[2] = this.#id
@@ -208,9 +217,9 @@ class SCServo {
       this.#txBuf[idx] = v
       idx++
     }
-    this.#txBuf[idx] = checksum(this.#txBuf.slice(0, idx))
+    this.#txBuf[idx] = checksum(this.#txBuf, idx)
     idx++
-    // trace(`writing: ${this.#txBuf.slice(0, idx)}\n`)
+    // trace(`writing: ${this.#txBuf.subarray(0, idx)}\n`)
     for (let i = 0; i < idx; i++) {
       packetHandler.write(this.#txBuf[i])
     }

--- a/firmware/tests/unit/payload-buffer.test.ts
+++ b/firmware/tests/unit/payload-buffer.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { PayloadBuffer } from '../../stackchan/drivers/payload-buffer.js'
+
+test('copyFrom reuses existing allocation when capacity is sufficient', () => {
+  const buffer = new PayloadBuffer(4)
+  const source = Uint8Array.from([1, 2, 3, 4])
+
+  const firstView = buffer.copyFrom(source, 2)
+  assert.equal(firstView.length, 2)
+  assert.deepEqual(Array.from(firstView), [1, 2])
+  const initialBuffer = firstView.buffer
+
+  const secondView = buffer.copyFrom(source, 2, 2)
+  assert.equal(secondView.length, 2)
+  assert.deepEqual(Array.from(secondView), [3, 4])
+  assert.strictEqual(secondView.buffer, initialBuffer)
+})
+
+test('copyFrom grows the allocation once when required and reuses it afterwards', () => {
+  const buffer = new PayloadBuffer(1)
+  const first = buffer.copyFrom(Uint8Array.from([5, 6, 7]), 3)
+  assert.equal(first.length, 3)
+  assert.deepEqual(Array.from(first), [5, 6, 7])
+  const grown = first.buffer
+
+  const second = buffer.copyFrom(Uint8Array.from([8]), 1)
+  assert.equal(second.length, 1)
+  assert.strictEqual(second.buffer, grown)
+  assert.equal(second[0], 8)
+})

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-tests",
+    "allowJs": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": [
+    "stackchan/drivers/payload-buffer.ts",
+    "tests/unit/**/*.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- refactor servo packet handlers to pass reusable payload buffers to callbacks and avoid per-message slicing
- update servo drivers to consume buffer/length responses, returning typed arrays with improved checksum handling and read validation
- add a shared payload buffer helper, TypeScript test configuration, and unit tests plus npm scripts/ignores for the new test build output

## Testing
- npm run test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f34aaf94832c923ded521309db0b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unit testing infrastructure with new test scripts and configuration.

* **Tests**
  * Introduced unit tests for payload buffer management to verify allocation behavior and data handling.

* **Chores**
  * Updated build configuration to ignore generated test artifacts.
  * Enhanced internal data handling mechanisms for improved robustness in driver communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->