### PR TITLE
Optimize servo packet writes to use typed arrays

### DIFF
--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -286,9 +286,7 @@ class Dynamixel {
     }
     trace('\n')
     */
-    for (let i = 0; i < idx; i++) {
-      packetHandler.write(this.#txBuf[i])
-    }
+    packetHandler.write(this.#txBuf.subarray(0, idx))
     return new Promise((resolve) => {
       const id = Timer.set(() => {
         this.#promises.shift()

--- a/firmware/stackchan/drivers/rs30x.ts
+++ b/firmware/stackchan/drivers/rs30x.ts
@@ -228,9 +228,7 @@ class RS30X {
     //   trace('0x' + this.#txBuf[i].toString(16).padStart(2, '0') + ', ')
     // }
     // trace(']\n')
-    for (let i = 0; i < idx; i++) {
-      packetHandler.write(this.#txBuf[i])
-    }
+    packetHandler.write(this.#txBuf.subarray(0, idx))
     return new Promise((resolve, _reject) => {
       const id = Timer.set(() => {
         this.#promises.shift()

--- a/firmware/stackchan/drivers/scservo.ts
+++ b/firmware/stackchan/drivers/scservo.ts
@@ -211,9 +211,7 @@ class SCServo {
     this.#txBuf[idx] = checksum(this.#txBuf.slice(0, idx))
     idx++
     // trace(`writing: ${this.#txBuf.slice(0, idx)}\n`)
-    for (let i = 0; i < idx; i++) {
-      packetHandler.write(this.#txBuf[i])
-    }
+    packetHandler.write(this.#txBuf.subarray(0, idx))
     return new Promise((resolve, _reject) => {
       const id = Timer.set(() => {
         this.#promises.shift()


### PR DESCRIPTION
## Summary
- confirm the serial packet handler supports typed array writes
- send servo protocol packets with a single Serial.write call instead of per-byte loops

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f348ea9c832c8218e403371731a0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized firmware driver communication by consolidating individual byte transmissions into efficient batch writes, improving data transmission performance without changing system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->