### PR TITLE
Feature/light

### DIFF
--- a/firmware/mods/light/manifest.json
+++ b/firmware/mods/light/manifest.json
@@ -1,0 +1,6 @@
+{
+  "include": ["$(MODDABLE)/examples/manifest_mod.json"],
+  "modules": {
+    "*": ["./mod"]
+  }
+}

--- a/firmware/mods/light/mod.js
+++ b/firmware/mods/light/mod.js
@@ -1,0 +1,31 @@
+export function onRobotCreated(robot) {
+  const led = robot.led
+  if (!led || !led.a) {
+    throw new Error('This device does not support LED or setup LED named as "a".')
+  }
+
+  const colors = [
+    { r: 255, g: 0, b: 0 },
+    { r: 0, g: 255, b: 0 },
+    { r: 0, g: 0, b: 255 },
+  ]
+  robot.button.a.onChanged = function () {
+    if (this.read()) {
+      const firstColor = colors.shift()
+      colors.push(firstColor)
+      robot.lightOn('a', firstColor.r, firstColor.g, firstColor.b)
+    }
+  }
+
+  robot.button.b.onChanged = function () {
+    if (this.read()) {
+      robot.lightOff('a')
+    }
+  }
+
+  robot.button.c.onChanged = function () {
+    if (this.read()) {
+      robot.lightRainbow('a')
+    }
+  }
+}

--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -14,7 +14,7 @@
         "@ffmpeg/ffmpeg": "^0.11.6",
         "@google-cloud/text-to-speech": "^6.1.0",
         "@microsoft/tsdoc": "^0.15.0",
-        "@moddable/typings": "^6.0.0",
+        "@moddable/typings": "^7.0.0",
         "cross-env-default": "^5.1.3-1",
         "lefthook": "^1.8.2",
         "node-fetch": "^3.3.0",
@@ -337,9 +337,9 @@
       "license": "MIT"
     },
     "node_modules/@moddable/typings": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-6.0.0.tgz",
-      "integrity": "sha512-YlRuVie5Bn5dfbYKuXUgOKpFMapi7IoEKfyAfPIjUdZtRDG4tVsGjRW5C53MfMIKyyuUL0nkcginB/JSCr5Efg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-7.0.0.tgz",
+      "integrity": "sha512-UjNFsHnlvQO5TobDeUVY3nNqCKH7nEzFZccnwZg9pDsqLgYv0oDNH0vZ2vGliZdrTMsX9iD7dY55g4gXwq67xA==",
       "dev": true,
       "license": "ISC"
     },

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -51,7 +51,7 @@
     "@ffmpeg/ffmpeg": "^0.11.6",
     "@google-cloud/text-to-speech": "^6.1.0",
     "@microsoft/tsdoc": "^0.15.0",
-    "@moddable/typings": "^6.0.0",
+    "@moddable/typings": "^7.0.0",
     "cross-env-default": "^5.1.3-1",
     "lefthook": "^1.8.2",
     "node-fetch": "^3.3.0",

--- a/firmware/stackchan/led/led.ts
+++ b/firmware/stackchan/led/led.ts
@@ -1,4 +1,4 @@
-import { NeoStrand, type NeoStrandEffect } from 'neostrand'
+import { NeoStrand, NeoStrandEffect, type NeoStrandEffectDictionary } from 'neostrand'
 import Timer from 'timer'
 
 const Timing_WS2812B = {
@@ -7,10 +7,50 @@ const Timing_WS2812B = {
   reset: { level0: 0, duration0: 100, level1: 0, duration1: 100 },
 } as const
 
+class Blink extends NeoStrandEffect {
+  private rgbOn: number
+  private rgbOff: number
+  constructor(
+    dictionary: NeoStrandEffectDictionary & {
+      rgb: { r: number; g: number; b: number }
+      index?: number
+      count?: number
+      duration?: number
+    },
+  ) {
+    super(dictionary)
+    this.name = 'Blink'
+    this.loop = 1
+
+    if (dictionary.index) {
+      this.start = dictionary.index
+    }
+    if (dictionary.count) {
+      this.size = dictionary.count
+      this.end = this.start + this.size
+      if (this.end > this.strand.length) this.end = this.strand.length
+    }
+    this.dur = dictionary.duration ?? 1000
+    this.rgbOn = this.strand.makeRGB(dictionary.rgb.r, dictionary.rgb.g, dictionary.rgb.b)
+    this.rgbOff = this.strand.makeRGB(0, 0, 0)
+  }
+
+  activate(effect: NeoStrandEffect): void {
+    effect.timeline.on(effect, { effectValue: [0, effect.dur] }, effect.dur, null, 0)
+    effect.reset(effect)
+  }
+
+  set effectValue(value) {
+    const half = this.dur / 2
+    const newColor = value < half ? this.rgbOn : this.rgbOff
+    const currentColor = this.strand.getPixel(this.start)
+    if (newColor !== currentColor) {
+      for (let i = this.start; i < this.end; i++) this.strand.set(i, newColor, this.start, this.end)
+    }
+  }
+}
+
 export default class Led extends NeoStrand {
-  private _blinkTimer?: Timer
-  private _blinking: boolean = false
-  private _blinkState: boolean = false
   private _effect?: NeoStrandEffect
 
   constructor(parameters: {
@@ -31,58 +71,49 @@ export default class Led extends NeoStrand {
     }
   }
 
+  private _stopEffect() {
+    if (this._effect) {
+      this.stop()
+      this._effect = undefined
+    }
+  }
+
   on(r: number, g: number, b: number, duration?: number, index?: number, count?: number) {
     const _index = index ?? 0
     const _count = count ?? this.length - _index
+    this._stopEffect()
     this._fill(this.makeRGB(r, g, b), _index, _count)
 
     this.update()
     if (duration) {
       Timer.set(() => {
-        this._fill(this.makeRGB(0, 0, 0), _index, _count)
-        this.update()
+        this.off(_index, _count)
       }, duration)
     }
   }
+
   off(index?: number, count?: number) {
     const _index = index ?? 0
     const _count = count ?? this.length - _index
-    this._blinking = false
-    if (this._blinkTimer !== undefined) {
-      Timer.clear(this._blinkTimer)
-      this._blinkTimer = undefined
-    }
-    if (this._effect) {
-      this.stop()
-      this._effect = undefined
-    }
+    this._stopEffect()
     this._fill(this.makeRGB(0, 0, 0), _index, _count)
     this.update()
   }
 
-  blink(r: number, g: number, b: number, interval: number, index?: number, count?: number) {
+  blink(r: number, g: number, b: number, duration: number, index?: number, count?: number) {
     const _index = index ?? 0
     const _count = count ?? this.length - _index
-    if (this._blinking) return
-    this._blinking = true
-    this._blinkState = false
+    this._stopEffect()
 
-    const step = () => {
-      if (!this._blinking) return
-      this._blinkState = !this._blinkState
-      if (this._blinkState) {
-        this._fill(this.makeRGB(r, g, b), _index, _count)
-      } else {
-        this._fill(this.makeRGB(0, 0, 0), _index, _count)
-      }
-      this.update()
-    }
-    this._blinkTimer = Timer.repeat(step, interval)
+    this._effect = new Blink({ strand: this, rgb: { r, g, b }, index: _index, count: _count, duration: duration })
+    this.setScheme([this._effect])
+    this.start(50)
   }
+
   rainbow(index?: number, count?: number) {
     const _index = index ?? 0
     const _count = count ?? this.length - _index
-    if (this._effect) return
+    this._stopEffect()
 
     this._effect = new NeoStrand.HueSpan({ strand: this, start: _index, end: _count })
     this.setScheme([this._effect])

--- a/firmware/stackchan/led/led.ts
+++ b/firmware/stackchan/led/led.ts
@@ -8,6 +8,7 @@ const Timing_WS2812B = {
 } as const
 
 class Blink extends NeoStrandEffect {
+  private light: boolean
   private rgbOn: number
   private rgbOff: number
   constructor(
@@ -21,6 +22,7 @@ class Blink extends NeoStrandEffect {
     super(dictionary)
     this.name = 'Blink'
     this.loop = 1
+    this.light = false
 
     if (dictionary.index) {
       this.start = dictionary.index
@@ -41,11 +43,16 @@ class Blink extends NeoStrandEffect {
   }
 
   set effectValue(value) {
-    const half = this.dur / 2
-    const newColor = value < half ? this.rgbOn : this.rgbOff
-    const currentColor = this.strand.getPixel(this.start)
-    if (newColor !== currentColor) {
-      for (let i = this.start; i < this.end; i++) this.strand.set(i, newColor, this.start, this.end)
+    const isFirstHalf = value <= this.dur / 2
+    const shouldTurnOn = !this.light && isFirstHalf
+    const shouldTurnOff = this.light && !isFirstHalf
+
+    if (shouldTurnOn || shouldTurnOff) {
+      const color = shouldTurnOn ? this.rgbOn : this.rgbOff
+      for (let i = this.start; i < this.end; i++) {
+        this.strand.set(i, color)
+      }
+      this.light = shouldTurnOn
     }
   }
 }
@@ -113,7 +120,7 @@ export default class Led extends NeoStrand {
       duration: duration,
     })
     this.setScheme([this._effect])
-    this.start(50)
+    this.start(100)
   }
 
   rainbow(index?: number, count?: number) {

--- a/firmware/stackchan/led/led.ts
+++ b/firmware/stackchan/led/led.ts
@@ -105,7 +105,13 @@ export default class Led extends NeoStrand {
     const _count = count ?? this.length - _index
     this._stopEffect()
 
-    this._effect = new Blink({ strand: this, rgb: { r, g, b }, index: _index, count: _count, duration: duration })
+    this._effect = new Blink({
+      strand: this,
+      rgb: { r, g, b },
+      index: _index,
+      count: _index + _count,
+      duration: duration,
+    })
     this.setScheme([this._effect])
     this.start(50)
   }

--- a/firmware/stackchan/led/led.ts
+++ b/firmware/stackchan/led/led.ts
@@ -59,6 +59,7 @@ class Blink extends NeoStrandEffect {
 
 export default class Led extends NeoStrand {
   private _effect?: NeoStrandEffect
+  private _offTimer?: Timer
 
   constructor(parameters: {
     pin: number
@@ -83,6 +84,10 @@ export default class Led extends NeoStrand {
       this.stop()
       this._effect = undefined
     }
+    if (this._offTimer) {
+      Timer.clear(this._offTimer)
+      this._offTimer = undefined
+    }
   }
 
   on(r: number, g: number, b: number, duration?: number, index?: number, count?: number) {
@@ -93,7 +98,7 @@ export default class Led extends NeoStrand {
 
     this.update()
     if (duration) {
-      Timer.set(() => {
+      this._offTimer = Timer.set(() => {
         this.off(_index, _count)
       }, duration)
     }
@@ -116,7 +121,7 @@ export default class Led extends NeoStrand {
       strand: this,
       rgb: { r, g, b },
       index: _index,
-      count: _index + _count,
+      count: _count,
       duration: duration,
     })
     this.setScheme([this._effect])

--- a/firmware/stackchan/led/led.ts
+++ b/firmware/stackchan/led/led.ts
@@ -115,7 +115,7 @@ export default class Led extends NeoStrand {
     const _count = count ?? this.length - _index
     this._stopEffect()
 
-    this._effect = new NeoStrand.HueSpan({ strand: this, start: _index, end: _count })
+    this._effect = new NeoStrand.HueSpan({ strand: this, start: _index, end: _index + _count })
     this.setScheme([this._effect])
     this.start(50)
   }

--- a/firmware/stackchan/led/led.ts
+++ b/firmware/stackchan/led/led.ts
@@ -1,0 +1,91 @@
+import { NeoStrand, type NeoStrandEffect } from 'neostrand'
+import Timer from 'timer'
+
+const Timing_WS2812B = {
+  mark: { level0: 1, duration0: 900, level1: 0, duration1: 350 },
+  space: { level0: 1, duration0: 350, level1: 0, duration1: 900 },
+  reset: { level0: 0, duration0: 100, level1: 0, duration1: 100 },
+} as const
+
+export default class Led extends NeoStrand {
+  private _blinkTimer?: Timer
+  private _blinking: boolean = false
+  private _blinkState: boolean = false
+  private _effect?: NeoStrandEffect
+
+  constructor(parameters: {
+    pin: number
+    length?: number
+    order?: string
+  }) {
+    super({
+      pin: parameters.pin,
+      length: parameters.length ?? 1,
+      order: parameters.order ?? 'GRB',
+      timing: Timing_WS2812B,
+    })
+  }
+  private _fill(color: number, index: number, count: number) {
+    for (let i = index; i < index + count; i++) {
+      this.set(i, color)
+    }
+  }
+
+  on(r: number, g: number, b: number, duration?: number, index?: number, count?: number) {
+    const _index = index ?? 0
+    const _count = count ?? this.length - _index
+    this._fill(this.makeRGB(r, g, b), _index, _count)
+
+    this.update()
+    if (duration) {
+      Timer.set(() => {
+        this._fill(this.makeRGB(0, 0, 0), _index, _count)
+        this.update()
+      }, duration)
+    }
+  }
+  off(index?: number, count?: number) {
+    const _index = index ?? 0
+    const _count = count ?? this.length - _index
+    this._blinking = false
+    if (this._blinkTimer !== undefined) {
+      Timer.clear(this._blinkTimer)
+      this._blinkTimer = undefined
+    }
+    if (this._effect) {
+      this.stop()
+      this._effect = undefined
+    }
+    this._fill(this.makeRGB(0, 0, 0), _index, _count)
+    this.update()
+  }
+
+  blink(r: number, g: number, b: number, interval: number, index?: number, count?: number) {
+    const _index = index ?? 0
+    const _count = count ?? this.length - _index
+    if (this._blinking) return
+    this._blinking = true
+    this._blinkState = false
+
+    const step = () => {
+      if (!this._blinking) return
+      this._blinkState = !this._blinkState
+      if (this._blinkState) {
+        this._fill(this.makeRGB(r, g, b), _index, _count)
+      } else {
+        this._fill(this.makeRGB(0, 0, 0), _index, _count)
+      }
+      this.update()
+    }
+    this._blinkTimer = Timer.repeat(step, interval)
+  }
+  rainbow(index?: number, count?: number) {
+    const _index = index ?? 0
+    const _count = count ?? this.length - _index
+    if (this._effect) return
+
+    this._effect = new NeoStrand.HueSpan({ strand: this, start: _index, end: _count })
+    this.setScheme([this._effect])
+    this.start(50)
+  }
+}

--- a/firmware/stackchan/led/manifest_led.json
+++ b/firmware/stackchan/led/manifest_led.json
@@ -1,0 +1,27 @@
+{
+  "modules": {
+    "*": ["$(MODULES)/drivers/neostrand/*", "./led"],
+    "piu/Timeline": "$(MODULES)/piu/All/piuTimeline"
+  },
+  "preload": ["neostrand", "piu/Timeline", "led"],
+  "platforms": {
+    "esp32": {
+      "include": ["$(MODULES)/drivers/neopixel/manifest.json"]
+    },
+    "mac": {
+      "modules": {
+        "neopixel": "./neopixel_stub"
+      }
+    },
+    "lin": {
+      "modules": {
+        "neopixel": "./neopixel_stub"
+      }
+    },
+    "win": {
+      "modules": {
+        "neopixel": "./neopixel_stub"
+      }
+    }
+  }
+}

--- a/firmware/stackchan/led/neopixel_stub.ts
+++ b/firmware/stackchan/led/neopixel_stub.ts
@@ -1,0 +1,31 @@
+class NeoPixel {
+  close() {}
+  update() {}
+
+  makeRGB(_r: number, _g: number, _b: number) {
+    return 0
+  }
+  makeHSB(_h: number, _s: number, _b: number) {
+    return 0
+  }
+
+  setPixel(_index: number, _color) {}
+  fill(_color, _index: number, _count: number) {}
+  getPixel(_index) {
+    return 0
+  }
+  set brightness(_value) {}
+  get brightness() {
+    return 128
+  }
+
+  get length() {
+    return 1
+  }
+  get byteLength() {
+    return 1
+  }
+}
+Object.freeze(NeoPixel.prototype)
+
+export default NeoPixel

--- a/firmware/stackchan/led/neopixel_stub.ts
+++ b/firmware/stackchan/led/neopixel_stub.ts
@@ -9,12 +9,12 @@ class NeoPixel {
     return 0
   }
 
-  setPixel(_index: number, _color) {}
-  fill(_color, _index: number, _count: number) {}
-  getPixel(_index) {
+  setPixel(_index: number, _color: number) {}
+  fill(_color: number, _index: number, _count: number) {}
+  getPixel(_index: number) {
     return 0
   }
-  set brightness(_value) {}
+  set brightness(_value: number) {}
   get brightness() {
     return 128
   }

--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -21,6 +21,7 @@ import Microphone from 'microphone'
 import Tone from 'tone'
 import { asyncWait } from 'stackchan-util'
 import loadPreferences from 'loadPreference'
+import Led from 'led'
 
 // wrapper button class for simulator
 class SimButton {
@@ -112,6 +113,15 @@ function createRobot() {
   const touch = TouchConstructor ? new Touch(TouchConstructor) : undefined
   const microphone = Modules.has('embedded:io/audio/in') ? new Microphone() : undefined
   const tone = new Tone({ volume: ttsPrefs.volume })
+
+  const configLed = config.led || {}
+  const led = Object.fromEntries(
+    Object.entries(configLed).map(([key, config]) => [
+      key,
+      new Led(config as { pin: number; length?: number; order?: string }),
+    ]),
+  )
+
   return new Robot({
     driver,
     renderer,
@@ -120,6 +130,7 @@ function createRobot() {
     touch,
     tone,
     microphone,
+    led,
   })
 }
 

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -11,6 +11,7 @@
     "./drivers/manifest_driver.json",
     "./ble/manifest_ble.json",
     "./dialogues/manifest_dialogue.json",
+    "./led/manifest_led.json",
     "./renderers/manifest_renderer.json",
     "./services/manifest_service.json",
     "./speeches/manifest_speech.json",

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -534,14 +534,14 @@ export class Robot {
    * @param r - The red component of the color (0-255).
    * @param g - The green component of the color (0-255).
    * @param b - The blue component of the color (0-255).
-   * @param interval - The time in milliseconds between blinks.
+   * @param duration - The time in milliseconds between blinks.
    * @param index - Optional index to specify which Led to control if multiple LEDs are present.
    * @param count - Optional number of times to blink the Led. If not provided, it will blink indefinitely.
    */
-  lightBlink(ledName: string, r: number, g: number, b: number, interval: number, index?: number, count?: number) {
+  lightBlink(ledName: string, r: number, g: number, b: number, duration: number, index?: number, count?: number) {
     const led = this.#led[ledName]
     if (led) {
-      led.blink(r, g, b, interval, index, count)
+      led.blink(r, g, b, duration, index, count)
     }
   }
 

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -68,7 +68,7 @@ type RobotConstructorParam<T extends string> = {
   touch?: Touch
   microphone?: Microphone
   tone?: Tone
-  led?: Record<string, InstanceType<typeof Led>>
+  led?: Record<string, Led>
 }
 
 const LEFT_RIGHT = Object.freeze(['left', 'right'])

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -536,7 +536,7 @@ export class Robot {
    * @param b - The blue component of the color (0-255).
    * @param interval - The time in milliseconds between blinks.
    * @param index - Optional index to specify which Led to control if multiple LEDs are present.
-   * @param count - Optional number of times to blink the Led. If not provided, it will blink indefinitely.
+   * @param count - Optional number of LEDs to blink. If not provided, it will affect all LEDs from the index to the end.
    */
   lightBlink(ledName: string, r: number, g: number, b: number, interval: number, index?: number, count?: number) {
     const led = this.#led[ledName]

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -5,6 +5,7 @@ import type Digital from 'embedded:io/digital'
 import type Touch from 'touch'
 import type Microphone from 'microphone'
 import type Tone from 'tone'
+import type Led from 'led'
 import { createBalloonDecorator } from 'decorator'
 import { DEFAULT_FONT } from 'consts'
 import Resource from 'Resource'
@@ -67,6 +68,7 @@ type RobotConstructorParam<T extends string> = {
   touch?: Touch
   microphone?: Microphone
   tone?: Tone
+  led?: Record<string, InstanceType<typeof Led>>
 }
 
 const LEFT_RIGHT = Object.freeze(['left', 'right'])
@@ -92,6 +94,7 @@ export class Robot {
   #touch: Touch
   #microphone: Microphone
   #tone: Tone
+  #led: Record<string, InstanceType<typeof Led>>
   #isMoving: boolean
   #renderer: Renderer
   #paused: boolean
@@ -113,6 +116,7 @@ export class Robot {
     this.#touch = params.touch
     this.#microphone = params.microphone
     this.#tone = params.tone
+    this.#led = params.led ?? {}
     this.#pose = params.pose ?? {
       body: {
         position: {
@@ -238,6 +242,15 @@ export class Robot {
    */
   get microphone() {
     return this.#microphone
+  }
+
+  /**
+   * get LED
+   *
+   * @returns Led instances
+   */
+  get led() {
+    return this.#led
   }
 
   /**
@@ -478,5 +491,70 @@ export class Robot {
       }
     }
     this.updating = false
+  }
+
+  /**
+   * Turns on an Led with the specified color and optional animation parameters.
+   * @param ledName - The name identifier of the Led to control
+   * @param r - Red color value (0-255)
+   * @param g - Green color value (0-255)
+   * @param b - Blue color value (0-255)
+   * @param duration - Optional duration in milliseconds for the animation
+   * @param index - Optional starting index for the Led animation
+   * @param count - Optional number of LEDs to animate
+   */
+  lightOn(ledName: string, r: number, g: number, b: number, duration?: number, index?: number, count?: number) {
+    const led = this.#led[ledName]
+    if (led) {
+      led.on(r, g, b, duration, index, count)
+    }
+  }
+
+  /**
+   * Turns off the specified Led.
+   *
+   * @param ledName - The name of the Led to turn off.
+   * @param index - Optional index of the Led to turn off. If not provided, all LEDs of the specified name will be turned off.
+   * @param count - Optional number of Led to turn off starting from the index. If not provided, all LEDs will be turned off.
+   *
+   * @remarks
+   * This method checks if the Led with the given name exists before attempting to turn it off.
+   */
+  lightOff(ledName: string, index?: number, count?: number) {
+    const led = this.#led[ledName]
+    if (led) {
+      led.off(index, count)
+    }
+  }
+
+  /**
+   * Blinks an Led with the specified color and interval.
+   *
+   * @param ledName - The name of the Led to blink.
+   * @param r - The red component of the color (0-255).
+   * @param g - The green component of the color (0-255).
+   * @param b - The blue component of the color (0-255).
+   * @param interval - The time in milliseconds between blinks.
+   * @param index - Optional index to specify which Led to control if multiple LEDs are present.
+   * @param count - Optional number of times to blink the Led. If not provided, it will blink indefinitely.
+   */
+  lightBlink(ledName: string, r: number, g: number, b: number, interval: number, index?: number, count?: number) {
+    const led = this.#led[ledName]
+    if (led) {
+      led.blink(r, g, b, interval, index, count)
+    }
+  }
+
+  /**
+   * Displays a rainbow light effect on the specified Led.
+   * @param ledName - The name of the Led to apply the rainbow effect to.
+   * @param index - Optional starting index for the rainbow effect.
+   * @param count - Optional number of Leds to apply the rainbow effect to.
+   */
+  lightRainbow(ledName: string, index?: number, count?: number) {
+    const led = this.#led[ledName]
+    if (led) {
+      led.rainbow(index, count)
+    }
   }
 }

--- a/firmware/stackchan/utilities/manifest_utility.json
+++ b/firmware/stackchan/utilities/manifest_utility.json
@@ -1,6 +1,7 @@
 {
   "include": [
     "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_net.json",
     "$(MODULES)/files/preference/manifest.json",
     "$(MODULES)/base/structuredClone/manifest.json",
     "$(MODULES)/base/deepEqual/manifest.json",

--- a/firmware/tests/led/main.ts
+++ b/firmware/tests/led/main.ts
@@ -5,19 +5,22 @@ import { asyncWait } from 'stackchan-util'
 const ledConfig = { pin: 15, length: 10 }
 const led = new Led(ledConfig)
 
-led.on(255, 0, 0)
-await asyncWait(500)
-led.on(0, 255, 0)
-await asyncWait(500)
-led.on(0, 0, 255)
-await asyncWait(500)
-led.off()
-await asyncWait(1000)
+while (true) {
+  led.on(255, 0, 0)
+  await asyncWait(500)
+  led.on(0, 255, 0)
+  await asyncWait(500)
+  led.on(0, 0, 255)
+  await asyncWait(500)
+  led.off()
+  await asyncWait(1000)
 
-led.on(255, 255, 255, 1000)
-await asyncWait(2000)
+  led.on(255, 255, 255, 1000)
+  await asyncWait(2000)
 
-led.blink(255, 255, 0, 1000)
-await asyncWait(5000)
+  led.blink(255, 255, 0, 1000)
+  await asyncWait(5000)
 
-led.rainbow()
+  led.rainbow()
+  await asyncWait(5000)
+}

--- a/firmware/tests/led/main.ts
+++ b/firmware/tests/led/main.ts
@@ -1,0 +1,25 @@
+import Led from 'led'
+import { asyncWait } from 'stackchan-util'
+
+// M5Stack + M5Go bottom
+const ledConfig = { pin: 15, length: 10 }
+const led = new Led(ledConfig)
+
+led.on(255, 0, 0)
+await asyncWait(500)
+led.on(0, 255, 0)
+await asyncWait(500)
+led.on(0, 0, 255)
+await asyncWait(500)
+led.off()
+await asyncWait(1000)
+
+led.on(255, 255, 255, 1000)
+await asyncWait(1000)
+
+led.blink(255, 255, 0, 500)
+await asyncWait(5000)
+led.off()
+await asyncWait(1000)
+
+led.rainbow()

--- a/firmware/tests/led/main.ts
+++ b/firmware/tests/led/main.ts
@@ -15,11 +15,9 @@ led.off()
 await asyncWait(1000)
 
 led.on(255, 255, 255, 1000)
-await asyncWait(1000)
+await asyncWait(2000)
 
-led.blink(255, 255, 0, 500)
+led.blink(255, 255, 0, 1000)
 await asyncWait(5000)
-led.off()
-await asyncWait(1000)
 
 led.rainbow()

--- a/firmware/tests/led/manifest.json
+++ b/firmware/tests/led/manifest.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../stackchan/utilities/manifest_utility.json",
+    "../../stackchan/led/manifest_led.json"
+  ],
+  "modules": {
+    "*": ["./main"]
+  },
+  "defines": {
+    "main": {
+      "async": 1
+    }
+  }
+}

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -21,6 +21,7 @@
         "./stackchan/default-mods/*",
         "./stackchan/dialogues/*",
         "./stackchan/drivers/*",
+        "./stackchan/led/*",
         "./stackchan/renderers/*",
         "./stackchan/services/*",
         "./stackchan/speeches/*",


### PR DESCRIPTION
## 概要

M5GO bottom付属LEDやNekomimi LEDといったNeoPixel互換LEDに対応します

[ModdableSDK#1549](https://github.com/Moddable-OpenSource/moddable/pull/1549) での型定義が必要となるので、一旦ドラフトになります。

## 使用方法

manifestファイルのの`config`セクションに以下のようにLEDの定義を追加することで、`robot.led`で`Led`クラスのインスタンスにアクセスできます。また、robot自身に`lightOn`などの関数を追加しています。

```
   "led": {
      "a": {
        "pin": 15,
        "length": 10
      }
    }
```

使用例は、`mods/light`や`tests/led`が参考になります。





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LED strip control: solid colors, blink, and rainbow animations; Robot API extended with LED control methods; interactive button-based light module.
* **Tests**
  * Added a firmware test that demonstrates LED sequences and effects.
* **Chores**
  * Added manifests and TypeScript path mappings to enable the new LED modules.
* **Dependencies**
  * Bumped @moddable/typings to ^7.0.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->