### PR TITLE
chore: replace broken Discord badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Stack-chan
 
 [![Build Stack-chan Firmware](https://github.com/stack-chan/stack-chan/actions/workflows/build.yml/badge.svg)](https://github.com/stack-chan/stack-chan/actions/workflows/build.yml)
-[![Discord server invitation](https://dcbadge.vercel.app/api/server/eGhd9adnBm)](https://discord.gg/eGhd9adnBm)
+[![Discord server invitation](https://img.shields.io/badge/Discord-Join%20server-5865F2?logo=discord&logoColor=white)](https://discord.gg/eGhd9adnBm)
 
 [日本語](./README_ja.md)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,7 +1,7 @@
 # ｽﾀｯｸﾁｬﾝ(Stack-chan)
 
 [![ファームウェアのビルド](https://github.com/stack-chan/stack-chan/actions/workflows/build.yml/badge.svg)](https://github.com/stack-chan/stack-chan/actions/workflows/build.yml)
-[![Discordサーバへの招待](https://dcbadge.vercel.app/api/server/eGhd9adnBm)](https://discord.gg/eGhd9adnBm)
+[![Discordサーバへの招待](https://img.shields.io/badge/Discord-Join%20server-5865F2?logo=discord&logoColor=white)](https://discord.gg/eGhd9adnBm)
 
 [English](./README.md)
 


### PR DESCRIPTION
## Summary
- replace the broken Discord badge image in the English and Japanese READMEs
- use a static Shields.io badge while keeping the existing invite link

## Testing
- curl -I replacement badge URL returned 200 image/svg+xml;charset=utf-8
- curl -I invite URL returned 200 text/html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Discord server invitation badge styling across project README files for improved consistency and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->