### PR TITLE
Work around latest Moddable XS_MODS linker regression

### DIFF
--- a/firmware/stackchan/utilities/esp32/xs-mods-compat.c
+++ b/firmware/stackchan/utilities/esp32/xs-mods-compat.c
@@ -1,0 +1,19 @@
+/*
+ * Work around Moddable public's current XS_MODS linker regression on ESP32.
+ * xs/platforms/mc/xsHosts.c references gXSAbortStrings as an extern symbol,
+ * but the latest upstream exports only fxAbortString() and keeps the table
+ * itself file-local. Keep this weak so an eventual upstream fix can override it.
+ */
+
+const char *gXSAbortStrings[] __attribute__((weak)) = {
+	"debugger",
+	"memory full",
+	"JavaScript stack overflow",
+	"fatal",
+	"dead strip",
+	"unhandled exception",
+	"not enough keys",
+	"too much computation",
+	"unhandled rejection",
+	"native stack overflow",
+};

--- a/firmware/stackchan/utilities/manifest_utility.json
+++ b/firmware/stackchan/utilities/manifest_utility.json
@@ -15,7 +15,8 @@
   "platforms": {
     "esp32": {
       "modules": {
-        "mac-address": "esp32/mac-address"
+        "mac-address": "esp32/mac-address",
+        "xs-mods-compat": "esp32/xs-mods-compat"
       }
     },
     "mac": {


### PR DESCRIPTION
## Summary
- add an ESP32-only weak fallback definition for `gXSAbortStrings`
- include that fallback in the utility manifest so `XS_MODS` hosts link again on the latest Moddable public branch

## Notes
- Stacked on #374.
- This is a downstream temporary workaround for the current upstream regression where `xs/platforms/mc/xsHosts.c` references `gXSAbortStrings` as an external symbol while `xs/sources/xsError.c` keeps that table file-local.
- This shim should be removed once the upstream fix lands.

## Verification
- `npm run build`
- `npm run build --target=esp32/m5stack_cores3`
- `npm run format`
- `npm run lint`
