### PR TITLE
chore: add root editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*.{js,ts,json,jsonc,yml,yaml,html,css,mjs}]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a repository-level .editorconfig so common text formats follow consistent line ending, indentation, and trailing-whitespace defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added editor configuration to standardize code formatting standards (encoding, line endings, indentation) across the repository for common file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->