### PR TITLE
chore: add changesets foundation config

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,11 @@
+# Changesets Foundation
+
+This directory reserves the repository-level configuration for future changelog and release-note automation.
+
+Current scope:
+
+- Track the release base branch as `dev/v1.0`
+- Keep the repository ready for future release PR automation
+- Avoid changing the existing firmware and web package workflows yet
+
+Future work can add the root package manager setup and release workflow once the maintainers decide how version bumps should map to firmware and web deliverables.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "dev/v1.0",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "linked": [],


### PR DESCRIPTION
Adds repository-level Changesets configuration as non-invasive release-note scaffolding anchored to dev/v1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Repository prepared for automated changelog and release management workflows.
  * Release tooling configured (changelog generation enabled, base branch set to dev/v1.0, internal dependency updates set to patch) while preserving existing firmware and web workflows and keeping automatic commit behavior disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->