### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Stack-chan is a JavaScript-driven M5Stack-embedded super-kawaii robot.
 * :cyclone:          Drive Serial(TTL)/PWM servos
 * :game_die:         Make applications on your own
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/stack-chan-stack-chan).
+
 ## Contents
 
 This repository includes all the component of the robot.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/stack-chan-stack-chan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a hosted deployment section to the README detailing availability via the provided link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->