### PR TITLE
Format enum values in renderer docs

### DIFF
--- a/docs/piu-renderer.md
+++ b/docs/piu-renderer.md
@@ -219,7 +219,7 @@ Each template is a `FaceBase` specialization and accepts `FaceBaseParams` (size/
 | --- | --- | --- | --- |
 | `cx`, `cy` | `number` | Required | Center position in face coordinates. |
 | `radius` | `number` | Optional | Iris radius. |
-| `side` | `'left' | 'right'` | Required | Eye side. |
+| `side` | `left`, `right` | Required | Eye side. |
 | `eyelidWidth`, `eyelidHeight` | `number` | Optional | Eyelid bounds. |
 
 #### Eyelid (`parts/eye.ts`)
@@ -230,7 +230,7 @@ Each template is a `FaceBase` specialization and accepts `FaceBaseParams` (size/
 | --- | --- | --- | --- |
 | `cx`, `cy` | `number` | Required | Center position. |
 | `width`, `height` | `number` | Required | Eyelid bounds. |
-| `side` | `'left' | 'right'` | Required | Eye side. |
+| `side` | `left`, `right` | Required | Eye side. |
 
 #### Mouth (`parts/mouth.ts`)
 **Role:** Rectangle mouth shape that grows/shrinks with `mouth.open`.
@@ -247,7 +247,7 @@ Each template is a `FaceBase` specialization and accepts `FaceBaseParams` (size/
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `cx`, `cy` | `number` | Required | Center position. |
-| `side` | `'left' | 'right'` | Required | Eye side. |
+| `side` | `left`, `right` | Required | Eye side. |
 | `canvasWidth`, `canvasHeight` | `number` | Optional | Canvas size used for outline. |
 
 **DogMouth (DogMouthOptions):**
@@ -288,7 +288,7 @@ Each template is a `FaceBase` specialization and accepts `FaceBaseParams` (size/
 **Params (EmoticonParams):**
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `key` | `'heart' | 'angry' | 'sweat' | 'tear' | 'sleepy'` | Required | Emoticon type. |
+| `key` | `heart`, `angry`, `sweat`, `tear`, `sleepy` | Required | Emoticon type. |
 | `name` | `string` | Optional | Optional key for effect management. |
 | `left/right/top/bottom/width/height` | `number` | Optional | Layout bounds. |
 | `angle` | `number` | Optional | Rotation angle. |
@@ -312,7 +312,7 @@ Each template is a `FaceBase` specialization and accepts `FaceBaseParams` (size/
 | --- | --- | --- | --- |
 | `key` | `string` | Required | Event key used for `bubble`. |
 | `label` | `string` | Required | Button label. |
-| `kind` | `'action' | 'toggle'` | Optional | Toggle buttons show an indicator. |
+| `kind` | `action`, `toggle` | Optional | Toggle buttons show an indicator. |
 | `active` | `boolean` | Optional | Initial toggle state. |
 
 **Public methods (DrawerBehavior):**

--- a/docs/piu-renderer_ja.md
+++ b/docs/piu-renderer_ja.md
@@ -220,7 +220,7 @@ new Application(
 | --- | --- | --- | --- |
 | `cx`, `cy` | `number` | 必須 | 中心座標。 |
 | `radius` | `number` | 任意 | 虹彩の半径。 |
-| `side` | `'left' | 'right'` | 必須 | 目の左右。 |
+| `side` | `left`, `right` | 必須 | 目の左右。 |
 | `eyelidWidth`, `eyelidHeight` | `number` | 任意 | まぶたのサイズ。 |
 
 #### Eyelid（`parts/eye.ts`）
@@ -231,7 +231,7 @@ new Application(
 | --- | --- | --- | --- |
 | `cx`, `cy` | `number` | 必須 | 中心座標。 |
 | `width`, `height` | `number` | 必須 | まぶたのサイズ。 |
-| `side` | `'left' | 'right'` | 必須 | 目の左右。 |
+| `side` | `left`, `right` | 必須 | 目の左右。 |
 
 #### Mouth（`parts/mouth.ts`）
 **役割:** `mouth.open` に応じて拡縮する矩形の口。
@@ -248,7 +248,7 @@ new Application(
 | 名称 | 型 | 必須 | 説明 |
 | --- | --- | --- | --- |
 | `cx`, `cy` | `number` | 必須 | 中心座標。 |
-| `side` | `'left' | 'right'` | 必須 | 目の左右。 |
+| `side` | `left`, `right` | 必須 | 目の左右。 |
 | `canvasWidth`, `canvasHeight` | `number` | 任意 | Outline 用キャンバスサイズ。 |
 
 **DogMouth（DogMouthOptions）:**
@@ -289,7 +289,7 @@ new Application(
 **Params（EmoticonParams）:**
 | 名称 | 型 | 必須 | 説明 |
 | --- | --- | --- | --- |
-| `key` | `'heart' | 'angry' | 'sweat' | 'tear' | 'sleepy'` | 必須 | 感情種別。 |
+| `key` | `heart`, `angry`, `sweat`, `tear`, `sleepy` | 必須 | 感情種別。 |
 | `name` | `string` | 任意 | Effect 管理用のキー。 |
 | `left/right/top/bottom/width/height` | `number` | 任意 | レイアウト指定。 |
 | `angle` | `number` | 任意 | 回転角。 |
@@ -313,7 +313,7 @@ new Application(
 | --- | --- | --- | --- |
 | `key` | `string` | 必須 | `bubble` に使うイベントキー。 |
 | `label` | `string` | 必須 | ボタン表示。 |
-| `kind` | `'action' | 'toggle'` | 任意 | toggle はインジケータを表示。 |
+| `kind` | `action`, `toggle` | 任意 | toggle はインジケータを表示。 |
 | `active` | `boolean` | 任意 | 初期トグル状態。 |
 
 **公開メソッド（DrawerBehavior）:**


### PR DESCRIPTION
一部テーブル表示に乱れがあったので修正しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated type documentation for renderer component options in English and Japanese language guides to improve clarity and consistency in type notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->