### PR TITLE
Fix PIU speech balloon 9-slice asset

### DIFF
--- a/firmware/stackchan/renderers-piu/effects/speech-balloon.ts
+++ b/firmware/stackchan/renderers-piu/effects/speech-balloon.ts
@@ -13,7 +13,7 @@ import {
   Texture,
 } from 'piu/MC'
 
-let bubbleTexture: PiuTexture | null = null
+let balloonTexture: PiuTexture | null = null
 
 const defaultOptions = {
   left: 16,
@@ -156,7 +156,7 @@ export const SpeechBalloon = Container.template((opts: BalloonOptions = {}) => {
       updatePalette(face: FaceContext) {
         currentFace = face
         if (!background || !bodyText) return
-        if (!bubbleTexture) bubbleTexture = new Texture('bubble.png')
+        if (!balloonTexture) balloonTexture = new Texture('balloon.png')
         const primary = face.theme.primary
         const secondary = face.theme.secondary
         if (primary === currentPrimary && secondary === currentSecondary) return
@@ -165,16 +165,16 @@ export const SpeechBalloon = Container.template((opts: BalloonOptions = {}) => {
         const bubbleColor = primary
         const textColor = secondary === bubbleColor ? '#000000' : secondary
         background.skin = new Skin({
-          texture: bubbleTexture,
+          texture: balloonTexture,
           color: [bubbleColor],
           x: 0,
           y: 0,
-          width: 204,
-          height: 332,
-          left: 24,
-          right: 24,
-          top: 12,
-          bottom: 12,
+          width: 80,
+          height: 40,
+          left: 8,
+          right: 8,
+          top: 8,
+          bottom: 8,
         })
         bodyText.style = new Style({ font: o.font, color: textColor, horizontal: 'left' })
       }

--- a/firmware/stackchan/renderers-piu/manifest_renderer_piu.json
+++ b/firmware/stackchan/renderers-piu/manifest_renderer_piu.json
@@ -38,7 +38,10 @@
     "*-alpha": [
       "../assets/images/microphone",
       "../assets/images/indicator",
-      "../assets/images/bubble",
+      {
+        "path": "balloon",
+        "source": "../../reference/moddable-avatar/assets/images/balloon"
+      },
       "../assets/images/faces/image-face/moddable-avatar/eye",
       "../assets/images/faces/image-face/moddable-avatar/eyelid",
       "../assets/images/faces/image-face/moddable-avatar/mouth"


### PR DESCRIPTION
## Summary
- Switch PIU SpeechBalloon from the Moddable conversationalAI bubble mask to the existing moddable-avatar balloon image
- Update the SpeechBalloon skin 9-slice dimensions to match the 80x40 avatar balloon asset

## Verification
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined speech balloon visual styling with updated appearance and adjusted sizing. The new design improves visual consistency and refinement throughout the interface, providing a more polished presentation of messages and dialogue interactions for an enhanced user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->