### PR TITLE
Fix mod config import type

### DIFF
--- a/firmware/stackchan/utilities/loadPreference.ts
+++ b/firmware/stackchan/utilities/loadPreference.ts
@@ -5,7 +5,9 @@ import config from 'mc/config'
 import Modules from 'modules'
 
 // biome-ignore lint/suspicious/noExplicitAny: Match the type definition of mc/config
-const modConfig: Record<string, any> = Modules.has('mod/config') ? Modules.importNow('mod/config') : {}
+type ConfigRecord = Record<string, any>
+
+const modConfig: ConfigRecord = Modules.has('mod/config') ? (Modules.importNow('mod/config') as ConfigRecord) : {}
 
 export default function loadPreferences(category: keyof typeof DOMAIN) {
   const mcPreference = structuredClone(config[category.toLowerCase()] ?? {})


### PR DESCRIPTION
## Summary
- Cast dynamically imported mod/config to the config record type before reading preferences
- Fix TypeScript compile failure caused by Modules.importNow() returning unknown

## Verification
- mcconfig -m -d -p lin ./firmware/tests/renderers/piu-simple/manifest.json
- mcconfig -m -d -p sim/m5stack -t build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to type definitions for better maintainability.

---

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->