### PR TITLE
Update erase-flash npm script to esptool

### DIFF
--- a/firmware/package.json
+++ b/firmware/package.json
@@ -23,7 +23,7 @@
     "update": "xs-dev update",
     "doctor": "echo stack-chan environment info: && git rev-parse HEAD && git rev-parse --show-toplevel && xs-dev doctor",
     "scan": "xs-dev scan",
-    "erase-flash": "esptool.py erase_flash",
+    "erase-flash": "esptool erase-flash",
     "install-hook": "lefthook install",
     "uninstall-hook": "lefthook uninstall"
   },


### PR DESCRIPTION
`ESP-IDF v6` に上がった影響と思われますが、`npm run erase-flash`実行時に以下WARNINGが出ます。

```
Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.
Warning: Deprecated: Command 'erase_flash' is deprecated. Use 'erase-flash' instead.
```

現状影響ないですが、後々使えなくなる可能性があるため、本PRではWARNINGに従ってnpm scriptを更新しました。
`npm run erase-flash`　の実行および、その後ファームウェアを書き込めることを動作確認しています

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flash erasure command in build scripts to align with current tooling standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->