### PR TITLE
ci: update Moddable SDK baseline to 8.1.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,7 +32,16 @@ runs:
         RUNNER_OS_NAME: ${{ runner.os }}
       run: |
         set -euo pipefail
-        REF="${INPUT_TARGET_BRANCH:-public}"
+        if [ -n "$INPUT_TARGET_BRANCH" ]; then
+          REF="$INPUT_TARGET_BRANCH"
+        else
+          RELEASE_RESPONSE=$(curl -fsSL "https://api.github.com/repos/Moddable-OpenSource/moddable/releases/latest")
+          REF=$(echo "$RELEASE_RESPONSE" | jq -r '.tag_name')
+          if [ -z "$REF" ] || [ "$REF" = "null" ]; then
+            echo "::error::Failed to resolve latest Moddable release tag"
+            exit 1
+          fi
+        fi
         API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/commits/$REF"
         RESPONSE=$(curl -fsSL "$API_URL")
         MODDABLE_SHA=$(echo "$RESPONSE" | jq -r '.sha')
@@ -42,6 +51,7 @@ runs:
         fi
         MODDABLE_REF=$(echo "$MODDABLE_SHA" | cut -c1-12)
         echo "Moddable ref: $REF ($MODDABLE_REF)"
+        echo "MODDABLE_TARGET_REF=$REF" >> "$GITHUB_ENV"
         echo "moddable_cache_key=$RUNNER_OS_NAME-moddable-$MODDABLE_REF" >> "$GITHUB_ENV"
       shell: bash
     - name: Restore cache of Moddable and ESP32
@@ -54,15 +64,12 @@ runs:
         key: ${{ env.moddable_cache_key }}-fontbm2
     - name: install Moddable
       if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
-      env:
-        INPUT_TARGET_BRANCH: ${{ inputs.target-branch }}
       run: |
         sudo apt-get update
         npm run setup
-        if [ -n "$INPUT_TARGET_BRANCH" ]; then
-          git -C "$HOME/.local/share/moddable" fetch origin "$INPUT_TARGET_BRANCH"
-          git -C "$HOME/.local/share/moddable" checkout --detach FETCH_HEAD
-        fi
+        git -C "$HOME/.local/share/moddable" fetch origin "$MODDABLE_TARGET_REF"
+        git -C "$HOME/.local/share/moddable" checkout --detach FETCH_HEAD
+        echo "Installed Moddable ref: $(git -C "$HOME/.local/share/moddable" describe --tags --always)"
       working-directory: ./firmware
       shell: bash
     - name: install ESP32

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   target-branch:
     description: "Target branch or tag to setup environment"
     required: false
-    default: "8.0.0"
+    default: ""
 runs:
   using: composite
   steps:

--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -14,7 +14,7 @@
         "@ffmpeg/ffmpeg": "^0.11.6",
         "@google-cloud/text-to-speech": "^6.1.0",
         "@microsoft/tsdoc": "^0.16.0",
-        "@moddable/typings": "^8.0.0",
+        "@moddable/typings": "^8.1.0",
         "cross-env-default": "^5.1.3-1",
         "lefthook": "^1.8.2",
         "node-fetch": "^3.3.0",
@@ -337,9 +337,9 @@
       "license": "MIT"
     },
     "node_modules/@moddable/typings": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-8.0.0.tgz",
-      "integrity": "sha512-5n5fprMvtqrEYmvcilw2DNXgHQTqMUvQQw2Tao3jn/t5fl2wNh4VFYnuUUTzRHPf4zsGq/0eLsZMvoiVVnCapg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-8.1.0.tgz",
+      "integrity": "sha512-HO2LNFRy5BFLVgHE9+LQ5s1I7EisGOXpUx7mcDTCMT10KoCJhEyEWG0bcCgQ6J/kFEgsXqYGVRG4P7inY8ifzA==",
       "dev": true,
       "license": "ISC"
     },

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -51,7 +51,7 @@
     "@ffmpeg/ffmpeg": "^0.11.6",
     "@google-cloud/text-to-speech": "^6.1.0",
     "@microsoft/tsdoc": "^0.16.0",
-    "@moddable/typings": "^8.0.0",
+    "@moddable/typings": "^8.1.0",
     "cross-env-default": "^5.1.3-1",
     "lefthook": "^1.8.2",
     "node-fetch": "^3.3.0",


### PR DESCRIPTION
## Summary
- Update `@moddable/typings` to `^8.1.0` and refresh `package-lock.json`.
- Resolve the default Moddable SDK ref from GitHub's latest release tag instead of `public`.
- Use that same resolved release ref for both the Moddable/ESP32 cache key and the checkout installed on cache misses.
- Keep the existing explicit `target-branch` override path for callers that need a non-default ref.

## Verification
- `npx xs-dev doctor` reports Moddable SDK 8.1.0.
- `npm run build` with Moddable SDK 8.1.0 and ESP-IDF 6.0: passed for default `esp32/m5stack`.
- `npm_config_target=esp32/m5stack_cores3 npm run build` with Moddable SDK 8.1.0 and ESP-IDF 6.0: passed.
- `npm run bundle`: command exits successfully locally after installing local `zip`; note that `mcbundle` still logs an `m5stack_fire` linker error around the target's legacy `pins/audioin` colliding with `embedded:io/audio/in`, but continues and creates the bundle artifact for the other bundled targets.
- `npm run lint`: passed with an existing warning in `stackchan/renderers-piu/drawer.ts`.
- `npm run format`: passed.
- Parsed `.github/actions/setup/action.yml` with PyYAML.
- Exercised the default ref-resolution shell path locally; it resolves the latest Moddable release tag to `8.1.0` and writes `MODDABLE_TARGET_REF=8.1.0` plus a cache key based on commit `b619a7524952`.

## Notes
- `npm run test:unit` currently fails before running tests with `TS5052: Option 'checkJs' cannot be specified without specifying option 'allowJs'.` I left that out of scope because this PR only updates the Moddable baseline/typings and restores the CI ref workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency @moddable/typings to a newer patch version.
  * Modified automated setup workflow defaults so the action will use the latest Moddable release when no explicit target is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->