### PR TITLE
ci: authenticate Moddable GitHub API requests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,14 +28,22 @@ runs:
       shell: bash
     - name: Resolve Moddable cache key
       env:
+        GITHUB_TOKEN: ${{ github.token }}
         INPUT_TARGET_BRANCH: ${{ inputs.target-branch }}
         RUNNER_OS_NAME: ${{ runner.os }}
       run: |
         set -euo pipefail
+        github_api_get() {
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$1"
+        }
         if [ -n "$INPUT_TARGET_BRANCH" ]; then
           REF="$INPUT_TARGET_BRANCH"
         else
-          RELEASE_RESPONSE=$(curl -fsSL "https://api.github.com/repos/Moddable-OpenSource/moddable/releases/latest")
+          RELEASE_RESPONSE=$(github_api_get "https://api.github.com/repos/Moddable-OpenSource/moddable/releases/latest")
           REF=$(echo "$RELEASE_RESPONSE" | jq -r '.tag_name')
           if [ -z "$REF" ] || [ "$REF" = "null" ]; then
             echo "::error::Failed to resolve latest Moddable release tag"
@@ -43,7 +51,7 @@ runs:
           fi
         fi
         API_URL="https://api.github.com/repos/Moddable-OpenSource/moddable/commits/$REF"
-        RESPONSE=$(curl -fsSL "$API_URL")
+        RESPONSE=$(github_api_get "$API_URL")
         MODDABLE_SHA=$(echo "$RESPONSE" | jq -r '.sha')
         if [[ ! "$MODDABLE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
           echo "::error::Failed to resolve Moddable commit for ref: $REF"


### PR DESCRIPTION
## Summary
- Authenticates the Moddable GitHub API calls in the shared setup action with the workflow `github.token`.
- Keeps the existing latest-release/tag resolution behavior, but avoids unauthenticated API 403/rate-limit failures on `dev/v1.0` push CI.

## Failure being fixed
`Build Stack-chan Firmware` on `dev/v1.0` failed in the `test` job while resolving the Moddable cache key:

```text
curl -fsSL https://api.github.com/repos/Moddable-OpenSource/moddable/commits/$REF
curl: (22) The requested URL returned error: 403
```

Run: https://github.com/stack-chan/stack-chan/actions/runs/25646717017

## Verification
- [x] Parsed `.github/actions/setup/action.yml` with PyYAML.
- [x] `git diff --check`
- [x] Local API smoke with the authenticated headers resolved the latest Moddable release and commit SHA without printing the token.

Release impact: none — CI-only setup hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal GitHub Actions configuration by refactoring API calls with enhanced authorization handling for better reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/431)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->