### PR TITLE
feat: add browser camera bridge

### DIFF
--- a/firmware/biome.json
+++ b/firmware/biome.json
@@ -8,10 +8,12 @@
   "files": {
     "includes": [
       "stackchan/**",
-      "!stackchan/wasm/audio-bridge.js",
       "mods/**",
       "tests/**",
-      "scripts/**"
+      "scripts/**",
+      "!stackchan/runtime-bitmap-port.js",
+      "!stackchan/wasm/audio-bridge.js",
+      "!stackchan/wasm/camera-bridge.js"
     ],
     "ignoreUnknown": false
   },

--- a/firmware/stackchan/camera-preview-utils.ts
+++ b/firmware/stackchan/camera-preview-utils.ts
@@ -1,0 +1,67 @@
+import type { CameraFrame } from './camera.js'
+
+export type MosaicBlock = {
+  x: number
+  y: number
+  width: number
+  height: number
+  color: number
+}
+
+export type MosaicOptions = {
+  width: number
+  height: number
+  blockSize: number
+}
+
+export function rgb565LeToPiuColor(buffer: ArrayBuffer, byteOffset: number): number {
+  const view = new Uint8Array(buffer)
+  const pixel = view[byteOffset] | (view[byteOffset + 1] << 8)
+  const red5 = (pixel >> 11) & 0x1f
+  const green6 = (pixel >> 5) & 0x3f
+  const blue5 = pixel & 0x1f
+  const red = (red5 << 3) | (red5 >> 2)
+  const green = (green6 << 2) | (green6 >> 4)
+  const blue = (blue5 << 3) | (blue5 >> 2)
+
+  return (red << 16) | (green << 8) | blue
+}
+
+function clampSampleCoordinate(value: number, maxExclusive: number): number {
+  const coordinate = value | 0
+  if (coordinate < 0) return 0
+  if (coordinate >= maxExclusive) return maxExclusive - 1
+  return coordinate
+}
+
+export function sampleRgb565LeMosaic(frame: CameraFrame, options: MosaicOptions): MosaicBlock[] {
+  if (frame.imageType !== 'rgb565le' || frame.width <= 0 || frame.height <= 0) {
+    return []
+  }
+
+  const blockSize = Math.max(1, options.blockSize | 0)
+  const targetWidth = Math.max(1, options.width | 0)
+  const targetHeight = Math.max(1, options.height | 0)
+  const blocks: MosaicBlock[] = []
+
+  for (let y = 0; y < targetHeight; y += blockSize) {
+    const height = Math.min(blockSize, targetHeight - y)
+    const sampleY = clampSampleCoordinate(((y + height / 2) * frame.height) / targetHeight, frame.height)
+
+    for (let x = 0; x < targetWidth; x += blockSize) {
+      const width = Math.min(blockSize, targetWidth - x)
+      const sampleX = clampSampleCoordinate(((x + width / 2) * frame.width) / targetWidth, frame.width)
+      const byteOffset = (sampleY * frame.width + sampleX) * 2
+
+      blocks.push({
+        x,
+        y,
+        width,
+        height,
+        color: rgb565LeToPiuColor(frame.buffer, byteOffset),
+      })
+    }
+  }
+
+  return blocks
+}

--- a/firmware/stackchan/camera-preview.ts
+++ b/firmware/stackchan/camera-preview.ts
@@ -1,51 +1,104 @@
 import type { CameraFrame } from './camera.js'
 import { sampleRgb565LeMosaic } from './camera-preview-utils.js'
 
-import { Container, Port, type Container as PiuContainer, type Port as PiuPort } from 'piu/MC'
+import Bitmap from 'commodetto/Bitmap'
+import { Container, type Container as PiuContainer, type Port as PiuPort } from 'piu/MC'
+import RuntimeBitmapPort from 'runtime-bitmap-port'
+
+export const CAMERA_PREVIEW_WIDTH = 200
+export const CAMERA_PREVIEW_HEIGHT = 120
+
+export type CameraPreviewRenderMode = 'runtime-bitmap-port' | 'mosaic'
+export type CameraPreviewOptions = {
+  onRender?: (mode: CameraPreviewRenderMode) => void
+  onDismiss?: () => void
+}
 
 const PREVIEW_LEFT = 60
 const PREVIEW_TOP = 60
-const PREVIEW_WIDTH = 200
-const PREVIEW_HEIGHT = 120
 const PREVIEW_BLOCK_SIZE = 48
 const PREVIEW_BACKGROUND = '#101010'
+
+type BitmapPort = PiuPort & {
+  drawBitmap?: (bitmap: Bitmap, x: number, y: number, sx?: number, sy?: number, sw?: number, sh?: number) => void
+}
 
 function piuColor(color: number): string {
   const hex = color.toString(16).padStart(6, '0')
   return `#${hex}`
 }
 
-export function createCameraPreviewFace(frame: CameraFrame): PiuContainer {
-  const previewPort = new Port(
-    { frame },
+function canDrawFrameAsBitmap(frame: CameraFrame): boolean {
+  return frame.imageType === 'rgb565le' && frame.buffer.byteLength >= frame.width * frame.height * 2
+}
+
+function drawRgb565Bitmap(port: BitmapPort, frame: CameraFrame): boolean {
+  if (!port.drawBitmap || !canDrawFrameAsBitmap(frame)) return false
+
+  const bitmap = new Bitmap(frame.width, frame.height, Bitmap.RGB565LE, frame.buffer, 0)
+  port.drawBitmap(
+    bitmap,
+    0,
+    0,
+    0,
+    0,
+    Math.min(frame.width, CAMERA_PREVIEW_WIDTH),
+    Math.min(frame.height, CAMERA_PREVIEW_HEIGHT),
+  )
+  return true
+}
+
+export function createCameraPreviewFace(frame: CameraFrame, options: CameraPreviewOptions = {}): PiuContainer {
+  const previewPort = new RuntimeBitmapPort(
+    { frame, options },
     {
       left: 0,
       top: 0,
-      width: PREVIEW_WIDTH,
-      height: PREVIEW_HEIGHT,
+      width: CAMERA_PREVIEW_WIDTH,
+      height: CAMERA_PREVIEW_HEIGHT,
+      active: true,
       Behavior: class extends Behavior {
         frame: CameraFrame | null = null
+        options: CameraPreviewOptions | null = null
+        lastRenderMode: CameraPreviewRenderMode | null = null
 
-        onCreate(_port: PiuPort, data: { frame: CameraFrame }) {
+        onCreate(_port: PiuPort, data: { frame: CameraFrame; options: CameraPreviewOptions }) {
           this.frame = data.frame
+          this.options = data.options
         }
 
         onDisplaying(port: PiuPort) {
           port.invalidate()
         }
 
+        onTouchEnded(_port: PiuPort) {
+          this.options?.onDismiss?.()
+        }
+
         onDraw(port: PiuPort) {
-          port.fillColor(PREVIEW_BACKGROUND, 0, 0, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+          port.fillColor(PREVIEW_BACKGROUND, 0, 0, CAMERA_PREVIEW_WIDTH, CAMERA_PREVIEW_HEIGHT)
           const frame = this.frame
           if (!frame) return
 
+          if (drawRgb565Bitmap(port as BitmapPort, frame)) {
+            this.reportRenderMode('runtime-bitmap-port')
+            return
+          }
+
           for (const block of sampleRgb565LeMosaic(frame, {
-            width: PREVIEW_WIDTH,
-            height: PREVIEW_HEIGHT,
+            width: CAMERA_PREVIEW_WIDTH,
+            height: CAMERA_PREVIEW_HEIGHT,
             blockSize: PREVIEW_BLOCK_SIZE,
           })) {
             port.fillColor(piuColor(block.color), block.x, block.y, block.width, block.height)
           }
+          this.reportRenderMode('mosaic')
+        }
+
+        reportRenderMode(mode: CameraPreviewRenderMode) {
+          if (this.lastRenderMode === mode) return
+          this.lastRenderMode = mode
+          this.options?.onRender?.(mode)
         }
       },
     },
@@ -54,8 +107,8 @@ export function createCameraPreviewFace(frame: CameraFrame): PiuContainer {
   return new Container(null, {
     left: PREVIEW_LEFT,
     top: PREVIEW_TOP,
-    width: PREVIEW_WIDTH,
-    height: PREVIEW_HEIGHT,
+    width: CAMERA_PREVIEW_WIDTH,
+    height: CAMERA_PREVIEW_HEIGHT,
     contents: [previewPort],
   })
 }

--- a/firmware/stackchan/camera-preview.ts
+++ b/firmware/stackchan/camera-preview.ts
@@ -1,0 +1,61 @@
+import type { CameraFrame } from './camera.js'
+import { sampleRgb565LeMosaic } from './camera-preview-utils.js'
+
+import { Container, Port, type Container as PiuContainer, type Port as PiuPort } from 'piu/MC'
+
+const PREVIEW_LEFT = 60
+const PREVIEW_TOP = 60
+const PREVIEW_WIDTH = 200
+const PREVIEW_HEIGHT = 120
+const PREVIEW_BLOCK_SIZE = 48
+const PREVIEW_BACKGROUND = '#101010'
+
+function piuColor(color: number): string {
+  const hex = color.toString(16).padStart(6, '0')
+  return `#${hex}`
+}
+
+export function createCameraPreviewFace(frame: CameraFrame): PiuContainer {
+  const previewPort = new Port(
+    { frame },
+    {
+      left: 0,
+      top: 0,
+      width: PREVIEW_WIDTH,
+      height: PREVIEW_HEIGHT,
+      Behavior: class extends Behavior {
+        frame: CameraFrame | null = null
+
+        onCreate(_port: PiuPort, data: { frame: CameraFrame }) {
+          this.frame = data.frame
+        }
+
+        onDisplaying(port: PiuPort) {
+          port.invalidate()
+        }
+
+        onDraw(port: PiuPort) {
+          port.fillColor(PREVIEW_BACKGROUND, 0, 0, PREVIEW_WIDTH, PREVIEW_HEIGHT)
+          const frame = this.frame
+          if (!frame) return
+
+          for (const block of sampleRgb565LeMosaic(frame, {
+            width: PREVIEW_WIDTH,
+            height: PREVIEW_HEIGHT,
+            blockSize: PREVIEW_BLOCK_SIZE,
+          })) {
+            port.fillColor(piuColor(block.color), block.x, block.y, block.width, block.height)
+          }
+        }
+      },
+    },
+  )
+
+  return new Container(null, {
+    left: PREVIEW_LEFT,
+    top: PREVIEW_TOP,
+    width: PREVIEW_WIDTH,
+    height: PREVIEW_HEIGHT,
+    contents: [previewPort],
+  })
+}

--- a/firmware/stackchan/camera.ts
+++ b/firmware/stackchan/camera.ts
@@ -12,6 +12,7 @@ export type CameraCaptureOptions = {
   width?: number
   height?: number
   imageType?: CameraImageType
+  useBrowserCamera?: boolean
 }
 
 export interface RobotCamera {

--- a/firmware/stackchan/default-mods/on-robot-created.ts
+++ b/firmware/stackchan/default-mods/on-robot-created.ts
@@ -1,4 +1,5 @@
-import { DogFace, SimpleFace } from 'behaviors/face'
+import { DogFace, ImageFace, SimpleFace } from 'behaviors/face'
+import { createCameraPreviewFace } from 'camera-preview'
 import type { StackchanMod } from 'default-mods/mod'
 import { Emoticon, type EmoticonKey } from 'effects/emoticon'
 import { Emotion } from 'face-context'
@@ -104,6 +105,34 @@ export const onRobotCreated: StackchanMod['onRobotCreated'] = (robot) => {
         target.hideBalloon()
       }
       robot.application.setDrawerButtonState('toggleSpeech', speechVisible)
+    },
+  })
+
+  const runCameraPreview = async (target: typeof robot) => {
+    try {
+      target.showBalloon('starting camera...')
+      await target.camera.start({ width: 320, height: 240, imageType: 'rgb565le', useBrowserCamera: true })
+      const frame = await target.camera.capture({ width: 320, height: 240, imageType: 'rgb565le' })
+      if (!frame) {
+        trace('[CameraPreview] capture returned no frame\n')
+        target.showBalloon('camera unavailable')
+        return
+      }
+      target.renderer?.setFace?.(createCameraPreviewFace(frame))
+      trace(`[CameraPreview] rendered ${frame.width}x${frame.height} ${frame.imageType} via Piu Port\n`)
+      target.showBalloon('camera preview')
+    } catch (error) {
+      trace(`[CameraPreview] error ${errorMessage(error)}\n`)
+      target.showBalloon('camera error')
+    } finally {
+      hideBalloonLater(1200)
+    }
+  }
+  robot.application.addDrawerButton({
+    key: 'cameraPreview',
+    label: 'Camera',
+    callback: (target) => {
+      void runCameraPreview(target)
     },
   })
 

--- a/firmware/stackchan/default-mods/on-robot-created.ts
+++ b/firmware/stackchan/default-mods/on-robot-created.ts
@@ -29,6 +29,7 @@ const UP = {
   p: -Math.PI / 6,
 }
 const RECORD_PLAYBACK_DURATION_MS = 2000
+const CAMERA_PREVIEW_DURATION_MS = 5000
 
 function errorMessage(error: unknown): string {
   if (error && typeof error === 'object' && 'message' in error) {
@@ -43,12 +44,25 @@ export const onRobotCreated: StackchanMod['onRobotCreated'] = (robot) => {
   let speechVisible = false
   let emoticonEffect: PiuContent | null = null
 
-  let faceMode: 'simple' | 'dog' = 'simple'
+  let faceMode: 'simple' | 'dog' | 'image' = 'simple'
+  let cameraPreviewTimer: ReturnType<typeof Timer.set> | undefined
   const syncFaceMode = (
     app = robot.renderer?.application as { distribute?: (event: string, payload: unknown) => void } | undefined,
   ) => {
     robot.application.setDrawerButtonState('toggleFace', faceMode !== 'simple')
     app?.distribute?.('onFaceMode', faceMode)
+  }
+  const closeDrawer = () =>
+    (robot.renderer?.application as { distribute?: (event: string) => void } | undefined)?.distribute?.('onDrawerClose')
+  const createCurrentFace = () =>
+    faceMode === 'dog' ? new DogFace({}) : faceMode === 'image' ? new ImageFace({}) : new SimpleFace({})
+  const restoreCameraPreview = () => {
+    if (cameraPreviewTimer) {
+      Timer.clear(cameraPreviewTimer)
+      cameraPreviewTimer = undefined
+    }
+    robot.renderer?.setFace?.(createCurrentFace())
+    robot.hideBalloon()
   }
   robot.application.addDrawerButton({
     key: 'toggleFace',
@@ -56,9 +70,8 @@ export const onRobotCreated: StackchanMod['onRobotCreated'] = (robot) => {
     kind: 'toggle',
     initialState: false,
     callback: (target) => {
-      faceMode = faceMode === 'simple' ? 'dog' : 'simple'
-      const nextFace = faceMode === 'dog' ? new DogFace({}) : new SimpleFace({})
-      target.renderer?.setFace?.(nextFace)
+      faceMode = faceMode === 'simple' ? 'dog' : faceMode === 'dog' ? 'image' : 'simple'
+      target.renderer?.setFace?.(createCurrentFace())
       const app = target.renderer?.application as { distribute?: (event: string, payload: unknown) => void } | undefined
       syncFaceMode(app)
     },
@@ -111,16 +124,26 @@ export const onRobotCreated: StackchanMod['onRobotCreated'] = (robot) => {
   const runCameraPreview = async (target: typeof robot) => {
     try {
       target.showBalloon('starting camera...')
-      await target.camera.start({ width: 320, height: 240, imageType: 'rgb565le', useBrowserCamera: true })
-      const frame = await target.camera.capture({ width: 320, height: 240, imageType: 'rgb565le' })
+      await target.camera.start({ width: 200, height: 120, imageType: 'rgb565le', useBrowserCamera: true })
+      const frame = await target.camera.capture({ width: 200, height: 120, imageType: 'rgb565le' })
       if (!frame) {
         trace('[CameraPreview] capture returned no frame\n')
         target.showBalloon('camera unavailable')
         return
       }
-      target.renderer?.setFace?.(createCameraPreviewFace(frame))
+      target.renderer?.setFace?.(
+        createCameraPreviewFace(frame, {
+          onRender: (mode) => {
+            trace(`[CameraPreview] render mode=${mode}\n`)
+          },
+          onDismiss: restoreCameraPreview,
+        }),
+      )
       trace(`[CameraPreview] rendered ${frame.width}x${frame.height} ${frame.imageType} via Piu Port\n`)
+      closeDrawer()
       target.showBalloon('camera preview')
+      if (cameraPreviewTimer) Timer.clear(cameraPreviewTimer)
+      cameraPreviewTimer = Timer.set(restoreCameraPreview, CAMERA_PREVIEW_DURATION_MS)
     } catch (error) {
       trace(`[CameraPreview] error ${errorMessage(error)}\n`)
       target.showBalloon('camera error')

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -25,6 +25,8 @@
       "./touch",
       "./robot",
       "./camera",
+      "./camera-preview",
+      "./camera-preview-utils",
       "./tone",
       "./main",
       "$(MODULES)/network/http/*"

--- a/firmware/stackchan/manifest_wasm.json
+++ b/firmware/stackchan/manifest_wasm.json
@@ -14,6 +14,7 @@
   "modules": {
     "*": ["./touch", "./robot", "./main"],
     "camera": "./wasm/camera",
+    "wasm-camera-bridge": "./wasm/camera-bridge",
     "camera-preview": "./camera-preview",
     "camera-preview-utils": "./camera-preview-utils",
     "runtime-bitmap-port": "./runtime-bitmap-port",
@@ -41,7 +42,7 @@
     "default-mods/on-launch": "./default-mods/wasm/on-launch",
     "default-mods/*": "./default-mods/*"
   },
-  "preload": ["wasm-audio-bridge", "robot"],
+  "preload": ["wasm-audio-bridge", "wasm-camera-bridge", "robot"],
   "strip": [],
   "creation": {
     "static": 442368,

--- a/firmware/stackchan/manifest_wasm.json
+++ b/firmware/stackchan/manifest_wasm.json
@@ -14,6 +14,8 @@
   "modules": {
     "*": ["./touch", "./robot", "./main"],
     "camera": "./wasm/camera",
+    "camera-preview": "./camera-preview",
+    "camera-preview-utils": "./camera-preview-utils",
     "wasm-audio-bridge": "./wasm/audio-bridge",
     "tone": "./wasm/tone",
     "led": "./wasm/led",

--- a/firmware/stackchan/manifest_wasm.json
+++ b/firmware/stackchan/manifest_wasm.json
@@ -16,6 +16,7 @@
     "camera": "./wasm/camera",
     "camera-preview": "./camera-preview",
     "camera-preview-utils": "./camera-preview-utils",
+    "runtime-bitmap-port": "./runtime-bitmap-port",
     "wasm-audio-bridge": "./wasm/audio-bridge",
     "tone": "./wasm/tone",
     "led": "./wasm/led",

--- a/firmware/stackchan/runtime-bitmap-port.c
+++ b/firmware/stackchan/runtime-bitmap-port.c
@@ -1,0 +1,74 @@
+#include "xs.h"
+#include "piuMC.h"
+#include "commodettoBitmap.h"
+#include "commodettoPoco.h"
+#include "xsmc.h"
+
+static void stackchanRuntimeBitmapPortDrawAux(void* it, PiuView* view, PiuCoordinate x, PiuCoordinate y, PiuDimension sw, PiuDimension sh)
+{
+	PiuPort* self = it;
+	Poco poco = (*view)->poco;
+	xsMachine* the = (*view)->the;
+	CommodettoBitmap cb;
+	PocoBitmapRecord bits;
+	void* data = NULL;
+	xsUnsignedValue dataSize;
+	(void)sw;
+	(void)sh;
+
+	xsBeginHost(the);
+	xsmcVars(7);
+	xsVar(0) = xsReference((*self)->reference);
+	xsmcGet(xsVar(1), xsVar(0), xsID("_runtimeBitmap"));
+	xsmcGet(xsVar(2), xsVar(0), xsID("_runtimeBitmapSX"));
+	xsmcGet(xsVar(3), xsVar(0), xsID("_runtimeBitmapSY"));
+	xsmcGet(xsVar(4), xsVar(0), xsID("_runtimeBitmapSW"));
+	xsmcGet(xsVar(5), xsVar(0), xsID("_runtimeBitmapSH"));
+
+	cb = xsmcGetHostChunk(xsVar(1));
+	bits.width = cb->w;
+	bits.height = cb->h;
+	bits.format = cb->format;
+#if COMMODETTO_BITMAP_ID
+	bits.id = cb->id;
+	bits.byteLength = cb->byteLength;
+#endif
+	if (cb->havePointer) {
+		bits.pixels = cb->bits.data;
+	}
+	else {
+		xsmcGet(xsVar(6), xsVar(1), xsID_buffer);
+		xsmcGetBufferReadable(xsVar(6), &data, &dataSize);
+		PocoDisableGC(poco);
+		bits.pixels = (PocoPixel*)(cb->bits.offset + (char*)data);
+	}
+
+	PocoBitmapDraw(
+		poco,
+		&bits,
+		x,
+		y,
+		(PocoDimension)xsmcToInteger(xsVar(2)),
+		(PocoDimension)xsmcToInteger(xsVar(3)),
+		(PocoDimension)xsmcToInteger(xsVar(4)),
+		(PocoDimension)xsmcToInteger(xsVar(5))
+	);
+	xsEndHost(the);
+}
+
+void xs_stackchan_runtime_bitmap_port_draw(xsMachine* the)
+{
+	PiuPort* self = PIU(Port, xsThis);
+	PiuView* view = (*self)->view;
+	PiuCoordinate x, y;
+	PiuDimension sw, sh;
+
+	if (!view)
+		xsUnknownError("out of sequence");
+
+	x = (PiuCoordinate)xsmcToInteger(xsArg(0));
+	y = (PiuCoordinate)xsmcToInteger(xsArg(1));
+	sw = (PiuDimension)xsmcToInteger(xsArg(4));
+	sh = (PiuDimension)xsmcToInteger(xsArg(5));
+	PiuViewDrawContent(view, stackchanRuntimeBitmapPortDrawAux, self, x, y, sw, sh);
+}

--- a/firmware/stackchan/runtime-bitmap-port.js
+++ b/firmware/stackchan/runtime-bitmap-port.js
@@ -1,6 +1,6 @@
 import { Port } from 'piu/MC'
 
-function drawNative(x, y, sx, sy, sw, sh) @ 'xs_stackchan_runtime_bitmap_port_draw';
+const drawNative = native('xs_stackchan_runtime_bitmap_port_draw')
 
 export default class RuntimeBitmapPort extends Port {
   drawBitmap(bitmap, x, y, sx = 0, sy = 0, sw = bitmap.width, sh = bitmap.height) {

--- a/firmware/stackchan/runtime-bitmap-port.js
+++ b/firmware/stackchan/runtime-bitmap-port.js
@@ -1,0 +1,14 @@
+import { Port } from 'piu/MC'
+
+function drawNative(x, y, sx, sy, sw, sh) @ 'xs_stackchan_runtime_bitmap_port_draw';
+
+export default class RuntimeBitmapPort extends Port {
+  drawBitmap(bitmap, x, y, sx = 0, sy = 0, sw = bitmap.width, sh = bitmap.height) {
+    this._runtimeBitmap = bitmap
+    this._runtimeBitmapSX = sx
+    this._runtimeBitmapSY = sy
+    this._runtimeBitmapSW = sw
+    this._runtimeBitmapSH = sh
+    drawNative.call(this, x, y, sx, sy, sw, sh)
+  }
+}

--- a/firmware/stackchan/wasm/audio-bridge.c
+++ b/firmware/stackchan/wasm/audio-bridge.c
@@ -9,27 +9,25 @@ void xs_stackchan_wasm_audio_tone(xsMachine* the)
 	double duration = xsmcToNumber(xsArg(1));
 	double volume = (xsmcArgc > 2) ? xsmcToNumber(xsArg(2)) : 1.0;
 	EM_ASM({
-		var host = globalThis.Host;
-		var audioOut = host && host.AudioOut;
-		if (audioOut && audioOut.tone)
+		const audioOut = globalThis.Host && globalThis.Host.AudioOut;
+		if (audioOut && audioOut.tone) {
 			audioOut.tone({
 				hz: $0,
 				duration: $1,
 				volume: $2,
 			});
+		}
 	}, hz, duration, volume);
 }
 
 void xs_stackchan_wasm_audio_close(xsMachine* the)
 {
 	EM_ASM({
-		var host = globalThis.Host;
-		var audioOut = host && host.AudioOut;
-		var audioIn = host && host.AudioIn;
-		if (audioOut && audioOut.close)
-			audioOut.close();
-		if (audioIn && audioIn.close)
-			audioIn.close();
+		const host = globalThis.Host;
+		const audioOut = host && host.AudioOut;
+		const audioIn = host && host.AudioIn;
+		if (audioOut && audioOut.close) audioOut.close();
+		if (audioIn && audioIn.close) audioIn.close();
 	});
 }
 

--- a/firmware/stackchan/wasm/audio-bridge.js
+++ b/firmware/stackchan/wasm/audio-bridge.js
@@ -1,12 +1,12 @@
 import Timer from 'timer'
 
-function tone(hz, duration, volume) @ "xs_stackchan_wasm_audio_tone";
-function close() @ "xs_stackchan_wasm_audio_close";
-function startPlayBuffer(buffer) @ "xs_stackchan_wasm_audio_start_play_buffer";
-function playStatus() @ "xs_stackchan_wasm_audio_play_status";
-function startRecord(duration) @ "xs_stackchan_wasm_audio_start_record";
-function recordStatus() @ "xs_stackchan_wasm_audio_record_status";
-function recordBuffer() @ "xs_stackchan_wasm_audio_record_buffer";
+const tone = native('xs_stackchan_wasm_audio_tone')
+const close = native('xs_stackchan_wasm_audio_close')
+const startPlayBuffer = native('xs_stackchan_wasm_audio_start_play_buffer')
+const playStatus = native('xs_stackchan_wasm_audio_play_status')
+const startRecord = native('xs_stackchan_wasm_audio_start_record')
+const recordStatus = native('xs_stackchan_wasm_audio_record_status')
+const recordBuffer = native('xs_stackchan_wasm_audio_record_buffer')
 
 export default {
   close,

--- a/firmware/stackchan/wasm/camera-bridge.c
+++ b/firmware/stackchan/wasm/camera-bridge.c
@@ -1,0 +1,87 @@
+#include "xs.h"
+#include "xsmc.h"
+#include <emscripten.h>
+#include <string.h>
+
+void xs_stackchan_wasm_camera_start(xsMachine* the)
+{
+	int width = (xsmcArgc > 0) ? xsmcToInteger(xsArg(0)) : 0;
+	int height = (xsmcArgc > 1) ? xsmcToInteger(xsArg(1)) : 0;
+	int useBrowserCamera = (xsmcArgc > 2) ? xsmcToBoolean(xsArg(2)) : 0;
+	EM_ASM({
+		const camera = globalThis.Host && globalThis.Host.Camera;
+		if (!camera || !camera.start)
+			return;
+		const options = {};
+		options.width = $0;
+		options.height = $1;
+		options.imageType = "rgb565le";
+		options.useBrowserCamera = !!$2;
+		Promise.resolve(camera.start(options)).catch((error) => {
+			console.warn("[bridge] Host.Camera.start failed", error);
+		});
+	}, width, height, useBrowserCamera);
+}
+
+void xs_stackchan_wasm_camera_stop(xsMachine* the)
+{
+	EM_ASM({
+		globalThis.Host && globalThis.Host.Camera && globalThis.Host.Camera.stop && globalThis.Host.Camera.stop();
+	});
+}
+
+void xs_stackchan_wasm_camera_capture(xsMachine* the)
+{
+	int width = (xsmcArgc > 0) ? xsmcToInteger(xsArg(0)) : 96;
+	int height = (xsmcArgc > 1) ? xsmcToInteger(xsArg(1)) : 96;
+	int length = EM_ASM_INT({
+		const camera = globalThis.Host && globalThis.Host.Camera;
+		let frame;
+		try {
+			const options = {};
+			options.width = $0;
+			options.height = $1;
+			options.imageType = "rgb565le";
+			frame = camera && camera.capture ? camera.capture(options) : undefined;
+		}
+		catch (error) {
+			console.warn("[bridge] Host.Camera.capture failed", error);
+			return 0;
+		}
+		if (!frame || frame.imageType !== "rgb565le" || !(frame.buffer instanceof ArrayBuffer))
+			return 0;
+		const data = new Uint8Array(frame.buffer);
+		const state = {};
+		state.width = frame.width | 0;
+		state.height = frame.height | 0;
+		state.data = data;
+		globalThis.__stackchanCameraCapture = state;
+		return data.byteLength;
+	}, width, height);
+	if (length <= 0) {
+		xsmcSetUndefined(xsResult);
+		return;
+	}
+
+	xsmcVars(1);
+	xsmcSetNewObject(xsResult);
+	xsmcSetInteger(xsVar(0), EM_ASM_INT({
+		const state = globalThis.__stackchanCameraCapture;
+		return state ? state.width : 0;
+	}));
+	xsmcSet(xsResult, xsID("width"), xsVar(0));
+	xsmcSetInteger(xsVar(0), EM_ASM_INT({
+		const state = globalThis.__stackchanCameraCapture;
+		return state ? state.height : 0;
+	}));
+	xsmcSet(xsResult, xsID("height"), xsVar(0));
+	xsmcSetString(xsVar(0), "rgb565le");
+	xsmcSet(xsResult, xsID("imageType"), xsVar(0));
+	void* buffer = xsmcSetArrayBuffer(xsVar(0), NULL, length);
+	EM_ASM({
+		const state = globalThis.__stackchanCameraCapture;
+		if (state && state.data)
+			HEAPU8.set(state.data.subarray(0, $1), $0);
+	}, buffer, length);
+	xsmcSet(xsResult, xsID("buffer"), xsVar(0));
+}

--- a/firmware/stackchan/wasm/camera-bridge.js
+++ b/firmware/stackchan/wasm/camera-bridge.js
@@ -1,6 +1,6 @@
-function start(width, height, useBrowserCamera) @ "xs_stackchan_wasm_camera_start";
-function stop() @ "xs_stackchan_wasm_camera_stop";
-function capture(width, height) @ "xs_stackchan_wasm_camera_capture";
+const start = native('xs_stackchan_wasm_camera_start')
+const stop = native('xs_stackchan_wasm_camera_stop')
+const capture = native('xs_stackchan_wasm_camera_capture')
 
 export default {
   capture,

--- a/firmware/stackchan/wasm/camera-bridge.js
+++ b/firmware/stackchan/wasm/camera-bridge.js
@@ -1,0 +1,15 @@
+function start(width, height, useBrowserCamera) @ "xs_stackchan_wasm_camera_start";
+function stop() @ "xs_stackchan_wasm_camera_stop";
+function capture(width, height) @ "xs_stackchan_wasm_camera_capture";
+
+export default {
+  capture,
+  start,
+  stop,
+}
+
+globalThis.__stackchanWasmCameraBridge = {
+  capture,
+  start,
+  stop,
+}

--- a/firmware/stackchan/wasm/camera.ts
+++ b/firmware/stackchan/wasm/camera.ts
@@ -12,7 +12,7 @@ type HostCameraBridge = {
 }
 
 type WasmCameraBridge = {
-  start: (width: number, height: number, useBrowserCamera: boolean) => void
+  start: (width: number, height: number, useBrowserCamera: boolean) => Promise<void> | void
   stop: () => void
   capture: (width: number, height: number) => CameraFrame | undefined
 }
@@ -50,6 +50,13 @@ function writeRgb565Le(view: Uint8Array, width: number, height: number): void {
   }
 }
 
+function copyFrameToWasmHeap(frame: CameraFrame): CameraFrame {
+  return {
+    ...frame,
+    buffer: frame.buffer.slice(0),
+  }
+}
+
 export default class Camera implements RobotCamera {
   #started = false
 
@@ -60,7 +67,7 @@ export default class Camera implements RobotCamera {
   async start(options?: CameraCaptureOptions): Promise<void> {
     const wasmBridge = wasmCameraBridge()
     if (wasmBridge) {
-      wasmBridge.start(
+      await wasmBridge.start(
         normalizeDimension(options?.width, DEFAULT_WIDTH),
         normalizeDimension(options?.height, DEFAULT_HEIGHT),
         Boolean(options?.useBrowserCamera),
@@ -97,7 +104,7 @@ export default class Camera implements RobotCamera {
 
     const hostFrame = await hostCamera()?.capture?.(options)
     if (hostFrame !== undefined) {
-      return hostFrame
+      return copyFrameToWasmHeap(hostFrame)
     }
 
     const imageType = options.imageType ?? DEFAULT_IMAGE_TYPE

--- a/firmware/stackchan/wasm/camera.ts
+++ b/firmware/stackchan/wasm/camera.ts
@@ -11,8 +11,17 @@ type HostCameraBridge = {
   capture?: (options?: CameraCaptureOptions) => Promise<CameraFrame | undefined> | CameraFrame | undefined
 }
 
+type WasmCameraBridge = {
+  start: (width: number, height: number, useBrowserCamera: boolean) => void
+  stop: () => void
+  capture: (width: number, height: number) => CameraFrame | undefined
+}
+
 const hostCamera = (): HostCameraBridge | undefined =>
   (globalThis as typeof globalThis & { Host?: { Camera?: HostCameraBridge } }).Host?.Camera
+
+const wasmCameraBridge = (): WasmCameraBridge | undefined =>
+  (globalThis as typeof globalThis & { __stackchanWasmCameraBridge?: WasmCameraBridge }).__stackchanWasmCameraBridge
 
 function normalizeDimension(value: number | undefined, fallback: number): number {
   if (value === undefined) {
@@ -49,16 +58,43 @@ export default class Camera implements RobotCamera {
   }
 
   async start(options?: CameraCaptureOptions): Promise<void> {
+    const wasmBridge = wasmCameraBridge()
+    if (wasmBridge) {
+      wasmBridge.start(
+        normalizeDimension(options?.width, DEFAULT_WIDTH),
+        normalizeDimension(options?.height, DEFAULT_HEIGHT),
+        Boolean(options?.useBrowserCamera),
+      )
+      this.#started = true
+      return
+    }
     await hostCamera()?.start?.(options)
     this.#started = true
   }
 
   async stop(): Promise<void> {
+    const wasmBridge = wasmCameraBridge()
+    if (wasmBridge) {
+      wasmBridge.stop()
+      this.#started = false
+      return
+    }
     await hostCamera()?.stop?.()
     this.#started = false
   }
 
   async capture(options: CameraCaptureOptions = {}): Promise<CameraFrame | undefined> {
+    const wasmBridge = wasmCameraBridge()
+    if (wasmBridge) {
+      const hostFrame = wasmBridge.capture(
+        normalizeDimension(options.width, DEFAULT_WIDTH),
+        normalizeDimension(options.height, DEFAULT_HEIGHT),
+      )
+      if (hostFrame !== undefined) {
+        return copyFrameToWasmHeap(hostFrame)
+      }
+    }
+
     const hostFrame = await hostCamera()?.capture?.(options)
     if (hostFrame !== undefined) {
       return hostFrame

--- a/firmware/tests/unit/camera-preview-utils.test.ts
+++ b/firmware/tests/unit/camera-preview-utils.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { rgb565LeToPiuColor, sampleRgb565LeMosaic } from '../../stackchan/camera-preview-utils.js'
+
+test('rgb565LeToPiuColor converts little-endian RGB565 pixels to 24-bit Piu colors', () => {
+  const buffer = new Uint8Array([
+    0x00,
+    0xf8, // red
+    0xe0,
+    0x07, // green
+    0x1f,
+    0x00, // blue
+    0xff,
+    0xff, // white
+  ]).buffer
+
+  assert.equal(rgb565LeToPiuColor(buffer, 0), 0xff0000)
+  assert.equal(rgb565LeToPiuColor(buffer, 2), 0x00ff00)
+  assert.equal(rgb565LeToPiuColor(buffer, 4), 0x0000ff)
+  assert.equal(rgb565LeToPiuColor(buffer, 6), 0xffffff)
+})
+
+test('sampleRgb565LeMosaic returns coarse blocks for a Piu-safe preview draw', () => {
+  const buffer = new Uint8Array(4 * 4 * 2)
+  for (let i = 0; i < buffer.length; i += 2) {
+    buffer[i] = 0xff
+    buffer[i + 1] = 0xff
+  }
+
+  const blocks = sampleRgb565LeMosaic(
+    { width: 4, height: 4, imageType: 'rgb565le', buffer: buffer.buffer },
+    { width: 8, height: 8, blockSize: 4 },
+  )
+
+  assert.deepEqual(blocks, [
+    { x: 0, y: 0, width: 4, height: 4, color: 0xffffff },
+    { x: 4, y: 0, width: 4, height: 4, color: 0xffffff },
+    { x: 0, y: 4, width: 4, height: 4, color: 0xffffff },
+    { x: 4, y: 4, width: 4, height: 4, color: 0xffffff },
+  ])
+})

--- a/firmware/tests/unit/native-api-bindings.test.ts
+++ b/firmware/tests/unit/native-api-bindings.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+
+const firmwareRoot = process.cwd()
+
+const nativeBindingModules = [
+  'stackchan/runtime-bitmap-port.js',
+  'stackchan/wasm/audio-bridge.js',
+  'stackchan/wasm/camera-bridge.js',
+]
+
+test('native binding bridge modules use Moddable Native API instead of @ syntax', () => {
+  const legacyBindings = nativeBindingModules.flatMap((modulePath) => {
+    const source = readFileSync(resolve(firmwareRoot, modulePath), 'utf8')
+
+    return source
+      .split('\n')
+      .map((line, index) => ({ line, lineNumber: index + 1, modulePath }))
+      .filter(({ line }) => /\)\s*@\s*['"]xs_/.test(line))
+      .map(({ modulePath, lineNumber, line }) => `${modulePath}:${lineNumber}: ${line.trim()}`)
+  })
+
+  assert.deepEqual(legacyBindings, [])
+})

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -163,6 +163,21 @@ test('WASM camera preview uses a native RuntimeBitmapPort binding before falling
   assert.doesNotMatch(previewSource, /drawRgb565Texture/)
 })
 
+test('WASM camera preview can be dismissed by touch or an automatic timeout', () => {
+  const previewSource = readFileSync('stackchan/camera-preview.ts', 'utf8')
+  const modSource = readFileSync('stackchan/default-mods/on-robot-created.ts', 'utf8')
+
+  assert.match(previewSource, /onDismiss\?: \(\) => void/)
+  assert.match(previewSource, /active: true/)
+  assert.match(previewSource, /onTouchEnded\(_port: PiuPort\)/)
+  assert.match(previewSource, /this\.options\?\.onDismiss\?\.\(\)/)
+  assert.match(modSource, /CAMERA_PREVIEW_DURATION_MS = 5000/)
+  assert.match(modSource, /onDismiss: restoreCameraPreview/)
+  assert.match(modSource, /distribute\?\.\('onDrawerClose'\)/)
+  assert.match(modSource, /closeDrawer\(\)/)
+  assert.match(modSource, /Timer\.set\(restoreCameraPreview, CAMERA_PREVIEW_DURATION_MS\)/)
+})
+
 test('WasmDriver applyRotation pushes pose changes to the browser Host.Driver bridge', async () => {
   const calls: unknown[] = []
   const previousHost = globalThis.Host

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -148,6 +148,8 @@ test('WASM main path loads an installed MOD archive before falling back to the d
   assert.match(wasmBlock, /Modules\.importNow\('mod'\) as StackchanMod/)
   assert.match(wasmBlock, /onRobotCreated = mod\.onRobotCreated \?\? onRobotCreated/)
   assert.match(wasmBlock, /onLaunch = mod\.onLaunch \?\? onLaunch/)
+})
+
 test('WASM camera preview uses a native RuntimeBitmapPort binding before falling back to mosaic', () => {
   const manifest = JSON.parse(readFileSync('stackchan/manifest_wasm.json', 'utf8'))
   const previewSource = readFileSync('stackchan/camera-preview.ts', 'utf8')
@@ -321,7 +323,6 @@ test('WASM camera forwards start and stop to the browser Host.Camera bridge when
   }
 })
 
-test('WASM camera forwards capture to Host.Camera and returns bridge frames', async () => {
 test('WASM camera uses the native browser camera bridge when it is preloaded', async () => {
   const calls: unknown[] = []
   const buffer = new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2]).buffer

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -31,6 +31,12 @@ type HostCameraTestBridge = {
   capture?: (options?: unknown) => unknown
 }
 
+type WasmCameraTestBridge = {
+  start?: (width: number, height: number, useBrowserCamera: boolean) => void
+  stop?: () => void
+  capture?: (width: number, height: number) => unknown
+}
+
 const setHostCamera = (CameraBridge: HostCameraTestBridge | undefined): typeof globalThis.Host => {
   const previousHost = globalThis.Host
   const nextHost = { ...(previousHost ?? {}) } as typeof globalThis.Host & { Camera?: HostCameraTestBridge }
@@ -43,6 +49,19 @@ const setHostCamera = (CameraBridge: HostCameraTestBridge | undefined): typeof g
 
   globalThis.Host = nextHost
   return previousHost
+}
+
+const setWasmCameraBridge = (CameraBridge: WasmCameraTestBridge | undefined): WasmCameraTestBridge | undefined => {
+  const env = globalThis as typeof globalThis & { __stackchanWasmCameraBridge?: WasmCameraTestBridge }
+  const previous = env.__stackchanWasmCameraBridge
+
+  if (CameraBridge) {
+    env.__stackchanWasmCameraBridge = CameraBridge
+  } else {
+    delete env.__stackchanWasmCameraBridge
+  }
+
+  return previous
 }
 
 const driverCases: Array<[string, DriverConstructor]> = [
@@ -68,6 +87,10 @@ test('WASM manifest keeps concrete servo driver module specifiers as facades for
   const manifest = JSON.parse(readFileSync('stackchan/manifest_wasm.json', 'utf8'))
 
   assert.equal(manifest.modules.camera, './wasm/camera')
+  assert.equal(manifest.modules['wasm-audio-bridge'], './wasm/audio-bridge')
+  assert.equal(manifest.modules['wasm-camera-bridge'], './wasm/camera-bridge')
+  assert.ok(manifest.preload.includes('wasm-camera-bridge'))
+  assert.equal(manifest.modules['embedded:io/audio/in'], './wasm/audio-in')
   assert.equal(manifest.modules['wasm-driver'], './drivers/wasm/wasm-driver')
   assert.equal(manifest.modules['embedded:io/audio/in'], './wasm/audio-in')
   assert.deepEqual(
@@ -282,6 +305,42 @@ test('WASM camera forwards start and stop to the browser Host.Camera bridge when
 })
 
 test('WASM camera forwards capture to Host.Camera and returns bridge frames', async () => {
+test('WASM camera uses the native browser camera bridge when it is preloaded', async () => {
+  const calls: unknown[] = []
+  const buffer = new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2]).buffer
+  const previousBridge = setWasmCameraBridge({
+    start(width, height, useBrowserCamera) {
+      calls.push({ start: { width, height, useBrowserCamera } })
+    },
+    stop() {
+      calls.push({ stop: true })
+    },
+    capture(width, height) {
+      calls.push({ capture: { width, height } })
+      return { width, height, imageType: 'rgb565le', buffer }
+    },
+  })
+
+  try {
+    const camera = new Camera()
+    await camera.start({ width: 200, height: 120, imageType: 'rgb565le', useBrowserCamera: true })
+    const frame = await camera.capture({ width: 200, height: 120, imageType: 'rgb565le' })
+    await camera.stop()
+
+    assert.deepEqual(calls, [
+      { start: { width: 200, height: 120, useBrowserCamera: true } },
+      { capture: { width: 200, height: 120 } },
+      { stop: true },
+    ])
+    assert.ok(frame)
+    assert.notEqual(frame.buffer, buffer)
+    assert.deepEqual(new Uint8Array(frame.buffer), new Uint8Array(buffer))
+  } finally {
+    setWasmCameraBridge(previousBridge)
+  }
+})
+
+test('WASM camera copies Host.Camera capture frames into local ArrayBuffers', async () => {
   const buffer = new ArrayBuffer(8)
   const previousHost = setHostCamera({
     capture(options) {

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -159,7 +159,8 @@ test('WASM camera preview uses a native RuntimeBitmapPort binding before falling
   assert.match(previewSource, /import RuntimeBitmapPort from 'runtime-bitmap-port'/)
   assert.match(previewSource, /new RuntimeBitmapPort\(/)
   assert.match(previewSource, /reportRenderMode\('runtime-bitmap-port'\)/)
-  assert.doesNotMatch(previewSource, /ENABLE_RUNTIME_TEXTURE_PREVIEW = true/)
+  assert.doesNotMatch(previewSource, /ENABLE_RUNTIME_TEXTURE_PREVIEW/)
+  assert.doesNotMatch(previewSource, /drawRgb565Texture/)
 })
 
 test('WasmDriver applyRotation pushes pose changes to the browser Host.Driver bridge', async () => {

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -176,6 +176,7 @@ test('WASM camera preview can be dismissed by touch or an automatic timeout', ()
   assert.match(modSource, /distribute\?\.\('onDrawerClose'\)/)
   assert.match(modSource, /closeDrawer\(\)/)
   assert.match(modSource, /Timer\.set\(restoreCameraPreview, CAMERA_PREVIEW_DURATION_MS\)/)
+  assert.doesNotMatch(modSource, /robot\.camera\.stop\(\)/)
 })
 
 test('WasmDriver applyRotation pushes pose changes to the browser Host.Driver bridge', async () => {

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -125,6 +125,18 @@ test('WASM main path loads an installed MOD archive before falling back to the d
   assert.match(wasmBlock, /Modules\.importNow\('mod'\) as StackchanMod/)
   assert.match(wasmBlock, /onRobotCreated = mod\.onRobotCreated \?\? onRobotCreated/)
   assert.match(wasmBlock, /onLaunch = mod\.onLaunch \?\? onLaunch/)
+test('WASM camera preview uses a native RuntimeBitmapPort binding before falling back to mosaic', () => {
+  const manifest = JSON.parse(readFileSync('stackchan/manifest_wasm.json', 'utf8'))
+  const previewSource = readFileSync('stackchan/camera-preview.ts', 'utf8')
+  const portSource = readFileSync('stackchan/runtime-bitmap-port.js', 'utf8')
+
+  assert.equal(manifest.modules['runtime-bitmap-port'], './runtime-bitmap-port')
+  assert.match(portSource, /drawBitmap\(bitmap, x, y, sx = 0, sy = 0, sw = bitmap\.width, sh = bitmap\.height\)/)
+  assert.match(portSource, /xs_stackchan_runtime_bitmap_port_draw/)
+  assert.match(previewSource, /import RuntimeBitmapPort from 'runtime-bitmap-port'/)
+  assert.match(previewSource, /new RuntimeBitmapPort\(/)
+  assert.match(previewSource, /reportRenderMode\('runtime-bitmap-port'\)/)
+  assert.doesNotMatch(previewSource, /ENABLE_RUNTIME_TEXTURE_PREVIEW = true/)
 })
 
 test('WasmDriver applyRotation pushes pose changes to the browser Host.Driver bridge', async () => {

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -40,6 +40,7 @@
     "stackchan/drivers/payload-buffer.ts",
     "stackchan/drivers/wasm/**/*.ts",
     "stackchan/camera.ts",
+    "stackchan/camera-preview-utils.ts",
     "stackchan/wasm/camera.ts",
     "stackchan/wasm/microphone.ts",
     "stackchan/drivers/m5stackchan-servo.ts",

--- a/firmware/typings/runtime-bitmap-port.d.ts
+++ b/firmware/typings/runtime-bitmap-port.d.ts
@@ -1,0 +1,8 @@
+declare module 'runtime-bitmap-port' {
+  import type { Port } from 'piu/MC'
+  import type Bitmap from 'commodetto/Bitmap'
+
+  export default class RuntimeBitmapPort extends Port {
+    drawBitmap(bitmap: Bitmap, x: number, y: number, sx?: number, sy?: number, sw?: number, sh?: number): void
+  }
+}

--- a/web/simulator/bridge.mjs
+++ b/web/simulator/bridge.mjs
@@ -347,11 +347,13 @@ export function createHostCameraBridge({
   return {
     async start(options = {}) {
       started = true
-      browserCameraRequested = Boolean(options.useBrowserCamera)
-      if (browserCameraRequested) {
-        await startBrowserCamera(options)
-      } else {
-        stopBrowserCamera()
+      if (Object.hasOwn(options, 'useBrowserCamera')) {
+        browserCameraRequested = Boolean(options.useBrowserCamera)
+        if (browserCameraRequested) {
+          await startBrowserCamera(options)
+        } else {
+          stopBrowserCamera()
+        }
       }
     },
     stop() {

--- a/web/simulator/bridge.mjs
+++ b/web/simulator/bridge.mjs
@@ -277,6 +277,8 @@ export function createHostCameraBridge({
   }
 
   const startBrowserCamera = async (options = {}) => {
+    if (browserCameraStarted && mediaStream && mediaVideo?.srcObject === mediaStream) return true
+
     stopBrowserCamera()
 
     const getUserMedia = navigatorObj?.mediaDevices?.getUserMedia?.bind(navigatorObj.mediaDevices)

--- a/web/simulator/bridge.mjs
+++ b/web/simulator/bridge.mjs
@@ -3,6 +3,7 @@ const MOD_INSTALL_HOOKS = ['_fxMainSetModArchive', '_wasmModInstallArchive']
 const DEFAULT_CAMERA_WIDTH = 96
 const DEFAULT_CAMERA_HEIGHT = 96
 const DEFAULT_CAMERA_IMAGE_TYPE = 'rgb565le'
+const HAVE_CURRENT_DATA = 2
 
 function normalizeDimension(value, fallback) {
   if (value === undefined) return fallback
@@ -198,29 +199,175 @@ export function createHostAudioOutBridge({
   }
 }
 
-export function createHostCameraBridge() {
+function writeImageDataRgb565Le(view, imageData) {
+  let offset = 0
+  const data = imageData.data
+
+  for (let index = 0; index < data.length; index += 4) {
+    const red = data[index] >> 3
+    const green = data[index + 1] >> 2
+    const blue = data[index + 2] >> 3
+    const pixel = (red << 11) | (green << 5) | blue
+
+    view[offset] = pixel & 0xff
+    view[offset + 1] = (pixel >> 8) & 0xff
+    offset += 2
+  }
+}
+
+function createSyntheticCameraFrame(options = {}) {
+  const imageType = options.imageType ?? DEFAULT_CAMERA_IMAGE_TYPE
+  if (imageType !== 'rgb565le') return undefined
+
+  const width = normalizeDimension(options.width, DEFAULT_CAMERA_WIDTH)
+  const height = normalizeDimension(options.height, DEFAULT_CAMERA_HEIGHT)
+  const buffer = new ArrayBuffer(width * height * 2)
+  writeRgb565Le(new Uint8Array(buffer), width, height)
+
+  return { width, height, imageType, buffer }
+}
+
+export function createHostCameraBridge({
+  documentObj = globalThis.document,
+  logger = console,
+  navigatorObj = globalThis.navigator,
+  videoElement,
+  canvasElement,
+} = {}) {
   let started = false
+  let browserCameraRequested = false
+  let browserCameraStarted = false
+  let mediaStream
+  let mediaVideo = videoElement
+  let mediaCanvas = canvasElement
+  let browserStartGeneration = 0
+
+  const logWarning = (message, error) => {
+    if (error) {
+      logger?.warn?.(message, error)
+    } else {
+      logger?.warn?.(message)
+    }
+  }
+
+  const ensureVideoElement = () => {
+    if (mediaVideo) return mediaVideo
+    if (!documentObj?.createElement) return undefined
+
+    mediaVideo = documentObj.createElement('video')
+    mediaVideo.muted = true
+    mediaVideo.playsInline = true
+    return mediaVideo
+  }
+
+  const ensureCanvasElement = () => {
+    if (mediaCanvas) return mediaCanvas
+    if (!documentObj?.createElement) return undefined
+
+    mediaCanvas = documentObj.createElement('canvas')
+    return mediaCanvas
+  }
+
+  const stopBrowserCamera = () => {
+    browserStartGeneration += 1
+    for (const track of mediaStream?.getTracks?.() ?? []) track.stop?.()
+    mediaStream = undefined
+    browserCameraStarted = false
+    if (mediaVideo) mediaVideo.srcObject = null
+  }
+
+  const startBrowserCamera = async (options = {}) => {
+    stopBrowserCamera()
+
+    const getUserMedia = navigatorObj?.mediaDevices?.getUserMedia?.bind(navigatorObj.mediaDevices)
+    if (!getUserMedia) {
+      browserCameraStarted = false
+      return false
+    }
+
+    const video = ensureVideoElement()
+    if (!video) {
+      browserCameraStarted = false
+      return false
+    }
+
+    try {
+      const startGeneration = browserStartGeneration
+      const stream = await getUserMedia({ video: options.video ?? true })
+      if (startGeneration !== browserStartGeneration || !started || !browserCameraRequested) {
+        for (const track of stream?.getTracks?.() ?? []) track.stop?.()
+        return false
+      }
+
+      mediaStream = stream
+      video.srcObject = mediaStream
+      if (typeof video.play === 'function') await video.play()
+      browserCameraStarted = true
+      return true
+    } catch (error) {
+      stopBrowserCamera()
+      logWarning('[bridge] browser camera unavailable; using synthetic Host.Camera fallback', error)
+      return false
+    }
+  }
+
+  const captureBrowserCamera = (options = {}) => {
+    if (!started || !browserCameraRequested || !browserCameraStarted) return undefined
+    if (!mediaVideo || mediaVideo.readyState < HAVE_CURRENT_DATA || !mediaVideo.videoWidth || !mediaVideo.videoHeight) {
+      return undefined
+    }
+
+    const canvas = ensureCanvasElement()
+    const context = canvas?.getContext?.('2d', { willReadFrequently: true })
+    if (!canvas || !context?.drawImage || !context?.getImageData) return undefined
+
+    const width = normalizeDimension(options.width, DEFAULT_CAMERA_WIDTH)
+    const height = normalizeDimension(options.height, DEFAULT_CAMERA_HEIGHT)
+
+    try {
+      canvas.width = width
+      canvas.height = height
+      context.drawImage(mediaVideo, 0, 0, width, height)
+
+      const imageData = context.getImageData(0, 0, width, height)
+      if (!imageData?.data || imageData.data.length < width * height * 4) return undefined
+
+      const buffer = new ArrayBuffer(width * height * 2)
+      writeImageDataRgb565Le(new Uint8Array(buffer), imageData)
+
+      return { width, height, imageType: 'rgb565le', buffer }
+    } catch (error) {
+      logWarning('[bridge] browser camera capture failed; using synthetic Host.Camera fallback', error)
+      return undefined
+    }
+  }
 
   return {
-    start() {
+    async start(options = {}) {
       started = true
+      browserCameraRequested = Boolean(options.useBrowserCamera)
+      if (browserCameraRequested) {
+        await startBrowserCamera(options)
+      } else {
+        stopBrowserCamera()
+      }
     },
     stop() {
       started = false
+      browserCameraRequested = false
+      stopBrowserCamera()
     },
     isStarted() {
       return started
+    },
+    isBrowserCameraStarted() {
+      return browserCameraStarted
     },
     capture(options = {}) {
       const imageType = options.imageType ?? DEFAULT_CAMERA_IMAGE_TYPE
       if (imageType !== 'rgb565le') return undefined
 
-      const width = normalizeDimension(options.width, DEFAULT_CAMERA_WIDTH)
-      const height = normalizeDimension(options.height, DEFAULT_CAMERA_HEIGHT)
-      const buffer = new ArrayBuffer(width * height * 2)
-      writeRgb565Le(new Uint8Array(buffer), width, height)
-
-      return { width, height, imageType, buffer }
+      return captureBrowserCamera(options) ?? createSyntheticCameraFrame(options)
     },
   }
 }

--- a/web/simulator/bridge.test.mjs
+++ b/web/simulator/bridge.test.mjs
@@ -482,6 +482,35 @@ describe('Host.Camera bridge', () => {
     assert.deepEqual(new Uint8Array(first.buffer), new Uint8Array(second.buffer))
   })
 
+  it('keeps an already-started browser camera stream when firmware starts camera preview', async () => {
+    const calls = []
+    const stream = { getTracks: () => [{ stop: () => calls.push('stop') }] }
+    const video = {
+      readyState: 2,
+      videoWidth: 16,
+      videoHeight: 16,
+      play: async () => calls.push('play'),
+    }
+    const bridge = createHostCameraBridge({
+      navigatorObj: {
+        mediaDevices: {
+          async getUserMedia(constraints) {
+            calls.push(['getUserMedia', constraints])
+            return stream
+          },
+        },
+      },
+      videoElement: video,
+    })
+
+    await bridge.start({ useBrowserCamera: true })
+    await bridge.start({ useBrowserCamera: true, width: 200, height: 120, imageType: 'rgb565le' })
+
+    assert.equal(bridge.isBrowserCameraStarted(), true)
+    assert.equal(video.srcObject, stream)
+    assert.deepEqual(calls, [['getUserMedia', { video: true }], 'play'])
+  })
+
   it('stops late-resolving browser streams when camera was stopped during permission prompt', async () => {
     let resolveStream
     const stopped = []

--- a/web/simulator/bridge.test.mjs
+++ b/web/simulator/bridge.test.mjs
@@ -363,15 +363,152 @@ describe('Host.Camera bridge', () => {
     assert.deepEqual(new Uint8Array(first.buffer), new Uint8Array(second.buffer))
   })
 
-  it('tracks start and stop without requiring browser media devices', () => {
+  it('tracks start and stop without requiring browser media devices', async () => {
     const bridge = createHostCameraBridge()
 
-    bridge.start({ width: 2, height: 2 })
+    await bridge.start({ width: 2, height: 2 })
     assert.equal(bridge.isStarted(), true)
 
     bridge.stop()
     bridge.stop()
     assert.equal(bridge.isStarted(), false)
+  })
+
+  it('captures ready browser video frames as RGB565LE through canvas', async () => {
+    const calls = []
+    const stream = { getTracks: () => [{ stop: () => calls.push('stop') }] }
+    const video = {
+      readyState: 2,
+      videoWidth: 16,
+      videoHeight: 16,
+      play: async () => calls.push('play'),
+    }
+    const canvas = {
+      getContext: () => ({
+        drawImage: (...args) => calls.push(['drawImage', ...args.slice(1)]),
+        getImageData: () => ({
+          data: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255]),
+        }),
+      }),
+    }
+    const bridge = createHostCameraBridge({
+      canvasElement: canvas,
+      navigatorObj: {
+        mediaDevices: {
+          async getUserMedia(constraints) {
+            calls.push(['getUserMedia', constraints])
+            return stream
+          },
+        },
+      },
+      videoElement: video,
+    })
+
+    await bridge.start({ useBrowserCamera: true })
+    const frame = bridge.capture({ width: 2, height: 2, imageType: 'rgb565le' })
+
+    assert.equal(bridge.isStarted(), true)
+    assert.equal(bridge.isBrowserCameraStarted(), true)
+    assert.deepEqual(calls.slice(0, 3), [['getUserMedia', { video: true }], 'play', ['drawImage', 0, 0, 2, 2]])
+    assert.equal(video.srcObject, stream)
+    assert.equal(canvas.width, 2)
+    assert.equal(canvas.height, 2)
+    assert.equal(frame.width, 2)
+    assert.equal(frame.height, 2)
+    assert.equal(frame.imageType, 'rgb565le')
+    assert.equal(frame.buffer.byteLength, 2 * 2 * 2)
+    assert.deepEqual(new Uint8Array(frame.buffer), new Uint8Array([0x00, 0xf8, 0xe0, 0x07, 0x1f, 0x00, 0xff, 0xff]))
+
+    bridge.stop()
+    assert.equal(video.srcObject, null)
+    assert.equal(calls.at(-1), 'stop')
+  })
+
+  it('falls back to synthetic RGB565LE when browser media APIs are absent', async () => {
+    const bridge = createHostCameraBridge({ navigatorObj: {}, documentObj: undefined })
+
+    await bridge.start({ useBrowserCamera: true })
+    const first = bridge.capture({ width: 2, height: 2, imageType: 'rgb565le' })
+    const second = createHostCameraBridge().capture({ width: 2, height: 2, imageType: 'rgb565le' })
+
+    assert.equal(bridge.isBrowserCameraStarted(), false)
+    assert.deepEqual(new Uint8Array(first.buffer), new Uint8Array(second.buffer))
+  })
+
+  it('falls back to synthetic RGB565LE when browser permission is denied', async () => {
+    const warnings = []
+    const bridge = createHostCameraBridge({
+      logger: { warn: (...args) => warnings.push(args) },
+      navigatorObj: {
+        mediaDevices: {
+          async getUserMedia() {
+            throw new Error('denied')
+          },
+        },
+      },
+      videoElement: { srcObject: undefined },
+    })
+
+    await assert.doesNotReject(() => bridge.start({ useBrowserCamera: true }))
+    const frame = bridge.capture({ width: 2, height: 2, imageType: 'rgb565le' })
+
+    assert.equal(bridge.isBrowserCameraStarted(), false)
+    assert.equal(frame.buffer.byteLength, 2 * 2 * 2)
+    assert.match(warnings[0][0], /browser camera unavailable/)
+  })
+
+  it('falls back to synthetic RGB565LE when browser video is not ready', async () => {
+    const bridge = createHostCameraBridge({
+      canvasElement: {
+        getContext: () => {
+          throw new Error('canvas should not be read before video is ready')
+        },
+      },
+      navigatorObj: {
+        mediaDevices: {
+          async getUserMedia() {
+            return { getTracks: () => [] }
+          },
+        },
+      },
+      videoElement: { readyState: 1, videoWidth: 0, videoHeight: 0 },
+    })
+
+    await bridge.start({ useBrowserCamera: true })
+    const first = bridge.capture({ width: 2, height: 2, imageType: 'rgb565le' })
+    const second = createHostCameraBridge().capture({ width: 2, height: 2, imageType: 'rgb565le' })
+
+    assert.equal(bridge.isBrowserCameraStarted(), true)
+    assert.deepEqual(new Uint8Array(first.buffer), new Uint8Array(second.buffer))
+  })
+
+  it('stops late-resolving browser streams when camera was stopped during permission prompt', async () => {
+    let resolveStream
+    const stopped = []
+    const stream = { getTracks: () => [{ stop: () => stopped.push('stop') }] }
+    const video = { srcObject: undefined, play: async () => {} }
+    const bridge = createHostCameraBridge({
+      navigatorObj: {
+        mediaDevices: {
+          getUserMedia() {
+            return new Promise((resolve) => {
+              resolveStream = resolve
+            })
+          },
+        },
+      },
+      videoElement: video,
+    })
+
+    const startPromise = bridge.start({ useBrowserCamera: true })
+    bridge.stop()
+    resolveStream(stream)
+    await startPromise
+
+    assert.equal(bridge.isStarted(), false)
+    assert.equal(bridge.isBrowserCameraStarted(), false)
+    assert.equal(video.srcObject, null)
+    assert.deepEqual(stopped, ['stop'])
   })
 
   it('keeps unsupported camera formats out of the simulator bridge', () => {

--- a/web/simulator/bridge.test.mjs
+++ b/web/simulator/bridge.test.mjs
@@ -504,11 +504,34 @@ describe('Host.Camera bridge', () => {
     })
 
     await bridge.start({ useBrowserCamera: true })
-    await bridge.start({ useBrowserCamera: true, width: 200, height: 120, imageType: 'rgb565le' })
+    await bridge.start({ width: 200, height: 120, imageType: 'rgb565le' })
 
     assert.equal(bridge.isBrowserCameraStarted(), true)
     assert.equal(video.srcObject, stream)
     assert.deepEqual(calls, [['getUserMedia', { video: true }], 'play'])
+  })
+
+  it('allows an explicit non-browser camera start to stop an active browser stream', async () => {
+    const calls = []
+    const stream = { getTracks: () => [{ stop: () => calls.push('stop') }] }
+    const video = { readyState: 2, videoWidth: 16, videoHeight: 16, play: async () => calls.push('play') }
+    const bridge = createHostCameraBridge({
+      navigatorObj: {
+        mediaDevices: {
+          async getUserMedia() {
+            return stream
+          },
+        },
+      },
+      videoElement: video,
+    })
+
+    await bridge.start({ useBrowserCamera: true })
+    await bridge.start({ useBrowserCamera: false })
+
+    assert.equal(bridge.isBrowserCameraStarted(), false)
+    assert.equal(video.srcObject, null)
+    assert.deepEqual(calls, ['play', 'stop'])
   })
 
   it('stops late-resolving browser streams when camera was stopped during permission prompt', async () => {

--- a/web/simulator/index.html
+++ b/web/simulator/index.html
@@ -43,12 +43,16 @@
             <button id="simulator-restart-button" type="button">Restart simulator</button>
             <button id="mod-clear-button" type="button">Clear MOD</button>
             <p id="mod-install-status">MOD: empty</p>
+          </div>
           <div class="controls">
             <button id="button-a" type="button">A: キョロキョロ</button>
             <button id="button-b" type="button">B: サーボ動作</button>
             <button id="button-c" type="button">C: 色変更</button>
             <button id="speech-toggle" type="button" aria-pressed="false">喋る</button>
-            <button id="camera-toggle" type="button" aria-pressed="false">Browser Camera</button>
+          </div>
+          <div class="camera-controls" aria-label="browser camera controls">
+            <button id="browser-camera-button" type="button">ブラウザカメラ開始</button>
+            <p id="browser-camera-status">Cameraボタンから自動開始を試します。必要ならこのボタンで許可してください。</p>
           </div>
           <pre id="trace-log" aria-label="firmware trace log"></pre>
         </aside>

--- a/web/simulator/index.html
+++ b/web/simulator/index.html
@@ -43,6 +43,12 @@
             <button id="simulator-restart-button" type="button">Restart simulator</button>
             <button id="mod-clear-button" type="button">Clear MOD</button>
             <p id="mod-install-status">MOD: empty</p>
+          <div class="controls">
+            <button id="button-a" type="button">A: キョロキョロ</button>
+            <button id="button-b" type="button">B: サーボ動作</button>
+            <button id="button-c" type="button">C: 色変更</button>
+            <button id="speech-toggle" type="button" aria-pressed="false">喋る</button>
+            <button id="camera-toggle" type="button" aria-pressed="false">Browser Camera</button>
           </div>
           <pre id="trace-log" aria-label="firmware trace log"></pre>
         </aside>

--- a/web/simulator/simulator-ui.test.mjs
+++ b/web/simulator/simulator-ui.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+test('simulator exposes a browser camera start button for permission-gated getUserMedia', () => {
+  const html = readFileSync('simulator/index.html', 'utf8')
+  const script = readFileSync('simulator/simulator.mjs', 'utf8')
+
+  assert.match(html, /id="browser-camera-button"/)
+  assert.match(html, /id="browser-camera-status"/)
+  assert.match(script, /getElementById\('browser-camera-button'\)/)
+  assert.match(script, /cameraBridge\.start\(\{ useBrowserCamera: true \}\)/)
+})

--- a/web/simulator/simulator.css
+++ b/web/simulator/simulator.css
@@ -144,6 +144,14 @@ button:hover,
   padding: 16px 0;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+  transform: none;
+}
+
+button[aria-pressed="true"] {
+  background: #8bd3ff;
 }
 
 .file-button,

--- a/web/simulator/simulator.css
+++ b/web/simulator/simulator.css
@@ -144,6 +144,8 @@ button:hover,
   padding: 16px 0;
   border-top: 1px solid rgba(255, 255, 255, 0.12);
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
 button:disabled {
   cursor: wait;
   opacity: 0.72;
@@ -176,6 +178,35 @@ button[aria-pressed="true"] {
   color: #bfb7ad;
   font-size: 0.9rem;
   line-height: 1.45;
+}
+
+.camera-controls {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0 0;
+}
+
+#browser-camera-button {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 12px;
+  background: #ffb36b;
+  color: #21160f;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+#browser-camera-button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+#browser-camera-status {
+  margin: 0;
+  color: #a9b9c9;
+  font-size: 0.82rem;
+  line-height: 1.5;
 }
 
 #trace-log {

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -553,14 +553,36 @@ const modClearButton = document.getElementById('mod-clear-button')
 const modInstallStatus = document.getElementById('mod-install-status')
 const traceLog = document.getElementById('trace-log')
 const modStorage = createModStorage()
+const browserCameraButton = document.getElementById('browser-camera-button')
+const browserCameraStatus = document.getElementById('browser-camera-status')
 const buttonBridge = createHostButtonBridge({ logger: (message) => console.log(message) })
 const audioOutBridge = createHostAudioOutBridge()
 const audioInBridge = createHostAudioInBridge()
+const cameraBridge = createHostCameraBridge()
+if (browserCameraButton) {
+  browserCameraButton.addEventListener('click', async () => {
+    browserCameraButton.disabled = true
+    if (browserCameraStatus) browserCameraStatus.textContent = 'ブラウザカメラを開始しています…'
+    try {
+      await cameraBridge.start({ useBrowserCamera: true })
+      if (browserCameraStatus) {
+        browserCameraStatus.textContent = cameraBridge.isBrowserCameraStarted()
+          ? 'ブラウザカメラ準備完了。ドロワーのCameraでプレビューできます。'
+          : 'ブラウザカメラは使えませんでした。合成フレームで続行します。'
+      }
+    } catch (error) {
+      console.warn('[bridge] browser camera button failed', error)
+      if (browserCameraStatus) browserCameraStatus.textContent = 'ブラウザカメラ開始に失敗しました。合成フレームで続行します。'
+    } finally {
+      browserCameraButton.disabled = false
+    }
+  })
+}
 globalThis.Host = {
   Button: buttonBridge.Button,
   AudioOut: audioOutBridge,
   AudioIn: audioInBridge,
-  Camera: createHostCameraBridge(),
+  Camera: cameraBridge,
 }
 console.log('[bridge] global Host.Button/Audio/Camera constructors installed')
 
@@ -613,7 +635,6 @@ const driverBridge = createHostDriverBridge({
 })
 globalThis.Host.Driver = driverBridge
 console.log('[bridge] global Host.Driver bridge installed')
-const cameraBridge = createHostCameraBridge()
 globalThis.Host.Camera = cameraBridge
 console.log('[bridge] global Host.Camera bridge installed')
 buttonBridge.setHtmlAction('a', () => scene.setLookAround(!scene.lookAround))
@@ -670,22 +691,6 @@ modClearButton.addEventListener('click', async () => {
   }
 })
 bindViewportScreenTouches({ viewport, scene, wasmView })
-document.getElementById('camera-toggle').addEventListener('click', async (event) => {
-  const button = event.currentTarget
-  const next = button.getAttribute('aria-pressed') !== 'true'
-  button.disabled = true
-
-  try {
-    if (next) {
-      await cameraBridge.start({ useBrowserCamera: true })
-    } else {
-      cameraBridge.stop()
-    }
-    button.setAttribute('aria-pressed', String(next && cameraBridge.isBrowserCameraStarted()))
-  } finally {
-    button.disabled = false
-  }
-})
 
 function animate(timeMs) {
   wasmView.idle(timeMs)

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -572,7 +572,8 @@ if (browserCameraButton) {
       }
     } catch (error) {
       console.warn('[bridge] browser camera button failed', error)
-      if (browserCameraStatus) browserCameraStatus.textContent = 'ブラウザカメラ開始に失敗しました。合成フレームで続行します。'
+      if (browserCameraStatus)
+        browserCameraStatus.textContent = 'ブラウザカメラ開始に失敗しました。合成フレームで続行します。'
     } finally {
       browserCameraButton.disabled = false
     }

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -613,6 +613,11 @@ const driverBridge = createHostDriverBridge({
 })
 globalThis.Host.Driver = driverBridge
 console.log('[bridge] global Host.Driver bridge installed')
+const cameraBridge = createHostCameraBridge()
+globalThis.Host.Camera = cameraBridge
+console.log('[bridge] global Host.Camera bridge installed')
+buttonBridge.setHtmlAction('a', () => scene.setLookAround(!scene.lookAround))
+buttonBridge.setHtmlAction('b', () => scene.runServoMotion())
 
 const wasmView = new WasmView({
   scene,
@@ -665,6 +670,22 @@ modClearButton.addEventListener('click', async () => {
   }
 })
 bindViewportScreenTouches({ viewport, scene, wasmView })
+document.getElementById('camera-toggle').addEventListener('click', async (event) => {
+  const button = event.currentTarget
+  const next = button.getAttribute('aria-pressed') !== 'true'
+  button.disabled = true
+
+  try {
+    if (next) {
+      await cameraBridge.start({ useBrowserCamera: true })
+    } else {
+      cameraBridge.stop()
+    }
+    button.setAttribute('aria-pressed', String(next && cameraBridge.isBrowserCameraStarted()))
+  } finally {
+    button.disabled = false
+  }
+})
 
 function animate(timeMs) {
   wasmView.idle(timeMs)


### PR DESCRIPTION
## Summary

- Replays the browser `getUserMedia` camera bridge on top of the current WASM simulator deployment branch after #439 was merged.
- Keeps `Host.Camera.start()` from stopping an already-opened browser camera when firmware starts preview without an explicit `useBrowserCamera` option.
- Preserves the runtime bitmap preview path and camera preview dismissal behavior without stopping the browser stream.

## Verification

- `cd firmware && npm run format && npm run test`
- `cd web && npm test && npm exec -- prettier --check simulator/bridge.mjs simulator/bridge.test.mjs simulator/simulator.mjs simulator/simulator-ui.test.mjs`
- conflict marker search: no matches

Supersedes closed #442, whose base branch was deleted after #439 merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live camera preview display with adaptive rendering for different device capabilities
  * Browser camera integration in simulator with user permission controls
  * Enhanced simulator UI with dedicated camera start button and button action controls

* **Tests**
  * Added unit tests for camera preview utilities and rendering
  * Added validation tests for native bindings and simulator UI integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->