### PR TITLE
fix: separate simulator face panel layers

### DIFF
--- a/web/simulator/geometry.mjs
+++ b/web/simulator/geometry.mjs
@@ -99,6 +99,24 @@ export function createRoundedRectPath({ width, height, radius, segments = 8 } = 
   })
 }
 
+export function computeFaceLayerDepths({
+  facePlacement = computeFaceModulePlacement(),
+  frontPanelClearance = 0.2,
+  screenFrameClearance = 0.1,
+  screenClearance = 0.03,
+} = {}) {
+  const beveledFaceFrontZ = facePlacement.frontZ + STACKCHAN_FACE_MM.bevelThickness
+  const frontPanelZ = beveledFaceFrontZ + frontPanelClearance
+  const screenFrameZ = frontPanelZ + screenFrameClearance
+  const screenZ = screenFrameZ + screenClearance
+  return {
+    beveledFaceFrontZ,
+    frontPanelZ,
+    screenFrameZ,
+    screenZ,
+  }
+}
+
 export function computeScreenPlane({
   faceWidth = STACKCHAN_FACE_MM.width,
   faceHeight = STACKCHAN_FACE_MM.height,
@@ -113,7 +131,7 @@ export function computeScreenPlane({
     ...size,
     x: 0,
     y: 0,
-    z: computeFaceModulePlacement().frontZ + STACKCHAN_FACE_MM.bevelThickness + 0.06,
+    z: computeFaceLayerDepths().screenZ,
   }
 }
 

--- a/web/simulator/geometry.test.mjs
+++ b/web/simulator/geometry.test.mjs
@@ -9,6 +9,7 @@ import {
   STACKCHAN_SIMULATOR_COLORS,
   STACKCHAN_SHELL_STL,
   computeFootPlacements,
+  computeFaceLayerDepths,
   computeFaceModulePlacement,
   computeScreenPlane,
   computeShellScaleForM5Stack,
@@ -69,13 +70,21 @@ describe('Stack-chan simulator geometry', () => {
     assert.equal(Math.max(...ys), 27)
   })
 
+  it('keeps the dark M5Stack front panel clearly separated from the gray face and below the screen layers', () => {
+    const layers = computeFaceLayerDepths()
+
+    assert.ok(layers.frontPanelZ - layers.beveledFaceFrontZ >= 0.18)
+    assert.ok(layers.screenFrameZ - layers.frontPanelZ >= 0.08)
+    assert.ok(layers.screenZ - layers.screenFrameZ >= 0.03)
+  })
+
   it('fits the 4:3 wasm screen canvas in front of the beveled face with a margin', () => {
     const plane = computeScreenPlane({ margin: 5 })
 
     assert.equal(SCREEN_CANVAS.width / SCREEN_CANVAS.height, 4 / 3)
     assert.equal(plane.width, 44)
     assert.equal(plane.height, 33)
-    assert.ok(Math.abs(plane.z - 29.69837209302326) < 1e-9)
+    assert.equal(plane.z, computeFaceLayerDepths().screenZ)
   })
 
   it('serves the v1 shell STL as a simulator-local asset while keeping the face geometry-generated', () => {

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -19,6 +19,7 @@ import {
   STACKCHAN_FOOT_MM,
   STACKCHAN_SIMULATOR_COLORS,
   STACKCHAN_SHELL_STL,
+  computeFaceLayerDepths,
   computeFaceModulePlacement,
   computeFootPlacements,
   computeScreenPlane,
@@ -168,8 +169,9 @@ class StackchanScene {
     this.faceModule = new THREE.Mesh(geometry, this.m5stackSideMaterial)
     this.headGroup.add(this.faceModule)
 
+    const layers = computeFaceLayerDepths()
     const frontPanelGeometry = new THREE.ShapeGeometry(shape)
-    frontPanelGeometry.translate(0, 0, facePlacement.frontZ + STACKCHAN_FACE_MM.bevelThickness + 0.01)
+    frontPanelGeometry.translate(0, 0, layers.frontPanelZ)
     this.faceFrontPanel = new THREE.Mesh(frontPanelGeometry, this.m5stackFrontMaterial)
     this.headGroup.add(this.faceFrontPanel)
 
@@ -221,7 +223,7 @@ class StackchanScene {
       new THREE.PlaneGeometry(plane.width + 2.4, plane.height + 2.4),
       new THREE.MeshBasicMaterial({ color: 0x211a17 })
     )
-    frame.position.set(plane.x, plane.y, plane.z - 0.03)
+    frame.position.set(plane.x, plane.y, computeFaceLayerDepths().screenFrameZ)
     this.headGroup.add(frame)
     this.screenMesh.renderOrder = 1
   }


### PR DESCRIPTION
## Summary
- separates the dark M5Stack front panel from the gray beveled face by an explicit depth clearance
- keeps the screen frame and screen texture on their own front layers so they remain visible above the panel
- adds a geometry regression test for the front-panel / frame / screen z-order spacing

## Test Plan
- [x] `cd web && npm test`
- [x] local browser smoke at `/simulator/` confirmed the diagonal gray z-fighting hatching is gone on the dark front panel

Release impact: none — web simulator visual layering fix only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved 3D geometry depth calculations in the simulator for more consistent positioning and layering of visual components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/450)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->