### PR TITLE
fix: avoid simulator screen frame overlap

### DIFF
--- a/web/simulator/geometry.mjs
+++ b/web/simulator/geometry.mjs
@@ -135,6 +135,23 @@ export function computeScreenPlane({
   }
 }
 
+export function computeScreenFrame({ border = 1.2, ...screenOptions } = {}) {
+  const screen = computeScreenPlane(screenOptions)
+  return {
+    x: screen.x,
+    y: screen.y,
+    z: computeFaceLayerDepths().screenFrameZ,
+    inner: {
+      width: screen.width,
+      height: screen.height,
+    },
+    outer: {
+      width: screen.width + border * 2,
+      height: screen.height + border * 2,
+    },
+  }
+}
+
 export function computeFaceModulePlacement({
   shellBounds = STACKCHAN_SHELL_STL.sourceBoundsMm,
   shellScale = computeShellScaleForM5Stack(),

--- a/web/simulator/geometry.test.mjs
+++ b/web/simulator/geometry.test.mjs
@@ -11,6 +11,7 @@ import {
   computeFootPlacements,
   computeFaceLayerDepths,
   computeFaceModulePlacement,
+  computeScreenFrame,
   computeScreenPlane,
   computeShellScaleForM5Stack,
   computeShellPlacementFromBounds,
@@ -85,6 +86,19 @@ describe('Stack-chan simulator geometry', () => {
     assert.equal(plane.width, 44)
     assert.equal(plane.height, 33)
     assert.equal(plane.z, computeFaceLayerDepths().screenZ)
+  })
+
+  it('keeps the Moddable screen from sharing pixels with the screen frame geometry', () => {
+    const screen = computeScreenPlane({ margin: 5 })
+    const frame = computeScreenFrame({ margin: 5, border: 1.2 })
+
+    assert.equal(frame.z, computeFaceLayerDepths().screenFrameZ)
+    assert.equal(frame.inner.width, screen.width)
+    assert.equal(frame.inner.height, screen.height)
+    assert.equal(frame.outer.width, screen.width + 2.4)
+    assert.equal(frame.outer.height, screen.height + 2.4)
+    assert.ok(frame.outer.width > frame.inner.width)
+    assert.ok(frame.outer.height > frame.inner.height)
   })
 
   it('serves the v1 shell STL as a simulator-local asset while keeping the face geometry-generated', () => {

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -22,6 +22,7 @@ import {
   computeFaceLayerDepths,
   computeFaceModulePlacement,
   computeFootPlacements,
+  computeScreenFrame,
   computeScreenPlane,
   computeShellPlacementFromBounds,
   computeStackchanKinematics,
@@ -219,11 +220,31 @@ class StackchanScene {
     this.screenMesh.position.set(plane.x, plane.y, plane.z)
     this.headGroup.add(this.screenMesh)
 
+    const framePlacement = computeScreenFrame({ margin: 5, border: 1.2 })
+    const frameShape = new THREE.Shape()
+    const outerHalfWidth = framePlacement.outer.width / 2
+    const outerHalfHeight = framePlacement.outer.height / 2
+    frameShape.moveTo(-outerHalfWidth, -outerHalfHeight)
+    frameShape.lineTo(outerHalfWidth, -outerHalfHeight)
+    frameShape.lineTo(outerHalfWidth, outerHalfHeight)
+    frameShape.lineTo(-outerHalfWidth, outerHalfHeight)
+    frameShape.closePath()
+
+    const screenHole = new THREE.Path()
+    const innerHalfWidth = framePlacement.inner.width / 2
+    const innerHalfHeight = framePlacement.inner.height / 2
+    screenHole.moveTo(-innerHalfWidth, -innerHalfHeight)
+    screenHole.lineTo(-innerHalfWidth, innerHalfHeight)
+    screenHole.lineTo(innerHalfWidth, innerHalfHeight)
+    screenHole.lineTo(innerHalfWidth, -innerHalfHeight)
+    screenHole.closePath()
+    frameShape.holes.push(screenHole)
+
     const frame = new THREE.Mesh(
-      new THREE.PlaneGeometry(plane.width + 2.4, plane.height + 2.4),
+      new THREE.ShapeGeometry(frameShape),
       new THREE.MeshBasicMaterial({ color: 0x211a17 })
     )
-    frame.position.set(plane.x, plane.y, computeFaceLayerDepths().screenFrameZ)
+    frame.position.set(framePlacement.x, framePlacement.y, framePlacement.z)
     this.headGroup.add(frame)
     this.screenMesh.renderOrder = 1
   }


### PR DESCRIPTION
## Summary
- changes the simulator screen frame from a full rectangle behind the Moddable screen into a ring with a screen-sized hole
- keeps the Moddable screen canvas on its own plane so it no longer shares pixels with frame geometry
- adds a geometry regression test for the frame/screen dimensions and z-order

## Test Plan
- [x] `cd web && npm test`
- [x] local browser smoke at `/simulator/` confirmed the Moddable screen area is cleanly separated from the frame

Release impact: none — web simulator visual layering fix only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced screen frame geometry with configurable border and margin parameters for improved visual representation.

* **Tests**
  * Added geometry validation tests to verify screen frame positioning and dimension calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/451)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->