### PR TITLE
fix: tune WASM simulator geometry

### DIFF
--- a/web/simulator/geometry.mjs
+++ b/web/simulator/geometry.mjs
@@ -49,6 +49,30 @@ function cleanZero(value) {
   return Object.is(value, -0) || Math.abs(value) < 1e-9 ? 0 : value
 }
 
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value))
+}
+
+function parseFiniteNumber(value, fallback) {
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export function computeGeometryTuning({ shellGap = 10, footHeight = -4, footForward = 0 } = {}) {
+  return {
+    shellOffset: {
+      x: 0,
+      y: 0,
+      z: -clamp(parseFiniteNumber(shellGap, 10), 0, 12),
+    },
+    feetOffset: {
+      x: 0,
+      y: clamp(parseFiniteNumber(footHeight, -4), -4, 4),
+      z: clamp(parseFiniteNumber(footForward, 0), -8, 8),
+    },
+  }
+}
+
 function rotatePoint({ x, y, z }, rotation) {
   const cosX = Math.cos(rotation.x)
   const sinX = Math.sin(rotation.x)
@@ -179,7 +203,7 @@ export function computeShellScaleForM5Stack({
 
 export function computeShellPlacementFromBounds(
   bounds,
-  { scale = computeShellScaleForM5Stack(), rotationOffset = STACKCHAN_SHELL_STL.rotationOffset } = {}
+  { scale = computeShellScaleForM5Stack(), rotationOffset = STACKCHAN_SHELL_STL.rotationOffset, tuning = computeGeometryTuning() } = {}
 ) {
   const size = {
     x: bounds.max.x - bounds.min.x,
@@ -192,19 +216,21 @@ export function computeShellPlacementFromBounds(
     z: (bounds.min.z + bounds.max.z) / 2,
   }
   const rotatedCenter = rotatePoint({ x: center.x * scale, y: center.y * scale, z: center.z * scale }, rotationOffset)
+  const shellDepthAfterRotation = size.y * scale
 
   return {
     scale,
     position: {
-      x: cleanZero(-rotatedCenter.x),
-      y: cleanZero(-rotatedCenter.y),
-      z: cleanZero(-rotatedCenter.z),
+      x: cleanZero(-rotatedCenter.x + tuning.shellOffset.x),
+      y: cleanZero(-rotatedCenter.y + tuning.shellOffset.y),
+      z: cleanZero(-rotatedCenter.z + tuning.shellOffset.z),
     },
     rotation: {
       x: rotationOffset.x,
       y: rotationOffset.y,
       z: rotationOffset.z,
     },
+    frontZ: cleanZero(shellDepthAfterRotation / 2 + tuning.shellOffset.z),
     keepGeneratedFace: true,
   }
 }
@@ -222,11 +248,12 @@ export function computeFootPlacements({
   foot = STACKCHAN_FOOT_MM,
   gap = 2,
   yOffset = -2,
+  tuning = computeGeometryTuning(),
 } = {}) {
   const centerOffset = foot.width / 2 + gap / 2
-  const y = -body.height / 2 - foot.height / 2 + yOffset
-  const z = 0
-  return [-centerOffset, centerOffset].map((x) => ({ x, y, z }))
+  const y = -body.height / 2 - foot.height / 2 + yOffset + tuning.feetOffset.y
+  const z = tuning.feetOffset.z
+  return [-centerOffset, centerOffset].map((x) => ({ x: x + tuning.feetOffset.x, y, z }))
 }
 
 export function nextLookAroundPose(timeMs, { enabled = true } = {}) {

--- a/web/simulator/geometry.test.mjs
+++ b/web/simulator/geometry.test.mjs
@@ -11,6 +11,7 @@ import {
   computeFootPlacements,
   computeFaceLayerDepths,
   computeFaceModulePlacement,
+  computeGeometryTuning,
   computeScreenFrame,
   computeScreenPlane,
   computeShellScaleForM5Stack,
@@ -41,7 +42,7 @@ describe('Stack-chan simulator geometry', () => {
     assert.equal(feet.length, 2)
     assert.deepEqual(
       feet.map((foot) => foot.y),
-      [-33, -33]
+      [-37, -37]
     )
     assert.deepEqual(
       feet.map((foot) => foot.x),
@@ -58,6 +59,46 @@ describe('Stack-chan simulator geometry', () => {
     assert.equal(STACKCHAN_SIMULATOR_COLORS.feet, 0x8f949c)
     assert.equal(STACKCHAN_SIMULATOR_COLORS.m5stackSide, 0x8f949c)
     assert.equal(STACKCHAN_SIMULATOR_COLORS.m5stackFront, 0x2f343b)
+  })
+
+  it('derives inspectable tuning defaults for the shell gap and foot pose', () => {
+    const tuning = computeGeometryTuning()
+
+    assert.deepEqual(tuning.shellOffset, { x: 0, y: 0, z: -10 })
+    assert.deepEqual(tuning.feetOffset, { x: 0, y: -4, z: 0 })
+
+    const face = computeFaceModulePlacement({ tuning })
+    const shell = computeShellPlacementFromBounds(STACKCHAN_SHELL_STL.sourceBoundsMm, { tuning })
+    const feet = computeFootPlacements({ tuning })
+
+    assert.ok(face.shellFrontZ - shell.frontZ >= 9.9)
+    assert.ok(Math.abs(face.frontZ - 28.438372093023258) < 1e-9)
+    assert.deepEqual(
+      feet.map((foot) => foot.y),
+      [-37, -37]
+    )
+    assert.deepEqual(
+      feet.map((foot) => foot.z),
+      [0, 0]
+    )
+  })
+
+  it('clamps geometry tuning values to a safe visual range', () => {
+    assert.deepEqual(
+      computeGeometryTuning({ shellGap: '99', footHeight: '99', footForward: '-99' }),
+      {
+        shellOffset: { x: 0, y: 0, z: -12 },
+        feetOffset: { x: 0, y: 4, z: -8 },
+      }
+    )
+
+    assert.deepEqual(
+      computeGeometryTuning({ shellGap: '8', footHeight: '-2', footForward: '4' }),
+      {
+        shellOffset: { x: 0, y: 0, z: -8 },
+        feetOffset: { x: 0, y: -2, z: 4 },
+      }
+    )
   })
 
   it('creates a rounded-rectangle path bounded by the 54mm square', () => {
@@ -137,7 +178,7 @@ describe('Stack-chan simulator geometry', () => {
     assert.ok(Math.abs(placement.scale - 1.0465116279069768) < 1e-12)
     assert.ok(Math.abs(placement.position.x - 0) < 1e-9)
     assert.ok(Math.abs(placement.position.y - 0) < 1e-9)
-    assert.ok(Math.abs(placement.position.z - 21.191860465116278) < 1e-9)
+    assert.ok(Math.abs(placement.position.z - 11.191860465116278) < 1e-9)
     assert.deepEqual(placement.rotation, { x: -Math.PI / 2, y: 0, z: 0 })
     assert.equal(placement.keepGeneratedFace, true)
   })

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -22,6 +22,7 @@ import {
   computeFaceLayerDepths,
   computeFaceModulePlacement,
   computeFootPlacements,
+  computeGeometryTuning,
   computeScreenFrame,
   computeScreenPlane,
   computeShellPlacementFromBounds,
@@ -45,6 +46,7 @@ class StackchanScene {
     this.targetDriverRotation = { y: 0, p: 0, r: 0 }
     this.lastDriverUpdateMs = undefined
     this.torqueEnabled = true
+    this.geometryTuning = computeGeometryTuning()
     this.raycaster = new THREE.Raycaster()
     this.pointerNdc = new THREE.Vector2()
 
@@ -125,7 +127,9 @@ class StackchanScene {
       STACKCHAN_SHELL_STL.url,
       (geometry) => {
         geometry.computeVertexNormals()
-        const placement = computeShellPlacementFromBounds(STACKCHAN_SHELL_STL.sourceBoundsMm)
+        const placement = computeShellPlacementFromBounds(STACKCHAN_SHELL_STL.sourceBoundsMm, {
+          tuning: this.geometryTuning,
+        })
         this.shell = new THREE.Mesh(geometry, this.shellMaterial)
         this.shell.position.set(placement.position.x, placement.position.y, placement.position.z)
         this.shell.rotation.set(placement.rotation.x, placement.rotation.y, placement.rotation.z)
@@ -193,7 +197,7 @@ class StackchanScene {
     )
     const outlineGeometry = new THREE.EdgesGeometry(geometry, 24)
 
-    for (const placement of computeFootPlacements()) {
+    for (const placement of computeFootPlacements({ tuning: this.geometryTuning })) {
       const foot = new THREE.Mesh(geometry, this.footMaterial)
       foot.position.set(placement.x, placement.y, placement.z)
       this.feetGroup.add(foot)


### PR DESCRIPTION
## Summary
- Applies the final WASM simulator geometry tuning values: shell/M5Stack gap 10mm, foot height -4mm, foot forward/back 0mm
- Uses the fixed tuning in shell STL placement and foot placement
- Adds geometry tests for the tuned defaults and clamped override path

## Release impact
- patch: user-visible Web simulator geometry adjustment only

## Test Plan
- [x] `cd web && npm test`
- [x] `cd web && git diff --check`
- [x] Browser smoke via local tunnel confirmed the slider tuning UI is absent after the fixed values are applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added geometry tuning system enabling customization of shell gap, foot height, and forward offset to adjust shell and feet positioning parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->