### PR TITLE
fix: isolate WASM camera preview from real-device runtime

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install Moddable Linux tool dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libfreetype6-dev libglib2.0-dev libgtk-3-dev pkg-config
+        sudo apt-get install -y libasound2-dev libfreetype6-dev libglib2.0-dev libgtk-3-dev pkg-config xvfb
       shell: bash
     - name: Resolve Moddable cache key
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run firmware tests
         working-directory: ./firmware
         run: npm run test
+      - name: Smoke test Linux simulator startup
+        working-directory: ./firmware
+        run: source "$HOME/.local/share/xs-dev-export.sh" && npm run smoke:lin
       - name: Run web simulator tests
         working-directory: ./web
         run: npm test

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -15,6 +15,8 @@
     "test": "npm run test:unit",
     "test:unit": "rm -rf dist-tests && tsc --project tsconfig.test.json && node --test \"dist-tests/tests/unit/**/*.test.js\" \"dist-tests/stackchan/drivers/__tests__/**/*.test.js\"",
     "build": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target -t build \"$PWD/stackchan/manifest_local.json\"",
+    "build:lin": "mcconfig -d -m -p lin -t build \"$PWD/stackchan/manifest_local.json\"",
+    "smoke:lin": "bash scripts/smoke-lin.sh",
     "build:wasm": "mcconfig -d -m -p wasm -t build \"$PWD/stackchan/manifest_wasm.json\" && mkdir -p ../web/simulator && cp $MODDABLE/build/bin/wasm/debug/stackchan/mc.js $MODDABLE/build/bin/wasm/debug/stackchan/mc.wasm ../web/simulator/",
     "bundle": "mcbundle -d -m \"$PWD/stackchan/manifest.json\"",
     "deploy": "cross-env npm_config_target?=esp32/m5stack cross-env-shell mcconfig -d -m -p \\$npm_config_target -t deploy \"$PWD/stackchan/manifest_local.json\"",

--- a/firmware/scripts/smoke-lin.sh
+++ b/firmware/scripts/smoke-lin.sh
@@ -8,7 +8,16 @@ fi
 
 export PATH="$PWD/node_modules/.bin:$PATH"
 
+rm -rf "$MODDABLE/build/tmp/lin/mc/debug/stackchan" "$MODDABLE/build/bin/lin/mc/debug/stackchan"
 mcconfig -d -m -p lin -t build "$PWD/stackchan/manifest_local.json"
+
+build_dir="$MODDABLE/build/tmp/lin/mc/debug/stackchan"
+forbidden_imports=$(find "$build_dir" -path '*/tsc/*' -type f -name '*.js' -exec grep -nE 'runtime-bitmap-port|wasm-audio-bridge|wasm-camera-bridge' {} + || true)
+if [[ -n "$forbidden_imports" ]]; then
+  printf '%s\n' "$forbidden_imports"
+  echo "WASM-only native binding leaked into the Linux/default import graph" >&2
+  exit 1
+fi
 
 smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-10s}"
 set +e

--- a/firmware/scripts/smoke-lin.sh
+++ b/firmware/scripts/smoke-lin.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${MODDABLE:-}" ]]; then
+  echo "MODDABLE is not set" >&2
+  exit 1
+fi
+
+export PATH="$PWD/node_modules/.bin:$PATH"
+
+mcconfig -d -m -p lin -t build "$PWD/stackchan/manifest_local.json"
+
+smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-10s}"
+set +e
+timeout "$smoke_timeout" xvfb-run -a "$MODDABLE/build/bin/lin/release/mcsim" "$MODDABLE/build/bin/lin/mc/debug/stackchan/mc.so"
+status=$?
+set -e
+
+if [[ "$status" -eq 124 ]]; then
+  echo "mcsim stayed alive for $smoke_timeout; startup smoke passed"
+  exit 0
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  echo "mcsim exited before $smoke_timeout; treating as startup smoke failure" >&2
+else
+  echo "mcsim failed during startup smoke with exit code $status" >&2
+fi
+exit "$status"

--- a/firmware/stackchan/manifest_wasm.json
+++ b/firmware/stackchan/manifest_wasm.json
@@ -15,7 +15,7 @@
     "*": ["./touch", "./robot", "./main"],
     "camera": "./wasm/camera",
     "wasm-camera-bridge": "./wasm/camera-bridge",
-    "camera-preview": "./camera-preview",
+    "camera-preview": "./wasm/camera-preview",
     "camera-preview-utils": "./camera-preview-utils",
     "runtime-bitmap-port": "./runtime-bitmap-port",
     "wasm-audio-bridge": "./wasm/audio-bridge",

--- a/firmware/stackchan/wasm/camera-preview.ts
+++ b/firmware/stackchan/wasm/camera-preview.ts
@@ -1,12 +1,14 @@
-import type { CameraFrame } from './camera.js'
-import { sampleRgb565LeMosaic } from './camera-preview-utils.js'
+import type { CameraFrame } from '../camera.js'
+import { sampleRgb565LeMosaic } from '../camera-preview-utils.js'
 
-import { Container, Port, type Container as PiuContainer, type Port as PiuPort } from 'piu/MC'
+import Bitmap from 'commodetto/Bitmap'
+import { Container, type Container as PiuContainer, type Port as PiuPort } from 'piu/MC'
+import RuntimeBitmapPort from 'runtime-bitmap-port'
 
 export const CAMERA_PREVIEW_WIDTH = 200
 export const CAMERA_PREVIEW_HEIGHT = 120
 
-export type CameraPreviewRenderMode = 'mosaic'
+export type CameraPreviewRenderMode = 'runtime-bitmap-port' | 'mosaic'
 export type CameraPreviewOptions = {
   onRender?: (mode: CameraPreviewRenderMode) => void
   onDismiss?: () => void
@@ -17,13 +19,37 @@ const PREVIEW_TOP = 60
 const PREVIEW_BLOCK_SIZE = 48
 const PREVIEW_BACKGROUND = '#101010'
 
+type BitmapPort = PiuPort & {
+  drawBitmap?: (bitmap: Bitmap, x: number, y: number, sx?: number, sy?: number, sw?: number, sh?: number) => void
+}
+
 function piuColor(color: number): string {
   const hex = color.toString(16).padStart(6, '0')
   return `#${hex}`
 }
 
+function canDrawFrameAsBitmap(frame: CameraFrame): boolean {
+  return frame.imageType === 'rgb565le' && frame.buffer.byteLength >= frame.width * frame.height * 2
+}
+
+function drawRgb565Bitmap(port: BitmapPort, frame: CameraFrame): boolean {
+  if (!port.drawBitmap || !canDrawFrameAsBitmap(frame)) return false
+
+  const bitmap = new Bitmap(frame.width, frame.height, Bitmap.RGB565LE, frame.buffer, 0)
+  port.drawBitmap(
+    bitmap,
+    0,
+    0,
+    0,
+    0,
+    Math.min(frame.width, CAMERA_PREVIEW_WIDTH),
+    Math.min(frame.height, CAMERA_PREVIEW_HEIGHT),
+  )
+  return true
+}
+
 export function createCameraPreviewFace(frame: CameraFrame, options: CameraPreviewOptions = {}): PiuContainer {
-  const previewPort = new Port(
+  const previewPort = new RuntimeBitmapPort(
     { frame, options },
     {
       left: 0,
@@ -34,7 +60,7 @@ export function createCameraPreviewFace(frame: CameraFrame, options: CameraPrevi
       Behavior: class extends Behavior {
         frame: CameraFrame | null = null
         options: CameraPreviewOptions | null = null
-        didReportRenderMode = false
+        lastRenderMode: CameraPreviewRenderMode | null = null
 
         onCreate(_port: PiuPort, data: { frame: CameraFrame; options: CameraPreviewOptions }) {
           this.frame = data.frame
@@ -54,6 +80,11 @@ export function createCameraPreviewFace(frame: CameraFrame, options: CameraPrevi
           const frame = this.frame
           if (!frame) return
 
+          if (drawRgb565Bitmap(port as BitmapPort, frame)) {
+            this.reportRenderMode('runtime-bitmap-port')
+            return
+          }
+
           for (const block of sampleRgb565LeMosaic(frame, {
             width: CAMERA_PREVIEW_WIDTH,
             height: CAMERA_PREVIEW_HEIGHT,
@@ -61,13 +92,13 @@ export function createCameraPreviewFace(frame: CameraFrame, options: CameraPrevi
           })) {
             port.fillColor(piuColor(block.color), block.x, block.y, block.width, block.height)
           }
-          this.reportRenderMode()
+          this.reportRenderMode('mosaic')
         }
 
-        reportRenderMode() {
-          if (this.didReportRenderMode) return
-          this.didReportRenderMode = true
-          this.options?.onRender?.('mosaic')
+        reportRenderMode(mode: CameraPreviewRenderMode) {
+          if (this.lastRenderMode === mode) return
+          this.lastRenderMode = mode
+          this.options?.onRender?.(mode)
         }
       },
     },

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -150,11 +150,27 @@ test('WASM main path loads an installed MOD archive before falling back to the d
   assert.match(wasmBlock, /onLaunch = mod\.onLaunch \?\? onLaunch/)
 })
 
+test('real-device camera preview stays independent from the WASM-only RuntimeBitmapPort binding', () => {
+  const manifest = JSON.parse(readFileSync('stackchan/manifest.json', 'utf8'))
+  const previewSource = readFileSync('stackchan/camera-preview.ts', 'utf8')
+
+  assert.deepEqual(
+    manifest.modules['*'].filter((specifier: string) => specifier.includes('camera-preview')),
+    ['./camera-preview', './camera-preview-utils'],
+  )
+  assert.doesNotMatch(previewSource, /runtime-bitmap-port/)
+  assert.doesNotMatch(previewSource, /RuntimeBitmapPort/)
+  assert.match(previewSource, /new Port\(/)
+  assert.match(previewSource, /onRender\?: \(mode: CameraPreviewRenderMode\) => void/)
+  assert.match(previewSource, /this\.options\?\.onRender\?\.\('mosaic'\)/)
+})
+
 test('WASM camera preview uses a native RuntimeBitmapPort binding before falling back to mosaic', () => {
   const manifest = JSON.parse(readFileSync('stackchan/manifest_wasm.json', 'utf8'))
-  const previewSource = readFileSync('stackchan/camera-preview.ts', 'utf8')
+  const previewSource = readFileSync('stackchan/wasm/camera-preview.ts', 'utf8')
   const portSource = readFileSync('stackchan/runtime-bitmap-port.js', 'utf8')
 
+  assert.equal(manifest.modules['camera-preview'], './wasm/camera-preview')
   assert.equal(manifest.modules['runtime-bitmap-port'], './runtime-bitmap-port')
   assert.match(portSource, /drawBitmap\(bitmap, x, y, sx = 0, sy = 0, sw = bitmap\.width, sh = bitmap\.height\)/)
   assert.match(portSource, /xs_stackchan_runtime_bitmap_port_draw/)


### PR DESCRIPTION
## Summary

- Isolate the WASM-only `RuntimeBitmapPort` camera-preview path from the real-device/default import graph.
- Restore the real-device/default Camera drawer action to a portable Piu `Port` RGB565 mosaic preview fallback.
- Add a Linux simulator smoke test that builds `manifest_local.json`, rejects WASM-only native binding leaks in the generated default import graph, and starts `mcsim` under `xvfb`.

## Why

The default `camera-preview` module imported `runtime-bitmap-port`, but that binding is WASM-only. That can break real-device/default runtime behavior when the Camera drawer action or default mod pulls `camera-preview` into the import graph.

## RED check

I verified the new smoke check fails against the pre-fix base (`ae031ec`) by running the smoke script from this branch in a detached worktree:

```text
pre_fix_smoke_exit=1
.../stackchan/camera-preview.js:3:import RuntimeBitmapPort from 'runtime-bitmap-port';
WASM-only native binding leaked into the Linux/default import graph
```

A plain `mcsim` startup alone stayed alive on the pre-fix state, so the smoke test now includes the generated Linux/default import-graph leak check before launching `mcsim`.

## Test plan

- [x] `npm test` — pass 52 / fail 0
- [x] `STACKCHAN_LIN_SMOKE_TIMEOUT=5s npm run smoke:lin` — Linux/default import graph clean and `mcsim` stayed alive
- [x] `npm run build:wasm`
- [x] `npm run format && npm run lint` — exit 0; existing warnings remain
- [ ] Real-device flash / Camera button verification

## Release impact

patch — fixes real-device/default Camera drawer behavior regression risk and adds CI coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated smoke test for Linux simulator startup in CI pipeline

* **Chores**
  * Extended Linux system dependencies to include audio and graphics libraries
  * Added new build and test scripts for Linux simulation environment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->