### PR TITLE
ci: harden real-device startup smoke

### DIFF
--- a/firmware/scripts/smoke-lin.sh
+++ b/firmware/scripts/smoke-lin.sh
@@ -8,10 +8,26 @@ fi
 
 export PATH="$PWD/node_modules/.bin:$PATH"
 
-rm -rf "$MODDABLE/build/tmp/lin/mc/debug/stackchan" "$MODDABLE/build/bin/lin/mc/debug/stackchan"
-mcconfig -d -m -p lin -t build "$PWD/stackchan/manifest_local.json"
+platform="${STACKCHAN_LIN_SMOKE_PLATFORM:-lin/m5stack}"
+platform_path="${platform//\//\/}"
+smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-10s}"
+xsbug_port="${STACKCHAN_LIN_XSBUG_PORT:-5002}"
+xsbug_log="$(mktemp "${TMPDIR:-/tmp}/stackchan-lin-xsbug-log.XXXXXX")"
+server_log="$(mktemp "${TMPDIR:-/tmp}/stackchan-lin-xsbug-server.XXXXXX")"
+server_pid=""
 
-build_dir="$MODDABLE/build/tmp/lin/mc/debug/stackchan"
+cleanup() {
+  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+rm -rf "$MODDABLE/build/tmp/$platform_path/debug/stackchan" "$MODDABLE/build/bin/$platform_path/debug/stackchan"
+mcconfig -dl -m -p "$platform" -t build "$PWD/stackchan/manifest_local.json"
+
+build_dir="$MODDABLE/build/tmp/$platform_path/debug/stackchan"
 forbidden_imports=$(find "$build_dir" -path '*/tsc/*' -type f -name '*.js' -exec grep -nE 'runtime-bitmap-port|wasm-audio-bridge|wasm-camera-bridge' {} + || true)
 if [[ -n "$forbidden_imports" ]]; then
   printf '%s\n' "$forbidden_imports"
@@ -19,20 +35,54 @@ if [[ -n "$forbidden_imports" ]]; then
   exit 1
 fi
 
-smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-10s}"
+XSBUG_PORT="$xsbug_port" XSBUG_LOG_PATH="$xsbug_log" node ./scripts/xsbug-log-smoke-server.js >"$server_log" 2>&1 &
+server_pid=$!
+
+for _ in {1..50}; do
+  if grep -q 'xsbug smoke log server listening' "$server_log" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    cat "$server_log" >&2 || true
+    echo "xsbug smoke log server exited before startup" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+if ! grep -q 'xsbug smoke log server listening' "$server_log" 2>/dev/null; then
+  cat "$server_log" >&2 || true
+  echo "xsbug smoke log server did not become ready" >&2
+  exit 1
+fi
+
 set +e
-timeout "$smoke_timeout" xvfb-run -a "$MODDABLE/build/bin/lin/release/mcsim" "$MODDABLE/build/bin/lin/mc/debug/stackchan/mc.so"
+timeout "$smoke_timeout" xvfb-run -a "$MODDABLE/build/bin/lin/release/mcsim" "$MODDABLE/build/bin/$platform_path/debug/stackchan/mc.so"
 status=$?
 set -e
 
-if [[ "$status" -eq 124 ]]; then
-  echo "mcsim stayed alive for $smoke_timeout; startup smoke passed"
-  exit 0
+if [[ "$status" -ne 124 ]]; then
+  cat "$xsbug_log" >&2 || true
+  if [[ "$status" -eq 0 ]]; then
+    echo "mcsim exited before $smoke_timeout; treating as startup smoke failure" >&2
+  else
+    echo "mcsim failed during startup smoke with exit code $status" >&2
+  fi
+  exit "$status"
 fi
 
-if [[ "$status" -eq 0 ]]; then
-  echo "mcsim exited before $smoke_timeout; treating as startup smoke failure" >&2
-else
-  echo "mcsim failed during startup smoke with exit code $status" >&2
+if grep -E 'XS abort|# exception|stack overflow|module not found|Cannot find module|unhandled exception|throw!' "$xsbug_log" >&2; then
+  echo "mcsim runtime log contains startup failure markers" >&2
+  echo "xsbug log: $xsbug_log" >&2
+  exit 1
 fi
-exit "$status"
+
+if ! grep -q '\[main\] onRobotCreated complete' "$xsbug_log"; then
+  cat "$xsbug_log" >&2 || true
+  echo "mcsim startup log did not reach [main] onRobotCreated complete" >&2
+  echo "xsbug log: $xsbug_log" >&2
+  exit 1
+fi
+
+echo "mcsim stayed alive for $smoke_timeout; startup log reached onRobotCreated without runtime errors"
+echo "xsbug log: $xsbug_log"

--- a/firmware/scripts/smoke-lin.sh
+++ b/firmware/scripts/smoke-lin.sh
@@ -11,6 +11,7 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 platform="${STACKCHAN_LIN_SMOKE_PLATFORM:-lin/m5stack}"
 platform_path="${platform//\//\/}"
 smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-10s}"
+xsbug_host="${STACKCHAN_LIN_XSBUG_HOST:-127.0.0.1}"
 xsbug_port="${STACKCHAN_LIN_XSBUG_PORT:-5002}"
 xsbug_log="$(mktemp "${TMPDIR:-/tmp}/stackchan-lin-xsbug-log.XXXXXX")"
 server_log="$(mktemp "${TMPDIR:-/tmp}/stackchan-lin-xsbug-server.XXXXXX")"
@@ -25,7 +26,7 @@ cleanup() {
 trap cleanup EXIT
 
 rm -rf "$MODDABLE/build/tmp/$platform_path/debug/stackchan" "$MODDABLE/build/bin/$platform_path/debug/stackchan"
-mcconfig -dl -m -p "$platform" -t build "$PWD/stackchan/manifest_local.json"
+mcconfig -dl -x "$xsbug_host:$xsbug_port" -m -p "$platform" -t build "$PWD/stackchan/manifest_local.json"
 
 build_dir="$MODDABLE/build/tmp/$platform_path/debug/stackchan"
 forbidden_imports=$(find "$build_dir" -path '*/tsc/*' -type f -name '*.js' -exec grep -nE 'runtime-bitmap-port|wasm-audio-bridge|wasm-camera-bridge' {} + || true)
@@ -35,7 +36,7 @@ if [[ -n "$forbidden_imports" ]]; then
   exit 1
 fi
 
-XSBUG_PORT="$xsbug_port" XSBUG_LOG_PATH="$xsbug_log" node ./scripts/xsbug-log-smoke-server.js >"$server_log" 2>&1 &
+XSBUG_HOST="$xsbug_host" XSBUG_PORT="$xsbug_port" XSBUG_LOG_PATH="$xsbug_log" node ./scripts/xsbug-log-smoke-server.js >"$server_log" 2>&1 &
 server_pid=$!
 
 for _ in {1..50}; do
@@ -57,7 +58,7 @@ if ! grep -q 'xsbug smoke log server listening' "$server_log" 2>/dev/null; then
 fi
 
 set +e
-timeout "$smoke_timeout" xvfb-run -a "$MODDABLE/build/bin/lin/release/mcsim" "$MODDABLE/build/bin/$platform_path/debug/stackchan/mc.so"
+timeout "$smoke_timeout" env XSBUG_HOST="$xsbug_host" XSBUG_PORT="$xsbug_port" xvfb-run -a "$MODDABLE/build/bin/lin/release/mcsim" "$MODDABLE/build/bin/$platform_path/debug/stackchan/mc.so"
 status=$?
 set -e
 
@@ -65,10 +66,11 @@ if [[ "$status" -ne 124 ]]; then
   cat "$xsbug_log" >&2 || true
   if [[ "$status" -eq 0 ]]; then
     echo "mcsim exited before $smoke_timeout; treating as startup smoke failure" >&2
+    exit 1
   else
     echo "mcsim failed during startup smoke with exit code $status" >&2
+    exit "$status"
   fi
-  exit "$status"
 fi
 
 if grep -E 'XS abort|# exception|stack overflow|module not found|Cannot find module|unhandled exception|throw!' "$xsbug_log" >&2; then

--- a/firmware/scripts/xsbug-log-smoke-server.js
+++ b/firmware/scripts/xsbug-log-smoke-server.js
@@ -19,14 +19,19 @@ const append = (message) => {
 
 const server = createServer((socket) => {
   socket.setEncoding('utf8')
+  let promptBuffer = ''
   socket.on('data', (chunk) => {
     append(chunk)
+    promptBuffer += chunk
 
     // The debug Linux simulator pauses at startup and on breakpoints until the
     // debugger sends <go/>. Keep the smoke non-interactive so CI can inspect
     // the runtime log and continue through startup milestones.
-    if (/<(login|break|bubble)\b/.test(chunk)) {
+    if (/<(login|break|bubble)\b/.test(promptBuffer)) {
       socket.write('\r\n<go/>\r\n')
+      promptBuffer = ''
+    } else {
+      promptBuffer = promptBuffer.slice(-128)
     }
   })
   socket.on('error', (error) => {

--- a/firmware/scripts/xsbug-log-smoke-server.js
+++ b/firmware/scripts/xsbug-log-smoke-server.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { createServer } from 'node:net'
+import { appendFileSync, writeFileSync } from 'node:fs'
+
+const port = Number.parseInt(process.env.XSBUG_PORT ?? '5002', 10)
+const host = process.env.XSBUG_HOST ?? '127.0.0.1'
+const logPath = process.env.XSBUG_LOG_PATH
+
+if (!logPath) {
+  console.error('XSBUG_LOG_PATH is required')
+  process.exit(1)
+}
+
+writeFileSync(logPath, '')
+
+const append = (message) => {
+  appendFileSync(logPath, message)
+}
+
+const server = createServer((socket) => {
+  socket.setEncoding('utf8')
+  socket.on('data', (chunk) => {
+    append(chunk)
+
+    // The debug Linux simulator pauses at startup and on breakpoints until the
+    // debugger sends <go/>. Keep the smoke non-interactive so CI can inspect
+    // the runtime log and continue through startup milestones.
+    if (/<(login|break|bubble)\b/.test(chunk)) {
+      socket.write('\r\n<go/>\r\n')
+    }
+  })
+  socket.on('error', (error) => {
+    append(`\n[xsbug-smoke-server socket error] ${error.stack ?? error.message}\n`)
+  })
+})
+
+server.on('error', (error) => {
+  console.error(error.stack ?? error.message)
+  process.exit(1)
+})
+
+server.listen(port, host, () => {
+  console.log(`xsbug smoke log server listening on ${host}:${port}`)
+})

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -190,6 +190,9 @@
       }
     },
     "lin/m5stack": {
+      "creation": {
+        "stack": 1024
+      },
       "config": {
         "driver": {
           "type": "none"


### PR DESCRIPTION
## Summary
- harden `npm run smoke:lin` so it builds the real-device-like `lin/m5stack` platform instead of plain `lin`
- capture xsbug runtime logs in CI and fail on startup failure markers such as `XS abort`, `# exception`, `stack overflow`, and module resolution errors
- require the default firmware startup to reach `[main] onRobotCreated complete`
- give the Linux/m5stack simulator target a larger stack so the smoke covers the default runtime path without the simulator-only stack overflow

## Test Plan
- [x] `cd firmware && npm test`
- [x] `cd firmware && STACKCHAN_LIN_SMOKE_TIMEOUT=5s npm run smoke:lin`
- [x] `cd web && npm test`

## Release Impact
none — CI/test hardening only; no user-visible firmware behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved smoke-test infrastructure for Linux simulator builds: parameterizable target platform, background log capture, stricter timeout handling, runtime-log validations for startup/runtime failures, and more reliable cleanup.
  * Added explicit stack size configuration for a Linux platform variant to ensure consistent resource allocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->