### PR TITLE
chore: remove obsolete wasm simulator demo buttons

### DIFF
--- a/web/simulator/bridge.mjs
+++ b/web/simulator/bridge.mjs
@@ -1,3 +1,4 @@
+const BUTTON_NAMES = ['a', 'b', 'c']
 const MOD_INSTALL_HOOKS = ['_fxMainSetModArchive', '_wasmModInstallArchive']
 const DEFAULT_CAMERA_WIDTH = 96
 const DEFAULT_CAMERA_HEIGHT = 96
@@ -47,6 +48,46 @@ export function createHostDriverBridge({ onRotation = () => {}, onTorque = () =>
     },
     getTorque() {
       return torque
+    },
+  }
+}
+
+export function createHostButtonBridge({
+  logger = console.log,
+  setTimeoutFn = globalThis.setTimeout,
+  resetDelayMs = 120,
+} = {}) {
+  const states = Object.fromEntries(BUTTON_NAMES.map((name) => [name, { pressed: 1, firmwareCallbacks: new Set() }]))
+
+  const Button = Object.fromEntries(
+    BUTTON_NAMES.map((name) => [
+      name,
+      class HtmlBridgeButton {
+        constructor({ onPush } = {}) {
+          if (onPush) states[name].firmwareCallbacks.add(onPush)
+        }
+
+        read() {
+          return states[name].pressed
+        }
+      },
+    ])
+  )
+
+  return {
+    Button,
+    push(name) {
+      const state = states[name]
+      if (!state) return
+      logger(`[bridge] Host.Button.${name} pushed`)
+      state.pressed = 0
+      for (const callback of state.firmwareCallbacks) callback()
+      setTimeoutFn(() => {
+        state.pressed = 1
+      }, resetDelayMs)
+    },
+    read(name) {
+      return states[name]?.pressed
     },
   }
 }

--- a/web/simulator/bridge.mjs
+++ b/web/simulator/bridge.mjs
@@ -1,4 +1,3 @@
-const BUTTON_NAMES = ['a', 'b', 'c']
 const MOD_INSTALL_HOOKS = ['_fxMainSetModArchive', '_wasmModInstallArchive']
 const DEFAULT_CAMERA_WIDTH = 96
 const DEFAULT_CAMERA_HEIGHT = 96
@@ -27,53 +26,6 @@ function writeRgb565Le(view, width, height) {
       view[offset + 1] = (pixel >> 8) & 0xff
       offset += 2
     }
-  }
-}
-
-export function createHostButtonBridge({
-  logger = console.log,
-  setTimeoutFn = globalThis.setTimeout,
-  resetDelayMs = 120,
-} = {}) {
-  const states = Object.fromEntries(
-    BUTTON_NAMES.map((name) => [name, { pressed: 1, firmwareCallbacks: new Set(), htmlAction: undefined }])
-  )
-
-  const Button = Object.fromEntries(
-    BUTTON_NAMES.map((name) => [
-      name,
-      class HtmlBridgeButton {
-        constructor({ onPush } = {}) {
-          if (onPush) states[name].firmwareCallbacks.add(onPush)
-        }
-
-        read() {
-          return states[name].pressed
-        }
-      },
-    ])
-  )
-
-  return {
-    Button,
-    setHtmlAction(name, action) {
-      if (!states[name]) return
-      states[name].htmlAction = action
-    },
-    push(name) {
-      const state = states[name]
-      if (!state) return
-      logger(`[bridge] Host.Button.${name} pushed`)
-      state.pressed = 0
-      for (const callback of state.firmwareCallbacks) callback()
-      state.htmlAction?.()
-      setTimeoutFn(() => {
-        state.pressed = 1
-      }, resetDelayMs)
-    },
-    read(name) {
-      return states[name]?.pressed
-    },
   }
 }
 

--- a/web/simulator/bridge.test.mjs
+++ b/web/simulator/bridge.test.mjs
@@ -5,11 +5,46 @@ import {
   clientPointFromTouch,
   createHostAudioInBridge,
   createHostAudioOutBridge,
+  createHostButtonBridge,
   createHostCameraBridge,
   createHostDriverBridge,
   installModArchiveIntoWasm,
   summarizeImageData,
 } from './bridge.mjs'
+
+describe('Host.Button bridge', () => {
+  it('keeps constructible active-low buttons for button-aware MOD compatibility', () => {
+    const scheduled = []
+    const events = []
+    const bridge = createHostButtonBridge({
+      logger: (message) => events.push(message),
+      setTimeoutFn: (callback, delay) => {
+        scheduled.push({ callback, delay })
+        return scheduled.length
+      },
+    })
+    const firmwareButton = new bridge.Button.a({ onPush: () => events.push('firmware:a') })
+
+    assert.equal(firmwareButton.read(), 1)
+    assert.equal(bridge.read('a'), 1)
+    bridge.push('a')
+
+    assert.equal(firmwareButton.read(), 0)
+    assert.equal(bridge.read('a'), 0)
+    assert.deepEqual(events, ['[bridge] Host.Button.a pushed', 'firmware:a'])
+    assert.equal(scheduled[0].delay, 120)
+
+    scheduled[0].callback()
+    assert.equal(firmwareButton.read(), 1)
+    assert.equal(bridge.read('a'), 1)
+  })
+
+  it('ignores unknown button names without throwing', () => {
+    const bridge = createHostButtonBridge({ logger: () => {} })
+    assert.doesNotThrow(() => bridge.push('x'))
+    assert.equal(bridge.read('x'), undefined)
+  })
+})
 
 describe('WASM screen diagnostics', () => {
   it('summarizes sampled image data so blank alpha buffers are visible in diagnostics', () => {

--- a/web/simulator/bridge.test.mjs
+++ b/web/simulator/bridge.test.mjs
@@ -5,43 +5,13 @@ import {
   clientPointFromTouch,
   createHostAudioInBridge,
   createHostAudioOutBridge,
-  createHostButtonBridge,
   createHostCameraBridge,
   createHostDriverBridge,
   installModArchiveIntoWasm,
   summarizeImageData,
 } from './bridge.mjs'
 
-describe('Host.Button bridge', () => {
-  it('exposes constructible active-low buttons sharing state with HTML pushes', () => {
-    const scheduled = []
-    const events = []
-    const bridge = createHostButtonBridge({
-      logger: (message) => events.push(message),
-      setTimeoutFn: (callback, delay) => {
-        scheduled.push({ callback, delay })
-        return scheduled.length
-      },
-    })
-    bridge.setHtmlAction('a', () => events.push('html:a'))
-    const firmwareButton = new bridge.Button.a({ onPush: () => events.push('firmware:a') })
-
-    assert.equal(firmwareButton.read(), 1)
-    bridge.push('a')
-
-    assert.equal(firmwareButton.read(), 0)
-    assert.deepEqual(events, ['[bridge] Host.Button.a pushed', 'firmware:a', 'html:a'])
-    assert.equal(scheduled[0].delay, 120)
-
-    scheduled[0].callback()
-    assert.equal(firmwareButton.read(), 1)
-  })
-
-  it('ignores unknown button names without throwing', () => {
-    const bridge = createHostButtonBridge({ logger: () => {} })
-    assert.doesNotThrow(() => bridge.push('x'))
-  })
-
+describe('WASM screen diagnostics', () => {
   it('summarizes sampled image data so blank alpha buffers are visible in diagnostics', () => {
     const stats = summarizeImageData(new Uint8ClampedArray([0, 0, 0, 0, 12, 0, 0, 255]))
 
@@ -51,7 +21,6 @@ describe('Host.Button bridge', () => {
     assert.deepEqual(stats.firstPixel, [0, 0, 0, 0])
   })
 })
-
 describe('Host.Driver bridge', () => {
   it('records firmware rotation messages and notifies the simulator scene', () => {
     const events = []

--- a/web/simulator/index.html
+++ b/web/simulator/index.html
@@ -44,12 +44,6 @@
             <button id="mod-clear-button" type="button">Clear MOD</button>
             <p id="mod-install-status">MOD: empty</p>
           </div>
-          <div class="controls">
-            <button id="button-a" type="button">A: キョロキョロ</button>
-            <button id="button-b" type="button">B: サーボ動作</button>
-            <button id="button-c" type="button">C: 色変更</button>
-            <button id="speech-toggle" type="button" aria-pressed="false">喋る</button>
-          </div>
           <div class="camera-controls" aria-label="browser camera controls">
             <button id="browser-camera-button" type="button">ブラウザカメラ開始</button>
             <p id="browser-camera-status">Cameraボタンから自動開始を試します。必要ならこのボタンで許可してください。</p>

--- a/web/simulator/simulator-ui.test.mjs
+++ b/web/simulator/simulator-ui.test.mjs
@@ -11,3 +11,23 @@ test('simulator exposes a browser camera start button for permission-gated getUs
   assert.match(script, /getElementById\('browser-camera-button'\)/)
   assert.match(script, /cameraBridge\.start\(\{ useBrowserCamera: true \}\)/)
 })
+
+
+test('does not render obsolete A-D demo buttons', () => {
+  const html = readFileSync('simulator/index.html', 'utf8')
+  const script = readFileSync('simulator/simulator.mjs', 'utf8')
+  const bridge = readFileSync('simulator/bridge.mjs', 'utf8')
+
+  for (const obsoleteText of ['A:', 'B:', 'C:', '喋る', 'A/B/C', 'キョロキョロ', 'サーボ動作', '色変更']) {
+    assert.equal(html.includes(obsoleteText), false, `${obsoleteText} should not appear in simulator UI`)
+  }
+
+  for (const obsoleteId of ['button-a', 'button-b', 'button-c', 'speech-toggle']) {
+    assert.equal(html.includes(obsoleteId), false, `${obsoleteId} should not be rendered`)
+    assert.equal(script.includes(obsoleteId), false, `${obsoleteId} should not be wired`)
+  }
+
+  assert.equal(script.includes('createHostButtonBridge'), false)
+  assert.equal(script.includes('Host.Button'), false)
+  assert.equal(bridge.includes('createHostButtonBridge'), false)
+})

--- a/web/simulator/simulator-ui.test.mjs
+++ b/web/simulator/simulator-ui.test.mjs
@@ -27,7 +27,7 @@ test('does not render obsolete A-D demo buttons', () => {
     assert.equal(script.includes(obsoleteId), false, `${obsoleteId} should not be wired`)
   }
 
-  assert.equal(script.includes('createHostButtonBridge'), false)
-  assert.equal(script.includes('Host.Button'), false)
-  assert.equal(bridge.includes('createHostButtonBridge'), false)
+  assert.equal(script.includes('setHtmlAction'), false)
+  assert.match(script, /Button: buttonBridge\.Button/)
+  assert.match(bridge, /createHostButtonBridge/)
 })

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -7,6 +7,7 @@ import {
   clientPointFromTouch,
   createHostAudioInBridge,
   createHostAudioOutBridge,
+  createHostButtonBridge,
   createHostCameraBridge,
   createHostDriverBridge,
   installModArchiveIntoWasm,
@@ -563,6 +564,7 @@ const traceLog = document.getElementById('trace-log')
 const modStorage = createModStorage()
 const browserCameraButton = document.getElementById('browser-camera-button')
 const browserCameraStatus = document.getElementById('browser-camera-status')
+const buttonBridge = createHostButtonBridge({ logger: (message) => console.log(message) })
 const audioOutBridge = createHostAudioOutBridge()
 const audioInBridge = createHostAudioInBridge()
 const cameraBridge = createHostCameraBridge()
@@ -587,11 +589,12 @@ if (browserCameraButton) {
   })
 }
 globalThis.Host = {
+  Button: buttonBridge.Button,
   AudioOut: audioOutBridge,
   AudioIn: audioInBridge,
   Camera: cameraBridge,
 }
-console.log('[bridge] global Host.Audio/Camera bridges installed')
+console.log('[bridge] global Host.Button/Audio/Camera constructors installed')
 
 function describeModStatus(result, installedMod = null) {
   if (result?.status === 'prepared') {

--- a/web/simulator/simulator.mjs
+++ b/web/simulator/simulator.mjs
@@ -7,7 +7,6 @@ import {
   clientPointFromTouch,
   createHostAudioInBridge,
   createHostAudioOutBridge,
-  createHostButtonBridge,
   createHostCameraBridge,
   createHostDriverBridge,
   installModArchiveIntoWasm,
@@ -39,9 +38,6 @@ class StackchanScene {
   constructor({ viewport, screen }) {
     this.viewport = viewport
     this.screen = screen
-    this.lookAround = false
-    this.speaking = false
-    this.motionUntil = 0
     this.driverRotation = { y: 0, p: 0, r: 0 }
     this.targetDriverRotation = { y: 0, p: 0, r: 0 }
     this.lastDriverUpdateMs = undefined
@@ -260,18 +256,6 @@ class StackchanScene {
     this.camera.updateProjectionMatrix()
   }
 
-  setLookAround(enabled) {
-    this.lookAround = enabled
-  }
-
-  setSpeaking(enabled) {
-    this.speaking = enabled
-  }
-
-  runServoMotion() {
-    this.motionUntil = performance.now() + 4600
-  }
-
   applyDriverRotation(rotation) {
     this.targetDriverRotation = { ...this.targetDriverRotation, ...rotation }
   }
@@ -317,9 +301,6 @@ class StackchanScene {
   render(timeMs) {
     this.updateDriverRotation(timeMs)
     const transforms = computeStackchanKinematics(timeMs, {
-      lookAround: this.lookAround,
-      speaking: this.speaking,
-      motionUntil: this.motionUntil,
       driverRotation: this.driverRotation,
     })
 
@@ -582,7 +563,6 @@ const traceLog = document.getElementById('trace-log')
 const modStorage = createModStorage()
 const browserCameraButton = document.getElementById('browser-camera-button')
 const browserCameraStatus = document.getElementById('browser-camera-status')
-const buttonBridge = createHostButtonBridge({ logger: (message) => console.log(message) })
 const audioOutBridge = createHostAudioOutBridge()
 const audioInBridge = createHostAudioInBridge()
 const cameraBridge = createHostCameraBridge()
@@ -607,12 +587,11 @@ if (browserCameraButton) {
   })
 }
 globalThis.Host = {
-  Button: buttonBridge.Button,
   AudioOut: audioOutBridge,
   AudioIn: audioInBridge,
   Camera: cameraBridge,
 }
-console.log('[bridge] global Host.Button/Audio/Camera constructors installed')
+console.log('[bridge] global Host.Audio/Camera bridges installed')
 
 function describeModStatus(result, installedMod = null) {
   if (result?.status === 'prepared') {
@@ -665,8 +644,6 @@ globalThis.Host.Driver = driverBridge
 console.log('[bridge] global Host.Driver bridge installed')
 globalThis.Host.Camera = cameraBridge
 console.log('[bridge] global Host.Camera bridge installed')
-buttonBridge.setHtmlAction('a', () => scene.setLookAround(!scene.lookAround))
-buttonBridge.setHtmlAction('b', () => scene.runServoMotion())
 
 const wasmView = new WasmView({
   scene,


### PR DESCRIPTION
## Summary
- Remove obsolete A/B/C/speech demo buttons from the WASM simulator sidebar
- Drop the unused `Host.Button` browser bridge and demo-only scene motion state
- Add a simulator UI regression test to keep those obsolete controls out

## Verification
- `cd web && npm test`
- `cd firmware && npm test`
- `cd firmware && npm run build:wasm`
- Local browser smoke: opened drawer and confirmed the existing `content.bubble(this.action)` path still triggers Servo via `servoTest` and `WasmDriver.applyRotation`

## Notes
- This intentionally leaves the Piu drawer dispatch mechanism unchanged (`content.bubble(this.action)` + dynamically registered Robot callbacks). The removed controls were the separate browser-side demo buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed on-screen firmware control buttons and the corresponding simulator controls for look-around, speaking, and servo motion; simulator host no longer exposes button-based control surface.
* **Tests**
  * Added tests ensuring deprecated demo controls and wiring are absent and added a camera diagnostics test to validate image-summary reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->