### PR TITLE
fix: add M5StackChan CoreS3 creation heap settings

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -142,6 +142,24 @@
         "virtualButton": false
       }
     },
+    "esp32/m5stackchan_cores3": {
+      "creation": {
+        "static": 0,
+        "chunk": {
+          "initial": 262144,
+          "incremental": 0
+        },
+        "heap": {
+          "initial": 4096,
+          "incremental": 256
+        },
+        "stack": 512,
+        "keys": {
+          "initial": 32,
+          "incremental": 32
+        }
+      }
+    },
     "esp32/m5atom_s3": {
       "config": {
         "renderer": {

--- a/firmware/tests/unit/platform-manifest.test.ts
+++ b/firmware/tests/unit/platform-manifest.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, test } from 'node:test'
+
+const stackchanManifest = JSON.parse(readFileSync('stackchan/manifest.json', 'utf8'))
+
+describe('Stack-chan platform manifest', () => {
+  test('gives M5StackChan CoreS3 the same expandable XS creation heap as CoreS3', () => {
+    const coreS3Creation = stackchanManifest.platforms['esp32/m5stack_cores3'].creation
+    const m5StackChanCoreS3Creation = stackchanManifest.platforms['esp32/m5stackchan_cores3']?.creation
+
+    assert.deepEqual(m5StackChanCoreS3Creation, coreS3Creation)
+    assert.equal(m5StackChanCoreS3Creation.heap.incremental, 256)
+  })
+})


### PR DESCRIPTION
## Summary
- Add explicit CoreS3-equivalent XS `creation` settings for `esp32/m5stackchan_cores3`
- Add a unit regression test that keeps the M5StackChan CoreS3 creation heap aligned with the normal CoreS3 target

## Background
M5StackChan CoreS3 builds were using the external subplatform name `m5stackchan_cores3`, so the existing `esp32/m5stack_cores3` `creation` override did not apply. The generated XS heap therefore had `incrementalHeapCount=0`, causing `# Slot allocation: failed in fixed size heap` / `XS abort: memory full` during startup after `[main] robot created`.

## Verification
- Confirmed the new unit test fails before the manifest fix because `platforms["esp32/m5stackchan_cores3"].creation` is missing
- `npm run format:fix`
- `npm run lint && npm run test:unit`
  - `lint` exits successfully, with existing warnings unrelated to this change
  - `test:unit`: 53 tests passed
- `npm_config_target='esp32:./platforms/m5stackchan_cores3' npm run build`
- Confirmed generated `mc.xs.c` now has:
  - `initialChunkSize: 262144`
  - `initialHeapCount: 4096`
  - `incrementalHeapCount: 256`

## Release impact
patch — fixes M5StackChan CoreS3 runtime startup failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added memory allocation configuration parameters for M5StackChan CoreS3 platform support.

* **Tests**
  * Added unit tests to validate platform memory configuration values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->