### PR TITLE
fix: resolve WASM camera preview import

### DIFF
--- a/firmware/stackchan/wasm/camera-preview.ts
+++ b/firmware/stackchan/wasm/camera-preview.ts
@@ -1,5 +1,5 @@
 import type { CameraFrame } from '../camera.js'
-import { sampleRgb565LeMosaic } from '../camera-preview-utils.js'
+import { sampleRgb565LeMosaic } from 'camera-preview-utils'
 
 import Bitmap from 'commodetto/Bitmap'
 import { Container, type Container as PiuContainer, type Port as PiuPort } from 'piu/MC'

--- a/firmware/tests/unit/wasm-stubs.test.ts
+++ b/firmware/tests/unit/wasm-stubs.test.ts
@@ -175,6 +175,8 @@ test('WASM camera preview uses a native RuntimeBitmapPort binding before falling
   assert.match(portSource, /drawBitmap\(bitmap, x, y, sx = 0, sy = 0, sw = bitmap\.width, sh = bitmap\.height\)/)
   assert.match(portSource, /xs_stackchan_runtime_bitmap_port_draw/)
   assert.match(previewSource, /import RuntimeBitmapPort from 'runtime-bitmap-port'/)
+  assert.match(previewSource, /from 'camera-preview-utils'/)
+  assert.doesNotMatch(previewSource, /^import (?!type).*from '\.\.\//m)
   assert.match(previewSource, /new RuntimeBitmapPort\(/)
   assert.match(previewSource, /reportRenderMode\('runtime-bitmap-port'\)/)
   assert.doesNotMatch(previewSource, /ENABLE_RUNTIME_TEXTURE_PREVIEW/)


### PR DESCRIPTION
## Summary
- fix the WASM camera preview runtime import so it resolves through the manifest module alias
- add a unit guard to keep runtime WASM camera-preview imports from using parent-relative specifiers

## Root cause
PR #453 changed the WASM manifest to load `./wasm/camera-preview`, but that module imported the shared mosaic helper as `../camera-preview-utils.js`. The specifier remained in `mc.wasm` and the deployed simulator aborted during XS module resolution before the firmware main path completed.

## Verification
- Reproduced failure on deployed `dev/v1.0` simulator: `# exception: throw!` / `XS abort: unhandled exception`, blank canvas
- Compared CI artifacts: #452 artifact starts normally; #453 artifact aborts in the same browser smoke
- RED before fix: `npm run test:unit -- --test-name-pattern "WASM camera preview uses"` failed on the new import assertion
- PASS after fix: `npm run test:unit -- --test-name-pattern "WASM camera preview uses"`
- PASS after fix: `npm run test:unit`
- PASS after fix: `npm run build:wasm`
- Browser smoke against local build: trace reaches `[main] wasm path complete`, canvas has non-zero pixels (`nonZeroAlpha: 76800`, `nonZeroRgb: 1152`)

## Release impact
patch — fixes the currently deployed `dev/v1.0` WASM simulator Runtime Error without changing real-device camera preview behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module resolution for camera preview utilities.

* **Tests**
  * Enhanced test coverage to verify module import configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->