### PR TITLE
CIでのBiome実行をbiome ciに変更する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,23 +29,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  format:
+  biome:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - name: Check format
+      - name: Run Biome
         working-directory: ./firmware
-        run: npm run format
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
-      - name: Lint firmware
-        working-directory: ./firmware
-        run: npm run lint
+        run: npx biome ci .
 
   test:
     runs-on: ubuntu-latest

--- a/firmware/biome.json
+++ b/firmware/biome.json
@@ -22,7 +22,7 @@
     "indentStyle": "space",
     "indentWidth": 2
   },
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "assist": { "actions": { "source": { "organizeImports": "off" } } },
   "linter": {
     "enabled": true,
     "rules": {


### PR DESCRIPTION
## Summary

- CI時のbiome確認として`biome format`と`biome lint`を実行していますが、CI実行環境との相性がよい`biome ci`の使用が推奨されるため、`biome ci`の実行に移行します

参考：[継続的インテグレーション](https://biomejs.dev/ja/recipes/continuous-integration/)

## What Changed

- CI時のformatとlintを`biome ci`に統合します。これによりActions実施時のAnnotationsに指摘結果が表示されるようになります
- `biome ci`では`organizeImports`も実行されますが、現状エラーが発生します。現状CIではformat、lintのみ実行しており互換性維持のため`organizeImports`を無効化します

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npm run test`
- [x] Other checks were run when relevant
  - CI Runnerが失敗とならないこと: https://github.com/stc1988/stack-chan/actions/runs/25963804322

## Affected Areas

- [ ] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [x] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated firmware verification checks in the continuous integration pipeline, replacing separate format and lint steps with a unified verification step
  * Disabled automatic import organization in the code formatter configuration to provide developers with more control over import statements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->