### PR TITLE
add LED test to default-mods

### DIFF
--- a/firmware/stackchan/default-mods/on-robot-created.ts
+++ b/firmware/stackchan/default-mods/on-robot-created.ts
@@ -233,6 +233,30 @@ export const onRobotCreated: StackchanMod['onRobotCreated'] = (robot) => {
   })
 
   /**
+   * LED test(Drawer action)
+   */
+  if (Object.keys(robot.led).length) {
+    const ledName = Object.keys(robot.led)[0] as string
+    let isLighting = false
+    const toggleLED = () => {
+      isLighting = !isLighting
+      if (isLighting) {
+        robot.lightRainbow(ledName)
+      } else {
+        robot.lightOff(ledName)
+      }
+      robot.application.setDrawerButtonState('toggleLED', isLighting)
+    }
+    robot.application.addDrawerButton({
+      key: 'toggleLED',
+      label: 'LED',
+      kind: 'toggle',
+      initialState: isLighting,
+      callback: toggleLED,
+    })
+  }
+
+  /**
    * Audio tests (Drawer actions)
    */
   let isAudioTesting = false


### PR DESCRIPTION
## Summary

- default-modsのドロワーメニューにLED動作確認の項目を追加

## What Changed

- default-modsのドロワーメニューにLED点灯の切り替えをする項目を追加

https://github.com/user-attachments/assets/ff034b38-6ad9-45dc-9448-d0720ed79771

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npm run test`
- [x] Other checks were run when relevant
  - configにledセクションがない場合はLED項目が表示されないことを確認

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an LED test feature with an interactive toggle control in the drawer interface. Users can now switch LED lights between rainbow mode and off when LED hardware is detected on the robot, with persistent state tracking and real-time interface updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->