### PR TITLE
specify creation for sim

### DIFF
--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -201,6 +201,9 @@
       }
     },
     "mac/m5stack": {
+      "creation": {
+        "stack": 1024
+      },
       "config": {
         "driver": {
           "type": "none"
@@ -218,6 +221,9 @@
       }
     },
     "win/m5stack": {
+      "creation": {
+        "stack": 1024
+      },
       "config": {
         "driver": {
           "type": "none"
@@ -225,6 +231,9 @@
       }
     },
     "mac/m5atom_s3": {
+      "creation": {
+        "stack": 1024
+      },
       "config": {
         "renderer": {
           "type": "small-face"
@@ -235,6 +244,9 @@
       }
     },
     "lin/m5atom_s3": {
+      "creation": {
+        "stack": 1024
+      },
       "config": {
         "renderer": {
           "type": "small-face"
@@ -245,6 +257,9 @@
       }
     },
     "win/m5atom_s3": {
+      "creation": {
+        "stack": 1024
+      },
       "config": {
         "renderer": {
           "type": "small-face"


### PR DESCRIPTION
## Summary

- lin/m5stack 以外のsim環境で`creation`を指定する

## What Changed

- lin/m5stack 以外のsim環境でで`creation`を指定することで起動時のメモリ不足を解消します

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npm run test`
- [x] Other checks were run when relevant
 - mac/m5stack で起動ができること

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform configurations for M5Stack and M5Atom S3 devices with memory stack sizing adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->