### PR TITLE
test: add M5StackChan CoreS3 smoke mod

### DIFF
--- a/firmware/docs/m5stackchan-cores3-smoke.md
+++ b/firmware/docs/m5stackchan-cores3-smoke.md
@@ -1,0 +1,42 @@
+# M5StackChan CoreS3 smoke check
+
+This smoke check exercises the current M5StackChan CoreS3 servo-power and 12 RGB LED paths with a small MOD. It is intended for manual hardware validation and does not require secrets or network configuration.
+
+Related tracking issues: #406, #408, #409, #412.
+
+## Build the host
+
+Run these commands from `firmware/`.
+
+```console
+$ mcconfig -d -m -p esp32:./platforms/m5stackchan_cores3 -t build "$PWD/stackchan/manifest_m5stackchan_cores3.json"
+```
+
+To flash the host when hardware is connected:
+
+```console
+$ mcconfig -d -m -p esp32:./platforms/m5stackchan_cores3 -t deploy "$PWD/stackchan/manifest_m5stackchan_cores3.json"
+```
+
+## Install the smoke MOD
+
+```console
+$ npm run mod --target=esp32:./platforms/m5stackchan_cores3 ./mods/m5stackchan_smoke/manifest.json
+```
+
+## Expected smoke sequence
+
+Open `xsbug` or serial logs and verify these log prefixes:
+
+- `[M5StackChan CoreS3 smoke] start`
+- `[M5StackChan CoreS3 smoke] servo: torque on`
+- `[M5StackChan CoreS3 smoke] servo: neutral pose`
+- `[M5StackChan CoreS3 smoke] servo: small yaw/pitch check`
+- `[M5StackChan CoreS3 smoke] servo: torque off`
+- `[M5StackChan CoreS3 smoke] LED: lightOn red`
+- `[M5StackChan CoreS3 smoke] LED: lightBlink green`
+- `[M5StackChan CoreS3 smoke] LED: lightRainbow`
+- `[M5StackChan CoreS3 smoke] LED: lightOff`
+- `[M5StackChan CoreS3 smoke] complete`
+
+The servo motion is intentionally small. Keep the device clear of obstructions before running the check. The LED names and PY32 wiring come from `platforms/m5stackchan_cores3/manifest.json`.

--- a/firmware/mods/README.md
+++ b/firmware/mods/README.md
@@ -5,6 +5,10 @@ For instructions on how to write mods, please refer to [Build and Write Programs
 
 Some mods require a network connection or an external server to run (as of writing).
 
+## M5StackChan CoreS3 Smoke
+
+- [m5stackchan_smoke](./m5stackchan_smoke/): Servo-power and head LED smoke check for M5StackChan CoreS3. See [M5StackChan CoreS3 smoke check](../docs/m5stackchan-cores3-smoke.md).
+
 ## Look Around: Kyoro-kyoro gaze Stack-chan
 
 ![squeaking Stack-chan](../../docs/images/stackchan.gif)

--- a/firmware/mods/README_ja.md
+++ b/firmware/mods/README_ja.md
@@ -5,6 +5,10 @@ MODの書き込み方法は[プログラムのビルドと書き込み](../docs/
 
 一部のMODは動かすためにネットワーク接続や外部のサーバを準備を準備する必要があります（執筆中）。
 
+## M5StackChan CoreS3 Smoke
+
+- [m5stackchan_smoke](./m5stackchan_smoke/): M5StackChan CoreS3 のサーボ電源とヘッドLEDの smoke 確認です。手順は [M5StackChan CoreS3 smoke check](../docs/m5stackchan-cores3-smoke.md) を参照してください。
+
 ## Look Around: きょろきょろｽﾀｯｸﾁｬﾝ
 
 ![きょろきょろｽﾀｯｸﾁｬﾝ](../../docs/images/stackchan.gif)

--- a/firmware/mods/m5stackchan_smoke/manifest.json
+++ b/firmware/mods/m5stackchan_smoke/manifest.json
@@ -1,0 +1,6 @@
+{
+  "include": ["$(MODDABLE)/examples/manifest_mod.json"],
+  "modules": {
+    "*": ["./mod"]
+  }
+}

--- a/firmware/mods/m5stackchan_smoke/mod.js
+++ b/firmware/mods/m5stackchan_smoke/mod.js
@@ -1,0 +1,55 @@
+import Timer from 'timer'
+
+const LED_NAME = 'head'
+const STEP_MS = 1200
+
+function delay(ms) {
+  return new Promise((resolve) => Timer.set(resolve, ms))
+}
+
+async function runSmoke(robot) {
+  trace('[M5StackChan CoreS3 smoke] start\n')
+  trace('[M5StackChan CoreS3 smoke] target=esp32:./platforms/m5stackchan_cores3 mod=mods/m5stackchan_smoke\n')
+
+  try {
+    trace('[M5StackChan CoreS3 smoke] servo: torque on\n')
+    await robot.setTorque(true)
+    trace('[M5StackChan CoreS3 smoke] servo: neutral pose\n')
+    await robot.setPose({ rotation: { y: 0, p: 0, r: 0 } }, 0.5)
+    await delay(STEP_MS)
+    trace('[M5StackChan CoreS3 smoke] servo: small yaw/pitch check\n')
+    await robot.setPose({ rotation: { y: 0.08, p: -0.06, r: 0 } }, 0.5)
+    await delay(STEP_MS)
+    trace('[M5StackChan CoreS3 smoke] servo: neutral pose\n')
+    await robot.setPose({ rotation: { y: 0, p: 0, r: 0 } }, 0.5)
+  } catch (error) {
+    trace(`[M5StackChan CoreS3 smoke] servo: error ${error}\n`)
+  } finally {
+    try {
+      trace('[M5StackChan CoreS3 smoke] servo: torque off\n')
+      await robot.setTorque(false)
+    } catch (error) {
+      trace(`[M5StackChan CoreS3 smoke] servo: torque off error ${error}\n`)
+    }
+  }
+
+  trace('[M5StackChan CoreS3 smoke] LED: lightOn red\n')
+  robot.lightOn(LED_NAME, 24, 0, 0)
+  await delay(STEP_MS)
+  trace('[M5StackChan CoreS3 smoke] LED: lightBlink green\n')
+  robot.lightBlink(LED_NAME, 0, 24, 0, 250)
+  await delay(STEP_MS * 2)
+  trace('[M5StackChan CoreS3 smoke] LED: lightRainbow\n')
+  robot.lightRainbow(LED_NAME)
+  await delay(STEP_MS * 2)
+  trace('[M5StackChan CoreS3 smoke] LED: lightOff\n')
+  robot.lightOff(LED_NAME)
+
+  trace('[M5StackChan CoreS3 smoke] complete\n')
+}
+
+export function onRobotCreated(robot) {
+  Timer.set(() => {
+    void runSmoke(robot)
+  }, 1000)
+}

--- a/firmware/tests/unit/platform-manifest.test.ts
+++ b/firmware/tests/unit/platform-manifest.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs'
 import { describe, test } from 'node:test'
 
 const stackchanManifest = JSON.parse(readFileSync('stackchan/manifest.json', 'utf8'))
+const m5StackChanPlatformManifest = JSON.parse(readFileSync('platforms/m5stackchan_cores3/manifest.json', 'utf8'))
+const m5StackChanStackchanManifest = JSON.parse(readFileSync('stackchan/manifest_m5stackchan_cores3.json', 'utf8'))
 
 describe('Stack-chan platform manifest', () => {
   test('gives M5StackChan CoreS3 the same expandable XS creation heap as CoreS3', () => {
@@ -11,5 +13,52 @@ describe('Stack-chan platform manifest', () => {
 
     assert.deepEqual(m5StackChanCoreS3Creation, coreS3Creation)
     assert.equal(m5StackChanCoreS3Creation.heap.incremental, 256)
+  })
+
+  test('keeps M5StackChan CoreS3 platform wiring on the PY32 servo power and head LED paths', () => {
+    assert.deepEqual(m5StackChanPlatformManifest.include, [
+      '$(BUILD)/devices/esp32/targets/m5stack_cores3/manifest.json',
+    ])
+    assert.equal(m5StackChanPlatformManifest.config.driver.type, 'm5stackchan')
+    assert.deepEqual(m5StackChanPlatformManifest.config.driver.serial, {
+      transmit: 6,
+      receive: 7,
+      port: 1,
+      baud: 1000000,
+    })
+    assert.deepEqual(m5StackChanPlatformManifest.config.driver.servoPower, {
+      type: 'py32',
+      pin: 0,
+      address: 111,
+    })
+    assert.deepEqual(m5StackChanPlatformManifest.config.led.head, {
+      type: 'py32',
+      length: 12,
+      ledPin: 13,
+      address: 111,
+    })
+  })
+
+  test('provides a M5StackChan CoreS3 smoke MOD with no private config', () => {
+    const smokeManifest = JSON.parse(readFileSync('mods/m5stackchan_smoke/manifest.json', 'utf8'))
+    const smokeSource = readFileSync('mods/m5stackchan_smoke/mod.js', 'utf8')
+    const smokeDocs = readFileSync('docs/m5stackchan-cores3-smoke.md', 'utf8')
+
+    assert.deepEqual(m5StackChanStackchanManifest.include, ['./manifest.json'])
+    assert.equal(m5StackChanStackchanManifest.config.driver.type, 'm5stackchan')
+    assert.equal(m5StackChanStackchanManifest.config.driver.serial.transmit, 6)
+    assert.equal(m5StackChanStackchanManifest.config.driver.serial.receive, 7)
+
+    assert.deepEqual(smokeManifest.include, ['$(MODDABLE)/examples/manifest_mod.json'])
+    assert.deepEqual(smokeManifest.modules, { '*': ['./mod'] })
+    assert.equal(smokeManifest.config, undefined)
+
+    for (const api of ['lightOn', 'lightBlink', 'lightRainbow', 'lightOff', 'setTorque', 'setPose']) {
+      assert.match(smokeSource, new RegExp(`robot\\.${api}\\b`), `smoke MOD should exercise robot.${api}`)
+    }
+    assert.match(smokeSource, /M5StackChan CoreS3 smoke/)
+    assert.match(smokeDocs, /esp32:\.\/platforms\/m5stackchan_cores3/)
+    assert.match(smokeDocs, /stackchan\/manifest_m5stackchan_cores3\.json/)
+    assert.match(smokeDocs, /mods\/m5stackchan_smoke\/manifest\.json/)
   })
 })


### PR DESCRIPTION
## Summary
- Add a `mods/m5stackchan_smoke` MOD for M5StackChan CoreS3 servo-power and head LED smoke validation.
- Document CLI-first build/deploy/MOD install steps for `esp32:./platforms/m5stackchan_cores3` using the no-secret M5StackChan manifest.
- Extend platform manifest tests to protect M5StackChan CoreS3 PY32 servo-power / LED wiring and smoke MOD presence.

Refs #406
Refs #408
Refs #409
Refs #412

## Codex goals workflow
- Drafted with `codex exec --enable goals --sandbox workspace-write` from a dedicated worktree.
- Reviewed, formatted, tested, and committed by the orchestrating agent.

## Test Plan
- [x] `npm run test:unit`
- [x] `npm run format`
- [x] `npm run lint` — exits 0; existing warnings remain unrelated to this slice.
- [ ] `mcconfig -d -m -p esp32:./platforms/m5stackchan_cores3 -t build "$PWD/stackchan/manifest_m5stackchan_cores3.json"` — attempted locally but blocked by missing `$IDF_PATH` in this WSL session.

## Manual hardware smoke still needed
- Build/deploy host with `stackchan/manifest_m5stackchan_cores3.json`.
- Install `mods/m5stackchan_smoke/manifest.json`.
- Check logs for `[M5StackChan CoreS3 smoke] ...` sequence.
- Confirm small servo motion, torque-off cleanup, and `head` LED on/blink/rainbow/off behavior.

## Release impact
patch — adds a user-facing smoke MOD and docs for M5StackChan CoreS3 validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive smoke test guide for M5StackChan CoreS3 hardware verification, including test procedures and expected behaviors

* **New Features**
  * Introduced automated smoke test module for M5StackChan CoreS3 that validates servo control and LED functionality with ordered test sequences

* **Tests**
  * Enhanced unit tests to validate platform configuration and smoke test module integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stack-chan/stack-chan/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->