### PR TITLE
Increase preference screen application displayListLength to 4096

### DIFF
--- a/firmware/stackchan/default-mods/on-launch.ts
+++ b/firmware/stackchan/default-mods/on-launch.ts
@@ -46,6 +46,7 @@ const buildStatusUI = (status: Status): StatusLabels => {
     hint: new Label(null, { left: 0, right: 0, height: 22, style: labelStyle }),
   }
   new Application(null, {
+    displayListLength: 4096,
     skin: screenSkin,
     contents: [
       new Container(null, {


### PR DESCRIPTION
## Summary

- 設定画面を表示できるようにする

## What Changed

- 表示時に、`display list overflowed`エラーが発生するため、`displayListLength`を明示的に指定する

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npm run test`
- [x] Other checks were run when relevant
  - Core2, CoreS3で設定画面を表示できることを確認

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized display rendering configuration parameters for improved performance and stability on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->