### PR TITLE
Moddable8.2.0対応

### DIFF
--- a/firmware/package-lock.json
+++ b/firmware/package-lock.json
@@ -14,7 +14,7 @@
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@google-cloud/text-to-speech": "^6.4.1",
         "@microsoft/tsdoc": "^0.16.0",
-        "@moddable/typings": "^8.1.1",
+        "@moddable/typings": "^8.2.0",
         "cross-env-default": "^5.1.3-1",
         "fontkit": "^2.0.2",
         "lefthook": "^2.1.9",
@@ -795,9 +795,9 @@
       "license": "MIT"
     },
     "node_modules/@moddable/typings": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-8.1.1.tgz",
-      "integrity": "sha512-l4TEfm8NQA8fjxOiRBPho8utEDZt70ihBMQqJOIWayZz6Y/JDIMqpV6sLDfZJRXyK1bfQqAtoh0kqVGBOe5+Lw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@moddable/typings/-/typings-8.2.1.tgz",
+      "integrity": "sha512-Vk174/TzM7+danPHW7dV3OwmPR3K5DmZ+nXUV6s6B/PgslByLS4S+R0WN4uiwIFZn0tShvxNcTS2EH0r+TxPMQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -55,7 +55,7 @@
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@google-cloud/text-to-speech": "^6.4.1",
     "@microsoft/tsdoc": "^0.16.0",
-    "@moddable/typings": "^8.1.1",
+    "@moddable/typings": "^8.2.0",
     "cross-env-default": "^5.1.3-1",
     "fontkit": "^2.0.2",
     "lefthook": "^2.1.9",

--- a/firmware/stackchan/default-mods/on-launch.ts
+++ b/firmware/stackchan/default-mods/on-launch.ts
@@ -132,15 +132,27 @@ async function waitForKey(): Promise<boolean> {
     let count = 0
     const handle = Timer.repeat(() => {
       if (isPressed()) {
-        if (touch?.sample) touch.close()
         Timer.clear(handle)
-        resolve(true)
+        if (touch && !config.Touch) {
+          // CoreS3 async touch driver
+          touch.close(() => {
+            resolve(true)
+          })
+        } else {
+          resolve(true)
+        }
       }
       count++
       if (count >= 10) {
-        if (touch?.sample) touch.close()
         Timer.clear(handle)
-        resolve(false)
+        if (touch && !config.Touch) {
+          // CoreS3 async touch driver
+          touch.close(() => {
+            resolve(false)
+          })
+        } else {
+          resolve(false)
+        }
       }
     }, 100)
   })

--- a/firmware/stackchan/default-mods/on-launch.ts
+++ b/firmware/stackchan/default-mods/on-launch.ts
@@ -141,6 +141,7 @@ async function waitForKey(): Promise<boolean> {
         } else {
           resolve(true)
         }
+        return
       }
       count++
       if (count >= 10) {

--- a/firmware/stackchan/services/manifest_service.json
+++ b/firmware/stackchan/services/manifest_service.json
@@ -7,6 +7,7 @@
     "$(MODULES)/network/ble/manifest_server.json",
     "$(MODULES)/network/ble/manifest_client.json",
     "$(MODULES)/network/mdns/manifest.json",
+    "$(MODULES)/network/wifi/manifest.json",
     "../utilities/manifest_utility.json",
     "./http-server/manifest.json",
     "./mcp-server/manifest.json",


### PR DESCRIPTION
## Summary

- [Moddable SDK 8.2.0](https://github.com/Moddable-OpenSource/moddable/releases/tag/8.2.0) の変更により起動しなくなったため、動作互換のある修正を行います

## What Changed

- Wifi管理でEcma419のWifiモジュールを採用し、`manifest_net.json`に`net/wifi`が含まれなくなったためモジュール参照エラー発生
  - stackchan側に`net/wifi`を追加。最終的には実装自体をEcma419のWifiモジュールへ移行が必要です
- CoreS3でFT6206が非同期版に変更されたため、起動時のWifi設定画面への移行判定後の`close`が実施されず、piuでのタッチドライバー処理化とコンフリクト
  - closeにコールバックを設定し、close完了後にpromiseを返却するように修正
- 修正として必須ではないですが`@moddale/typings`パッケージの更新

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npm run test`
- [x] Other checks were run when relevant
  - CoreS3, Core2, Simで起動することを確認

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted touch release handling to clear repeating timers and finalize the touch driver asynchronously, improving touch responsiveness.

* **Chores**
  * Bumped a development dependency version.
  * Added Wi‑Fi module configuration to the project manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->