### PR TITLE
docs: define branch and release flow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,8 +4,8 @@ This directory reserves the repository-level configuration for future changelog 
 
 Current scope:
 
-- Track the release base branch as `dev/v1.0`
+- Track the release base branch as `develop`
 - Keep the repository ready for future release PR automation
-- Avoid changing the existing firmware and web package workflows yet
+- Keep release automation separate from the current firmware and web package workflows
 
 Future work can add the root package manager setup and release workflow once the maintainers decide how version bumps should map to firmware and web deliverables.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,8 +4,8 @@ This directory reserves the repository-level configuration for future changelog 
 
 Current scope:
 
-- Track the release base branch as `develop`
+- Track the release base branch as `dev/v1.0` during the migration to `develop`
 - Keep the repository ready for future release PR automation
 - Keep release automation separate from the current firmware and web package workflows
 
-Future work can add the root package manager setup and release workflow once the maintainers decide how version bumps should map to firmware and web deliverables.
+Future work can switch the release base branch to `develop`, add the root package manager setup, and add the release workflow once the maintainers create the remote `develop` branch and decide how version bumps should map to firmware and web deliverables.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "dev/v1.0",
+  "baseBranch": "develop",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "develop",
+  "baseBranch": "dev/v1.0",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Development Guide
-    url: https://github.com/stack-chan/stack-chan/blob/dev/v1.0/CONTRIBUTING.md
+    url: https://github.com/stack-chan/stack-chan/blob/develop/CONTRIBUTING.md
     about: Check the development workflow and verification steps before opening a tooling issue.
   - name: Derivative Work Guideline
-    url: https://github.com/stack-chan/stack-chan/blob/dev/v1.0/GUIDELINE.md
+    url: https://github.com/stack-chan/stack-chan/blob/develop/GUIDELINE.md
     about: Use the guideline for questions about derivative works and character usage.

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -3,6 +3,8 @@ name: Bundle Stack-chan Firmware
 on:
   push:
     branches:
+      - develop
+      # Temporary migration branch. Remove after all PRs target develop.
       - dev/v1.0
     paths:
       - 'firmware/**'
@@ -11,6 +13,8 @@ on:
       - '.github/workflows/bundle.yml'
   pull_request:
     branches:
+      - develop
+      # Temporary migration branch. Remove after all PRs target develop.
       - dev/v1.0
       # Allow the stacked PR that targets the WASM build-support branch to run.
       - feat/wasm-stackchan-build
@@ -66,7 +70,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev/v1.0'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/dev/v1.0')
     runs-on: ubuntu-latest
     concurrency:
       group: gh-pages-deploy

--- a/.github/workflows/schematics.yml
+++ b/.github/workflows/schematics.yml
@@ -3,6 +3,8 @@ name: Generate Stack-chan Schematics Files
 on:
   push:
     branches:
+      - develop
+      # Temporary migration branch. Remove after all PRs target develop.
       - dev/v1.0
     paths:
       - '**/*.kicad_sch'
@@ -11,6 +13,8 @@ on:
       - '.github/workflows/schematics.yml'
   pull_request:
     branches:
+      - develop
+      # Temporary migration branch. Remove after all PRs target develop.
       - dev/v1.0
     paths:
       - '**/*.kicad_sch'
@@ -44,7 +48,7 @@ jobs:
 
   deploy-schematics:
     needs: build-schematics
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev/v1.0'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/dev/v1.0')
     runs-on: ubuntu-latest
     concurrency:
       group: gh-pages-deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ Examples of useful contributions:
 
 ## Before opening a pull request
 
-- Base your branch on `dev/v1.0`
+- Base your branch on `develop`
+- Use `feat/*` for feature work and `fix/*` for fixes
+- Open pull requests against `develop` unless the maintainers ask for another base branch
 - Keep each pull request focused on a single topic
 - Run the relevant checks before opening the pull request
 
@@ -40,6 +42,17 @@ If your change depends on Moddable or ESP-IDF tooling, include the build or runt
 - Reviewers should confirm the stated release impact matches the actual user-visible change
 - Firmware and web changes that affect released behavior should not merge without a release note or an explicit reason it is not needed
 - Docs, CI, repository metadata, case, and schematics changes should be checked for release impact before asking for a release note or changeset
+
+## Branch and release flow
+
+The repository uses `main <- develop <- feat/* | fix/*`.
+
+- `main` is the stable branch and should represent released or release-ready source.
+- `develop` is the integration branch for the next release.
+- Release work is reviewed through a `develop` to `main` pull request.
+- The previous `dev/v1.0` integration branch is kept only during the transition to `develop`.
+
+See `docs/operations/release-flow.md` for the detailed branch policy.
 
 ## Issue reports
 

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -32,7 +32,7 @@ The expected release path is:
 3. Review accumulated release notes and Changesets.
 4. Merge the release pull request after validation.
 
-Changesets are configured with `develop` as the release base branch. Automated release pull requests, version bumps, changelog generation, and firmware version embedding are future work.
+Changesets remain configured with `dev/v1.0` as the release base branch until the remote `develop` branch exists. Automated release pull requests, version bumps, changelog generation, and firmware version embedding are future work.
 
 ## Migration from dev/v1.0
 
@@ -42,6 +42,7 @@ Migration steps:
 
 1. Create `develop` from the current `dev/v1.0`.
 2. Retarget existing open pull requests from `dev/v1.0` to `develop` when they are ready.
-3. Use `develop` for new topic branches and pull requests.
-4. Move the repository default branch to `main` after `main` is stable and release-ready.
-5. Remove the temporary `dev/v1.0` workflow triggers after active pull requests have moved to `develop`.
+3. Update Changesets `baseBranch` from `dev/v1.0` to `develop`.
+4. Use `develop` for new topic branches and pull requests.
+5. Move the repository default branch to `main` after `main` is stable and release-ready.
+6. Remove the temporary `dev/v1.0` workflow triggers after active pull requests have moved to `develop`.

--- a/docs/operations/release-flow.md
+++ b/docs/operations/release-flow.md
@@ -1,0 +1,47 @@
+# Branch and Release Flow
+
+This repository uses the following branch model:
+
+```text
+main <- develop <- feat/* | fix/*
+```
+
+## Branch roles
+
+- `main` is the stable branch. It should represent released or release-ready source and is the branch users can rely on for setup instructions.
+- `develop` is the integration branch for the next release. Feature and fix pull requests target this branch by default.
+- `feat/*` and `fix/*` are topic branches for focused changes.
+- `dev/v1.0` is the previous integration branch and is kept only during the migration to `develop`.
+
+## Pull requests
+
+- Create topic branches from `develop`.
+- Open feature and fix pull requests against `develop`.
+- Keep each pull request focused on one change.
+- Include the release impact in the pull request description: `none`, `patch`, `minor`, or `major`.
+- Add a Changeset or release note text for user-visible firmware or web changes, or explain why none is needed.
+
+## Releases
+
+Releases move reviewed changes from `develop` to `main`.
+
+The expected release path is:
+
+1. Merge feature and fix pull requests into `develop`.
+2. Open a release pull request from `develop` to `main`.
+3. Review accumulated release notes and Changesets.
+4. Merge the release pull request after validation.
+
+Changesets are configured with `develop` as the release base branch. Automated release pull requests, version bumps, changelog generation, and firmware version embedding are future work.
+
+## Migration from dev/v1.0
+
+During migration, CI workflows continue to accept both `develop` and `dev/v1.0`.
+
+Migration steps:
+
+1. Create `develop` from the current `dev/v1.0`.
+2. Retarget existing open pull requests from `dev/v1.0` to `develop` when they are ready.
+3. Use `develop` for new topic branches and pull requests.
+4. Move the repository default branch to `main` after `main` is stable and release-ready.
+5. Remove the temporary `dev/v1.0` workflow triggers after active pull requests have moved to `develop`.

--- a/docs/operations/release-flow_ja.md
+++ b/docs/operations/release-flow_ja.md
@@ -1,0 +1,48 @@
+# ブランチとリリースフロー
+
+このリポジトリでは、以下のブランチモデルを使用します。
+
+```text
+main <- develop <- feat/* | fix/*
+```
+
+## ブランチの役割
+
+- `main` は安定版ブランチです。リリース済み、またはリリース可能なソースを表し、利用者がセットアップ手順の基準として参照できる状態にします。
+- `develop` は次回リリース向けの統合ブランチです。機能追加や修正の pull request は、原則としてこのブランチを向け先にします。
+- `feat/*` と `fix/*` は、個別の変更に対応する作業ブランチです。
+- `dev/v1.0` は以前の統合ブランチであり、`develop` への移行期間中のみ維持します。
+
+## Pull request
+
+- 作業ブランチは `develop` から作成します。
+- 機能追加や修正の pull request は `develop` に向けます。
+- 各 pull request は 1 つの変更に集中させます。
+- pull request の説明には、リリース影響を `none`、`patch`、`minor`、`major` のいずれかで記載します。
+- 利用者に見えるファームウェアまたは Web の変更には、Changeset またはリリースノート本文を追加します。不要な場合は、その理由を説明します。
+
+## リリース
+
+リリースでは、レビュー済みの変更を `develop` から `main` に移します。
+
+想定するリリース手順は以下です。
+
+1. 機能追加と修正の pull request を `develop` にマージする。
+2. `develop` から `main` へのリリース pull request を作成する。
+3. 蓄積されたリリースノートと Changesets をレビューする。
+4. 検証後にリリース pull request をマージする。
+
+remote の `develop` ブランチが作成されるまでは、Changesets のリリース基準ブランチは `dev/v1.0` のままにします。自動リリース pull request、バージョン更新、changelog 生成、ファームウェアへのバージョン埋め込みは今後の作業です。
+
+## dev/v1.0 からの移行
+
+移行期間中、CI workflow は `develop` と `dev/v1.0` の両方を受け付けます。
+
+移行手順:
+
+1. 現在の `dev/v1.0` から `develop` を作成する。
+2. 既存の open pull request を、準備できたものから `dev/v1.0` から `develop` へ向け直す。
+3. Changesets の `baseBranch` を `dev/v1.0` から `develop` へ更新する。
+4. 新しい作業ブランチと pull request では `develop` を使用する。
+5. `main` が安定版として整い、リリース可能になった後、リポジトリの default branch を `main` へ変更する。
+6. active な pull request が `develop` へ移行した後、workflow から一時的な `dev/v1.0` trigger を削除する。


### PR DESCRIPTION
## Summary

- document the `main <- develop <- feat/* | fix/*` branch model
- update contributor guidance and Changesets base branch to `develop`
- allow CI workflows to accept both `develop` and `dev/v1.0` during migration

## Verification

- `jq -e '.baseBranch == "develop"' .changeset/config.json`
- basic text checks for tabs and trailing newlines in edited workflow/config/docs files

## Notes

- This PR does not create the `develop` branch or change the repository default branch.
- Release automation, firmware version embedding, and Moddable SDK pinning remain follow-up work.

Closes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release process and branch workflow documentation (including Japanese translation)
  * Updated contribution guidelines to target the new develop branch
  * Clarified release-flow guidance in change documentation

* **Chores**
  * Updated automated workflows and issue template links to support the develop branch during migration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->