### PR TITLE
ci: remove obsolete Moddable WASM Promise patch

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -45,15 +45,6 @@ jobs:
         uses: mymindstorm/setup-emsdk@v16
         with:
           version: 3.1.2
-      - name: Apply Moddable WASM Promise patch
-        run: |
-          patch_commit="651a69bba5fb704730891769d40df7badd44c225"
-          if grep -q "promiseJobsTimer" "$HOME/.local/share/moddable/xs/platforms/wasm_xs.h"; then
-            echo "Moddable WASM Promise patch is already present"
-            exit 0
-          fi
-          git -C "$HOME/.local/share/moddable" fetch https://github.com/meganetaaan/moddable.git "$patch_commit"
-          git -C "$HOME/.local/share/moddable" cherry-pick --no-commit FETCH_HEAD
       - name: Build WASM simulator firmware
         working-directory: ./firmware
         run: source "$HOME/.local/share/xs-dev-export.sh" && npm run build:wasm


### PR DESCRIPTION
Backports the reviewed change from #481 onto dev/v1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the firmware build workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->