### PR TITLE
Reuse startup PIU application for renderer

### DIFF
--- a/firmware/stackchan/renderers-piu/app-controller.ts
+++ b/firmware/stackchan/renderers-piu/app-controller.ts
@@ -1,4 +1,10 @@
-import type { Application as PiuApplication, Container as PiuContainer, Content as PiuContent } from 'piu/MC'
+import { Application } from 'piu/MC'
+import type {
+  Application as PiuApplication,
+  ApplicationDictionary,
+  Container as PiuContainer,
+  Content as PiuContent,
+} from 'piu/MC'
 import type { DrawerButtonSpec } from 'drawer'
 import type { FaceContext } from 'face-context'
 import {
@@ -18,6 +24,10 @@ type DrawerControllerHost = {
     removeButton?: (key: string) => void
     setButtonState?: (key: string, active: boolean) => void
   }
+}
+
+type GlobalWithApplication = typeof globalThis & {
+  application?: PiuApplication
 }
 
 export class AppController extends Behavior {
@@ -126,4 +136,25 @@ export class AppController extends Behavior {
       setButtonState: (key, active) => this.setDrawerButtonState(key, active),
     }
   }
+}
+
+export function createAppControllerApplication(
+  data: AppControllerParams,
+  dictionary: Omit<ApplicationDictionary, 'Behavior' | 'contents'> = {},
+): AppController {
+  const existingApplication = (globalThis as GlobalWithApplication).application
+  if (existingApplication) {
+    const controller = new AppController()
+    existingApplication.empty()
+    existingApplication.behavior = controller
+    controller.onCreate(existingApplication, data)
+    return controller
+  }
+
+  const application = new Application(data, {
+    ...dictionary,
+    contents: [],
+    Behavior: AppController,
+  })
+  return application.behavior as AppController
 }

--- a/firmware/stackchan/renderers-piu/renderer-dog.ts
+++ b/firmware/stackchan/renderers-piu/renderer-dog.ts
@@ -1,7 +1,7 @@
-import { Application, type Content as PiuContent } from 'piu/MC'
+import type { Content as PiuContent } from 'piu/MC'
 import { DogFace } from 'behaviors/face'
 import type { DrawerButtonSpec } from 'drawer'
-import { AppController } from 'app-controller'
+import { type AppController, createAppControllerApplication } from 'app-controller'
 import { RendererCompat } from 'renderer-compat'
 import { ChatStatusBar } from 'chat-status-bar'
 
@@ -13,15 +13,14 @@ type RendererOptions = {
 }
 
 export function createRenderer(options?: RendererOptions): AppController {
-  const application = new Application(
+  return createAppControllerApplication(
     {
       face: new DogFace(),
       appBar: new ChatStatusBar(),
       drawerButtons: options?.drawerButtons,
     },
-    { displayListLength: options?.displayListLength ?? 2048, contents: [], Behavior: AppController },
+    { displayListLength: options?.displayListLength ?? 2048 },
   )
-  return application.behavior as AppController
 }
 
 export class Renderer extends RendererCompat {

--- a/firmware/stackchan/renderers-piu/renderer-image.ts
+++ b/firmware/stackchan/renderers-piu/renderer-image.ts
@@ -1,7 +1,7 @@
-import { Application, type Content as PiuContent } from 'piu/MC'
+import type { Content as PiuContent } from 'piu/MC'
 import { ImageAvatarFace } from 'parts/image/image-avatar-face'
 import type { DrawerButtonSpec } from 'drawer'
-import { AppController } from 'app-controller'
+import { type AppController, createAppControllerApplication } from 'app-controller'
 import { RendererCompat } from 'renderer-compat'
 import { ChatStatusBar } from 'chat-status-bar'
 
@@ -13,15 +13,14 @@ type RendererOptions = {
 }
 
 export function createRenderer(options?: RendererOptions): AppController {
-  const application = new Application(
+  return createAppControllerApplication(
     {
       face: new ImageAvatarFace({ pack: options?.avatar }),
       appBar: new ChatStatusBar(),
       drawerButtons: options?.drawerButtons,
     },
-    { displayListLength: 4096, contents: [], Behavior: AppController },
+    { displayListLength: 4096 },
   )
-  return application.behavior as AppController
 }
 
 export class Renderer extends RendererCompat {

--- a/firmware/stackchan/renderers-piu/renderer-simple.ts
+++ b/firmware/stackchan/renderers-piu/renderer-simple.ts
@@ -1,7 +1,7 @@
-import { Application, type Content as PiuContent } from 'piu/MC'
+import type { Content as PiuContent } from 'piu/MC'
 import { SimpleFace } from 'behaviors/face'
 import type { DrawerButtonSpec } from 'drawer'
-import { AppController } from 'app-controller'
+import { type AppController, createAppControllerApplication } from 'app-controller'
 import { RendererCompat } from 'renderer-compat'
 import { ChatStatusBar } from 'chat-status-bar'
 
@@ -13,15 +13,14 @@ type RendererOptions = {
 }
 
 export function createRenderer(options?: RendererOptions): AppController {
-  const application = new Application(
+  return createAppControllerApplication(
     {
       face: new SimpleFace(),
       appBar: new ChatStatusBar(),
       drawerButtons: options?.drawerButtons,
     },
-    { displayListLength: options?.displayListLength ?? 2048, contents: [], Behavior: AppController },
+    { displayListLength: options?.displayListLength ?? 2048 },
   )
-  return application.behavior as AppController
 }
 
 // Compatibility: keep class name while delegating to Face constructor

--- a/firmware/stackchan/renderers-piu/renderer-small.ts
+++ b/firmware/stackchan/renderers-piu/renderer-small.ts
@@ -1,7 +1,7 @@
-import { Application, type Content as PiuContent } from 'piu/MC'
+import type { Content as PiuContent } from 'piu/MC'
 import { SmallFace } from 'behaviors/face'
 import type { DrawerButtonSpec } from 'drawer'
-import { AppController } from 'app-controller'
+import { type AppController, createAppControllerApplication } from 'app-controller'
 import { RendererCompat } from 'renderer-compat'
 import { ChatStatusBar } from 'chat-status-bar'
 
@@ -13,15 +13,14 @@ type RendererOptions = {
 }
 
 export function createRenderer(options?: RendererOptions): AppController {
-  const application = new Application(
+  return createAppControllerApplication(
     {
       face: new SmallFace(),
       appBar: new ChatStatusBar(),
       drawerButtons: options?.drawerButtons,
     },
-    { displayListLength: options?.displayListLength ?? 2048, contents: [], Behavior: AppController },
+    { displayListLength: options?.displayListLength ?? 2048 },
   )
-  return application.behavior as AppController
 }
 
 export class Renderer extends RendererCompat {

--- a/firmware/tests/unit/piu-renderer.test.ts
+++ b/firmware/tests/unit/piu-renderer.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { describe, test } from 'node:test'
+
+const rendererPaths = [
+  'stackchan/renderers-piu/renderer-simple.ts',
+  'stackchan/renderers-piu/renderer-small.ts',
+  'stackchan/renderers-piu/renderer-dog.ts',
+  'stackchan/renderers-piu/renderer-image.ts',
+]
+
+describe('PIU renderer application lifecycle', () => {
+  test('renderers reuse an existing startup Application when one is present', () => {
+    const controllerSource = readFileSync('stackchan/renderers-piu/app-controller.ts', 'utf8')
+
+    assert.match(controllerSource, /globalThis as GlobalWithApplication/)
+    assert.match(controllerSource, /existingApplication\.empty\(\)/)
+    assert.match(controllerSource, /existingApplication\.behavior = controller/)
+    assert.match(controllerSource, /controller\.onCreate\(existingApplication, data\)/)
+
+    for (const rendererPath of rendererPaths) {
+      const source = readFileSync(rendererPath, 'utf8')
+
+      assert.match(source, /createAppControllerApplication/)
+      assert.doesNotMatch(source, /new Application/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Reuse the startup PIU Application when creating renderers after the splash screen
- Avoid creating a second PIU Application during boot
- Add a unit test to guard renderer Application lifecycle

## Tests
- npm run test:unit
- npm run lint
- npm run build --target=esp32/m5stack_cores3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined PIU renderer application creation and initialization across all renderer implementations
  * Enhanced application lifecycle management with improved reuse of existing global applications

* **Tests**
  * Added unit tests validating renderer application startup and reuse behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->