### PR TITLE
Allow device to work without button.a, b or c

### DIFF
--- a/firmware/stackchan/default-mods/on-robot-created.ts
+++ b/firmware/stackchan/default-mods/on-robot-created.ts
@@ -367,23 +367,29 @@ export const onRobotCreated: StackchanMod['onRobotCreated'] = (robot) => {
   })
 
   if (robot.button != null) {
-    robot.button.a.onChanged = function () {
-      if (!this.read()) {
-        return
+    if (robot.button.a != null) {
+      robot.button.a.onChanged = function () {
+        if (!this.read()) {
+          return
+        }
+        void toggleLookAround()
       }
-      void toggleLookAround()
     }
-    robot.button.b.onChanged = function () {
-      if (!this.read()) {
-        return
+    if (robot.button.b != null) {
+      robot.button.b.onChanged = function () {
+        if (!this.read()) {
+          return
+        }
+        void runServoTest()
       }
-      void runServoTest()
     }
-    robot.button.c.onChanged = function () {
-      if (!this.read()) {
-        return
+    if (robot.button.c != null) {
+      robot.button.c.onChanged = function () {
+        if (!this.read()) {
+          return
+        }
+        toggleColor()
       }
-      toggleColor()
     }
   }
 


### PR DESCRIPTION
## Summary

Some devices may not have button.a .b or .c defined. Allow builds without buttons.

-

## What Changed

Check for existence of robot.button.a .b or .c before setting `onChanged`.

-

## Verification

- [ x ] `cd firmware && npm run format`
- [ x ] `cd firmware && npm run lint`
- [ x ] `cd firmware && npm run test`
- [ ] Other checks were run when relevant

## Affected Areas

- [ x ] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [ x ] none
- [ ] yes, described below

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced button input handling robustness to prevent potential edge case issues during initialization and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->