### PR TITLE
add power button

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -74,7 +74,7 @@ runs:
       if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        npm run setup
+        npm run setup -- --branch "$MODDABLE_TARGET_REF"
         git -C "$HOME/.local/share/moddable" fetch origin "$MODDABLE_TARGET_REF"
         git -C "$HOME/.local/share/moddable" checkout --detach FETCH_HEAD
         echo "Installed Moddable ref: $(git -C "$HOME/.local/share/moddable" describe --tags --always)"

--- a/firmware/stackchan/main.ts
+++ b/firmware/stackchan/main.ts
@@ -42,7 +42,7 @@ type SimulatorButtonCtor = new (options: {
 type RobotLed = Pick<Led, 'on' | 'off' | 'blink' | 'rainbow'>
 
 type GlobalEnvironment = {
-  button?: Partial<Record<'a' | 'b' | 'c', DeviceButton>>
+  button?: Partial<Record<'a' | 'b' | 'c' | 'power', DeviceButton>>
   network?: NetworkService
   device?: {
     sensor?: {

--- a/firmware/stackchan/manifest.json
+++ b/firmware/stackchan/manifest.json
@@ -51,7 +51,8 @@
     "serial": {
       "transmit": 17,
       "receive": 16
-    }
+    },
+    "enablePowerButton": true
   },
   "resources": {
     "*-mask": ["$(MODDABLE)/examples/assets/fonts/OpenSans-Regular-24"],

--- a/firmware/stackchan/robot.ts
+++ b/firmware/stackchan/robot.ts
@@ -82,7 +82,7 @@ export type Button = {
   onChanged: (this: Digital) => void
 }
 
-const buttonNames = ['a', 'b', 'c'] as const
+const buttonNames = ['a', 'b', 'c', 'power'] as const
 type ButtonName = (typeof buttonNames)[number]
 
 /**


### PR DESCRIPTION
## Summary

- Core2,CoreS3機種においては電源ボタン短押下イベントを取れるようになります

## What Changed

- Moddable8.2.2以降でCore2,CoreS3機種においては以下のように電源ボタン短押下イベントを取れるようになりました。

```
    if(robot.button.power != null) {
      robot.button.power.onChanged = function()  {
        if(!this.read()) {
          return
        }
        trace("power button\n")
      }
    }
```

PMICから取得する都合で、指が離れた時にボタンのon/offが同時に発火します。また、PMICへポーリングしにいきますが、CoreS3(RT版)ではCPU0使用率に影響は見れなかったため、デフォルトで有効にしています。`config.enablePowerButton:false`で無効化できます。

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npm run test`
- [x] Other checks were run when relevant
 - Core2およびPCシミュレーターでも起動することを確認

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for a configurable **power** button in addition to the existing button controls, enabling it by default via the device configuration.

* **Chores**
  * Improved the build/setup process to ensure Moddable setup uses the intended branch when cache is missed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->