### PR TITLE
feat: speed up dynamixel driver control loop

### DIFF
--- a/firmware/scripts/smoke-lin.sh
+++ b/firmware/scripts/smoke-lin.sh
@@ -10,7 +10,7 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 
 platform="${STACKCHAN_LIN_SMOKE_PLATFORM:-lin/m5stack}"
 platform_path="${platform//\//\/}"
-smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-10s}"
+smoke_timeout="${STACKCHAN_LIN_SMOKE_TIMEOUT:-20s}"
 xsbug_host="${STACKCHAN_LIN_XSBUG_HOST:-127.0.0.1}"
 xsbug_port="${STACKCHAN_LIN_XSBUG_PORT:-5002}"
 xsbug_log="$(mktemp "${TMPDIR:-/tmp}/stackchan-lin-xsbug-log.XXXXXX")"

--- a/firmware/stackchan/drivers/dynamixel-driver.ts
+++ b/firmware/stackchan/drivers/dynamixel-driver.ts
@@ -64,7 +64,7 @@ class PControl {
     this.goalPosition = 0
     this.presentPosition = 0
     this._offset = 0
-    this._lastGoalPosition = 0
+    this._lastGoalPosition = -1
     this._lastGoalCurrent = -1
   }
 
@@ -78,7 +78,7 @@ class PControl {
       }
     }
     this.goalPosition = 2048
-    this._lastGoalPosition = this._feedbackEnabled ? this.goalPosition : 0
+    this._lastGoalPosition = -1
     this._lastGoalCurrent = -1
     const mode = this._feedbackEnabled ? OPERATING_MODE.CURRENT_BASED_POSITION : OPERATING_MODE.POSITION
     await this.servo.setOperatingMode(mode)
@@ -172,7 +172,9 @@ export class DynamixelDriver {
     }
     this._attached = true
     if (!this._feedback || !this._feedbackLoopEnabled) {
-      void this._ensureInitialized()
+      void this._ensureInitialized().catch((error) => {
+        trace(`servo initialization failed: ${error}\n`)
+      })
       return
     }
     this._scheduleNext(0)
@@ -226,7 +228,9 @@ export class DynamixelDriver {
     }
     this._nextTimer = Timer.set(() => {
       this._nextTimer = undefined
-      void this.control()
+      void this.control().catch((error) => {
+        trace(`servo control failed: ${error}\n`)
+      })
     }, delay)
   }
 

--- a/firmware/stackchan/drivers/dynamixel-driver.ts
+++ b/firmware/stackchan/drivers/dynamixel-driver.ts
@@ -78,20 +78,25 @@ class PControl {
       }
     }
     this.goalPosition = 2048
-    this._lastGoalPosition = this.goalPosition
+    this._lastGoalPosition = this._feedbackEnabled ? this.goalPosition : 0
     this._lastGoalCurrent = -1
     const mode = this._feedbackEnabled ? OPERATING_MODE.CURRENT_BASED_POSITION : OPERATING_MODE.POSITION
     await this.servo.setOperatingMode(mode)
     await this.servo.setTorque(torqueEnabled)
     if (!this._feedbackEnabled) {
       await this.servo.setGoalPosition(this.goalPosition)
+      this._lastGoalPosition = this.goalPosition
+      this.presentPosition = this.goalPosition
     }
   }
 
   async update() {
     if (this._lastGoalPosition !== this.goalPosition) {
-      void this.servo.setGoalPosition(this.goalPosition + this._offset)
+      await this.servo.setGoalPosition(this.goalPosition + this._offset)
       this._lastGoalPosition = this.goalPosition
+      if (!this._feedbackEnabled) {
+        this.presentPosition = this.goalPosition
+      }
     }
     if (!this._feedbackEnabled) {
       return
@@ -108,8 +113,8 @@ class PControl {
     if (this._lastGoalCurrent === currentInt) {
       return
     }
+    await this.servo.setGoalCurrent(currentInt)
     this._lastGoalCurrent = currentInt
-    void this.servo.setGoalCurrent(currentInt)
   }
 
   async flushGoalPosition(): Promise<void> {
@@ -118,6 +123,7 @@ class PControl {
     }
     await this.servo.setGoalPosition(this.goalPosition + this._offset)
     this._lastGoalPosition = this.goalPosition
+    this.presentPosition = this.goalPosition
   }
 }
 
@@ -135,7 +141,7 @@ export class DynamixelDriver {
   _interval: number
   _initPromise?: Promise<void>
   constructor(param: DynamixelDriverProps) {
-    const baud = toPositiveInteger(param.baud ?? param.baudrate, DEFAULT_BAUD)
+    const baud = toPositiveInteger(param.baud, toPositiveInteger(param.baudrate, DEFAULT_BAUD))
     this._feedback = toBoolean(param.feedback, true)
     this._feedbackLoopEnabled = this._feedback
     this._pan = new Dynamixel({ id: param.panId, baudrate: baud })
@@ -189,15 +195,21 @@ export class DynamixelDriver {
       return
     }
     this._initPromise = (async () => {
-      // Keep read replies only when closed-loop control is enabled.
-      const statusReturnLevel: 0 | 1 = this._feedback && this._feedbackLoopEnabled ? 1 : 0
-      await this._pan.setStatusReturnLevel(statusReturnLevel)
-      await this._tilt.setStatusReturnLevel(statusReturnLevel)
+      const initStatusReturnLevel: 0 | 1 = this._feedback ? 1 : 0
+      await this._pan.setStatusReturnLevel(initStatusReturnLevel)
+      await this._tilt.setStatusReturnLevel(initStatusReturnLevel)
       for (const c of this._controls) {
         await c.init(this._torque)
       }
-      await this._pan.setProfileAcceleration(20)
-      await this._pan.setProfileVelocity(100)
+      for (const c of this._controls) {
+        await c.servo.setProfileAcceleration(20)
+        await c.servo.setProfileVelocity(100)
+      }
+      const finalStatusReturnLevel: 0 | 1 = this._feedback && this._feedbackLoopEnabled ? 1 : 0
+      if (finalStatusReturnLevel !== initStatusReturnLevel) {
+        await this._pan.setStatusReturnLevel(finalStatusReturnLevel)
+        await this._tilt.setStatusReturnLevel(finalStatusReturnLevel)
+      }
       this._initialized = true
       trace('servo initialized\n')
     })()

--- a/firmware/stackchan/drivers/dynamixel-driver.ts
+++ b/firmware/stackchan/drivers/dynamixel-driver.ts
@@ -5,7 +5,34 @@ import Timer from 'timer'
 type DynamixelDriverProps = {
   panId: number
   tiltId: number
-  baud: number
+  baud?: number
+  baudrate?: number
+  interval?: number
+  feedback?: boolean | number
+}
+
+const DEFAULT_BAUD = 1_000_000
+const DEFAULT_INTERVAL = 125
+
+function toPositiveInteger(value: number | undefined, fallback: number): number {
+  if (value == null) {
+    return fallback
+  }
+  const n = Math.floor(Number(value))
+  if (!Number.isFinite(n) || n <= 0) {
+    return fallback
+  }
+  return n
+}
+
+function toBoolean(value: boolean | number | undefined, fallback: boolean): boolean {
+  if (value == null) {
+    return fallback
+  }
+  if (typeof value === 'boolean') {
+    return value
+  }
+  return value !== 0
 }
 
 class PControl {
@@ -17,47 +44,80 @@ class PControl {
   goalPosition: number
   _offset: number
   _lastGoalPosition: number
+  _lastGoalCurrent: number
+  _feedbackEnabled: boolean
   presentPosition: number
-  constructor(servo: Dynamixel, gain: number, saturation: number, minCurrent: number, name = 'servo') {
+  constructor(
+    servo: Dynamixel,
+    gain: number,
+    saturation: number,
+    minCurrent: number,
+    feedbackEnabled: boolean,
+    name = 'servo',
+  ) {
     this.servo = servo
     this.gain = gain
     this.saturation = saturation
     this.minCurrent = minCurrent
+    this._feedbackEnabled = feedbackEnabled
     this.name = name
     this.goalPosition = 0
     this.presentPosition = 0
     this._offset = 0
     this._lastGoalPosition = 0
+    this._lastGoalCurrent = -1
   }
 
   async init(torqueEnabled: boolean) {
-    const result = await this.servo.readPresentPosition()
-    if (result.success && result.value > 4096) {
-      this._offset = 4096
-    } else if (!result.success) {
-      trace(`${this.name} ... failed to read initial position for offset detection\n`)
+    if (this._feedbackEnabled) {
+      const initialPosition = await this.servo.readPresentPositionValue()
+      if (initialPosition != null && initialPosition > 4096) {
+        this._offset = 4096
+      } else if (initialPosition == null) {
+        trace(`${this.name} ... failed to read initial position for offset detection\n`)
+      }
     }
     this.goalPosition = 2048
-    // Use CURRENT_BASED_POSITION mode for dynamic torque control
-    await this.servo.setOperatingMode(OPERATING_MODE.CURRENT_BASED_POSITION)
+    this._lastGoalPosition = this.goalPosition
+    this._lastGoalCurrent = -1
+    const mode = this._feedbackEnabled ? OPERATING_MODE.CURRENT_BASED_POSITION : OPERATING_MODE.POSITION
+    await this.servo.setOperatingMode(mode)
     await this.servo.setTorque(torqueEnabled)
+    if (!this._feedbackEnabled) {
+      await this.servo.setGoalPosition(this.goalPosition)
+    }
   }
 
   async update() {
     if (this._lastGoalPosition !== this.goalPosition) {
-      await this.servo.setGoalPosition(this.goalPosition + this._offset)
+      void this.servo.setGoalPosition(this.goalPosition + this._offset)
       this._lastGoalPosition = this.goalPosition
     }
-
-    const result = await this.servo.readPresentPosition()
-    if (!result.success) {
+    if (!this._feedbackEnabled) {
       return
     }
-    this.presentPosition = result.value - this._offset
-    const position = this.presentPosition
-    const positionError = Math.abs(this.goalPosition - position)
+
+    const position = await this.servo.readPresentPositionValue()
+    if (position == null) {
+      return
+    }
+    this.presentPosition = position - this._offset
+    const positionError = Math.abs(this.goalPosition - this.presentPosition)
     const current = Math.min(Math.max(positionError * this.gain, this.minCurrent), this.saturation)
-    await this.servo.setGoalCurrent(current)
+    const currentInt = current | 0
+    if (this._lastGoalCurrent === currentInt) {
+      return
+    }
+    this._lastGoalCurrent = currentInt
+    void this.servo.setGoalCurrent(currentInt)
+  }
+
+  async flushGoalPosition(): Promise<void> {
+    if (this._lastGoalPosition === this.goalPosition) {
+      return
+    }
+    await this.servo.setGoalPosition(this.goalPosition + this._offset)
+    this._lastGoalPosition = this.goalPosition
   }
 }
 
@@ -70,16 +130,26 @@ export class DynamixelDriver {
   _torque: boolean
   _running: boolean
   _attached: boolean
+  _feedback: boolean
+  _feedbackLoopEnabled: boolean
   _interval: number
+  _initPromise?: Promise<void>
   constructor(param: DynamixelDriverProps) {
-    this._pan = new Dynamixel({ id: param.panId, baudrate: param.baud })
-    this._tilt = new Dynamixel({ id: param.tiltId, baudrate: param.baud })
-    this._controls = [new PControl(this._pan, 1.0, 80, 40, 'pan'), new PControl(this._tilt, 4, 800, 0, 'tilt')]
+    const baud = toPositiveInteger(param.baud ?? param.baudrate, DEFAULT_BAUD)
+    this._feedback = toBoolean(param.feedback, true)
+    this._feedbackLoopEnabled = this._feedback
+    this._pan = new Dynamixel({ id: param.panId, baudrate: baud })
+    this._tilt = new Dynamixel({ id: param.tiltId, baudrate: baud })
+    this._controls = [
+      new PControl(this._pan, 1.0, 80, 40, this._feedback, 'pan'),
+      new PControl(this._tilt, 4, 800, 0, this._feedback, 'tilt'),
+    ]
     this._torque = true
     this._initialized = false
     this._running = false
     this._attached = false
-    this._interval = 125
+    this._interval = toPositiveInteger(param.interval, DEFAULT_INTERVAL)
+    this._initPromise = undefined
   }
 
   async setTorque(torque: boolean): Promise<void> {
@@ -95,7 +165,11 @@ export class DynamixelDriver {
       return
     }
     this._attached = true
-    this._scheduleNext()
+    if (!this._feedback || !this._feedbackLoopEnabled) {
+      void this._ensureInitialized()
+      return
+    }
+    this._scheduleNext(0)
   }
 
   onDetached(): void {
@@ -106,44 +180,88 @@ export class DynamixelDriver {
     }
   }
 
-  async control(): Promise<void> {
-    if (this._running) {
+  async _ensureInitialized(): Promise<void> {
+    if (this._initialized) {
       return
     }
-    this._running = true
-    try {
-      if (!this._initialized) {
-        this._initialized = true
-        for (const c of this._controls) {
-          await c.init(this._torque)
-        }
-        await this._pan.setProfileAcceleration(20)
-        await this._pan.setProfileVelocity(100)
-        trace('servo initialized\n')
-      }
-      if (!this._torque) {
-        return
-      }
-      // TODO: use bulk write/read instruction for performance
+    if (this._initPromise) {
+      await this._initPromise
+      return
+    }
+    this._initPromise = (async () => {
+      // Keep read replies only when closed-loop control is enabled.
+      const statusReturnLevel: 0 | 1 = this._feedback && this._feedbackLoopEnabled ? 1 : 0
+      await this._pan.setStatusReturnLevel(statusReturnLevel)
+      await this._tilt.setStatusReturnLevel(statusReturnLevel)
       for (const c of this._controls) {
-        await c.update()
+        await c.init(this._torque)
       }
+      await this._pan.setProfileAcceleration(20)
+      await this._pan.setProfileVelocity(100)
+      this._initialized = true
+      trace('servo initialized\n')
+    })()
+    try {
+      await this._initPromise
     } finally {
-      this._running = false
-      if (this._attached) {
-        this._scheduleNext()
-      }
+      this._initPromise = undefined
     }
   }
 
-  _scheduleNext(): void {
-    if (this._nextTimer || !this._attached) {
+  _scheduleNext(delay: number): void {
+    if (this._nextTimer || !this._attached || !this._feedback || !this._feedbackLoopEnabled) {
       return
     }
     this._nextTimer = Timer.set(() => {
       this._nextTimer = undefined
       void this.control()
-    }, this._interval)
+    }, delay)
+  }
+
+  async control(): Promise<void> {
+    if (this._running) {
+      return
+    }
+    this._running = true
+    const cycleStartedAt = Date.now()
+    try {
+      await this._ensureInitialized()
+      if (!this._torque) {
+        return
+      }
+      for (const c of this._controls) {
+        await c.update()
+      }
+    } finally {
+      this._running = false
+      if (this._attached && this._feedback && this._feedbackLoopEnabled) {
+        const elapsed = Date.now() - cycleStartedAt
+        const delay = elapsed < this._interval ? this._interval - elapsed : 0
+        this._scheduleNext(delay)
+      }
+    }
+  }
+
+  async setFeedbackLoopEnabled(enabled: boolean): Promise<void> {
+    if (!this._feedback) {
+      return
+    }
+    const next = Boolean(enabled)
+    if (this._feedbackLoopEnabled === next) {
+      return
+    }
+    this._feedbackLoopEnabled = next
+    if (this._nextTimer) {
+      Timer.clear(this._nextTimer)
+      this._nextTimer = undefined
+    }
+    await this._ensureInitialized()
+    const statusReturnLevel: 0 | 1 = this._feedbackLoopEnabled ? 1 : 0
+    await this._pan.setStatusReturnLevel(statusReturnLevel)
+    await this._tilt.setStatusReturnLevel(statusReturnLevel)
+    if (this._attached && this._feedbackLoopEnabled && !this._running) {
+      this._scheduleNext(0)
+    }
   }
 
   async applyRotation(ori: Rotation): Promise<void> {
@@ -151,10 +269,19 @@ export class DynamixelDriver {
     const tiltAngle = (ori.p * 180) / Math.PI
     this._controls[0].goalPosition = Math.floor(((panAngle + 180) * 4096) / 360)
     this._controls[1].goalPosition = Math.floor(((Math.min(Math.max(tiltAngle, -30), 10) + 180) * 4096) / 360)
+    if (!this._feedback || !this._feedbackLoopEnabled) {
+      await this._ensureInitialized()
+      if (!this._torque) {
+        return
+      }
+      await this._controls[0].flushGoalPosition()
+      await this._controls[1].flushGoalPosition()
+    }
   }
 
   async getRotation(): Promise<Maybe<Rotation>> {
-    const [p1, p2] = this._controls.map((c) => (c.presentPosition * 360) / 4096 - 180)
+    const p1 = (this._controls[0].presentPosition * 360) / 4096 - 180
+    const p2 = (this._controls[1].presentPosition * 360) / 4096 - 180
     return {
       success: true,
       value: {

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -632,6 +632,9 @@ class Dynamixel {
     if (length == null || !this.#hasValidResponse(6)) {
       throw new Error('failed to read offset angle')
     }
+    if (this.#responseBuffer[1] !== 0) {
+      throw new Error(`servo returned error code: ${this.#responseBuffer[1]} while reading offset angle`)
+    }
     return this.#readSignedDword(2)
   }
 

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -1,10 +1,7 @@
 import Serial from 'embedded:io/serial'
 import config from 'mc/config'
-
 import SingleWaitSlot from 'single-wait-slot'
 import Timer from 'timer'
-
-import { PayloadBuffer } from './payload-buffer'
 
 type Maybe<T> =
   | {
@@ -72,10 +69,11 @@ const ADDRESS = {
   HOMING_OFFSET: 20,
   TORQUE_ENABLE: 64,
   LED: 65,
+  STATUS_RETURN_LEVEL: 68,
   GOAL_CURRENT: 102,
-  GOAL_POSITION: 116,
   PROFILE_ACCELERATION: 108,
   PROFILE_VELOCITY: 112,
+  GOAL_POSITION: 116,
   PRESENT_CURRENT: 126,
   PRESENT_VELOCITY: 128,
   PRESENT_POSITION: 132,
@@ -89,97 +87,104 @@ const RX_STATE = {
 } as const
 type RxState = (typeof RX_STATE)[keyof typeof RX_STATE]
 
-function assertNeverRxState(state: never): never {
-  throw new Error(`Unknown RX state: ${state}`)
-}
-
 class PacketHandler extends Serial {
-  #callbacks: Map<number, (buffer: Uint8Array, length: number) => void>
+  #callbacks: Map<number, (buffer: Uint8Array, offset: number, length: number) => void>
   #rxBuffer: Uint8Array
-  #payloadBuffer: PayloadBuffer
+  #chunkBuffer: Uint8Array
   #idx: number
   #state: RxState
   #count: number
+
   constructor(option) {
     const onReadable = function (this: PacketHandler, bytesReadable: number) {
-      const rxBuf = this.#rxBuffer
-      let bytes = bytesReadable
-      while (bytes > 0) {
-        // NOTE: We can safely read a number
-        rxBuf[this.#idx++] = this.read() as number
-        bytes -= 1
-        switch (this.#state) {
-          case RX_STATE.SEEK:
-            if (this.#idx === 1 && rxBuf[0] !== 0xff) {
-              this.#idx = 0
-            }
-            if (this.#idx === 2 && rxBuf[1] !== 0xff) {
-              this.#idx = 0
-            }
-            if (this.#idx >= 3) {
-              if (rxBuf[2] === 0xfd) {
-                this.#state = RX_STATE.HEAD
-              } else {
-                // reset seek
-                // trace('seeking failed. reset\n')
-                this.#idx = 0
-              }
-            }
-            break
-          case RX_STATE.HEAD:
-            if (this.#idx >= 7) {
-              this.#count = (rxBuf[6] << 8) | rxBuf[5]
-              this.#state = RX_STATE.BODY
-              // trace(`length: ${this.#count}\n`)
-            }
-            break
-          case RX_STATE.BODY:
-            this.#count -= 1
-            if (this.#count === 0) {
-              const id = rxBuf[4]
-              const command = rxBuf[7] as Instruction
-              if (command === INSTRUCTION.WRITE || command === INSTRUCTION.READ) {
-                // trace(`got echo.  ... ${rxBuf.subarray(0, this.#idx)} ignoring\n`)
-              } else if (command === INSTRUCTION.STATUS) {
-                // trace(`got response for ${id}. triggering callback ... ${rxBuf.subarray(0, this.#idx)} \n`)
-                const payloadLength = this.#idx - 8
-                const payloadView = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 7)
-                const payload = new Uint8Array(payloadLength)
-                payload.set(payloadView.subarray(0, payloadLength))
-                this.#callbacks.get(id)?.(payload, payloadLength)
-              } else {
-                // trace(`something wrong for ${id}. ${rxBuf.subarray(0, this.#idx)} \n`)
-                const payloadLength = this.#idx - 8
-                const payloadView = this.#payloadBuffer.copyFrom(rxBuf, payloadLength, 7)
-                const payload = new Uint8Array(payloadLength)
-                payload.set(payloadView.subarray(0, payloadLength))
-                this.#callbacks.get(id)?.(payload, payloadLength)
-              }
-              this.#idx = 0
-              this.#state = RX_STATE.SEEK
-            }
-            break
-          default:
-            assertNeverRxState(this.#state)
+      let remaining = bytesReadable
+      while (remaining > 0) {
+        const requestLength = remaining > this.#chunkBuffer.length ? this.#chunkBuffer.length : remaining
+        const readLength = this.read(this.#chunkBuffer.subarray(0, requestLength)) as number
+        if (readLength == null || readLength <= 0) {
+          return
         }
-        // noop
+        this.#consumeChunk(this.#chunkBuffer, readLength)
+        remaining -= readLength
       }
     }
     super({
       ...option,
-      format: 'number',
+      format: 'buffer',
       onReadable,
     })
-    this.#callbacks = new Map<number, (buffer: Uint8Array, length: number) => void>()
-    this.#rxBuffer = new Uint8Array(64)
-    this.#payloadBuffer = new PayloadBuffer(32)
+    this.#callbacks = new Map<number, (buffer: Uint8Array, offset: number, length: number) => void>()
+    this.#rxBuffer = new Uint8Array(96)
+    this.#chunkBuffer = new Uint8Array(32)
     this.#idx = 0
     this.#state = RX_STATE.SEEK
+    this.#count = 0
   }
+
+  #resetSeek() {
+    this.#idx = 0
+    this.#state = RX_STATE.SEEK
+    this.#count = 0
+  }
+
+  #consumeChunk(source: Uint8Array, length: number): void {
+    const rxBuf = this.#rxBuffer
+    for (let i = 0; i < length; i++) {
+      if (this.#idx >= rxBuf.length) {
+        this.#resetSeek()
+      }
+      rxBuf[this.#idx++] = source[i]
+      switch (this.#state) {
+        case RX_STATE.SEEK:
+          if (this.#idx === 1 && rxBuf[0] !== 0xff) {
+            this.#idx = 0
+          }
+          if (this.#idx === 2 && rxBuf[1] !== 0xff) {
+            this.#idx = 0
+          }
+          if (this.#idx >= 3) {
+            if (rxBuf[2] === 0xfd) {
+              this.#state = RX_STATE.HEAD
+            } else {
+              this.#idx = 0
+            }
+          }
+          break
+        case RX_STATE.HEAD:
+          if (this.#idx >= 7) {
+            this.#count = (rxBuf[6] << 8) | rxBuf[5]
+            this.#state = RX_STATE.BODY
+          }
+          break
+        case RX_STATE.BODY:
+          this.#count -= 1
+          if (this.#count <= 0) {
+            const command = rxBuf[7] as Instruction
+            if (command !== INSTRUCTION.WRITE && command !== INSTRUCTION.READ) {
+              const callback = this.#callbacks.get(rxBuf[4])
+              if (callback != null) {
+                const payloadLength = this.#idx - 9
+                if (payloadLength > 0) {
+                  callback(rxBuf, 7, payloadLength)
+                }
+              }
+            }
+            this.#resetSeek()
+          }
+          break
+        default:
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore 6113
+          // eslint-disable-next-line no-case-declarations, @typescript-eslint/no-unused-vars
+          let _state: never
+      }
+    }
+  }
+
   hasCallbackOf(id: number): boolean {
     return this.#callbacks.has(id)
   }
-  registerCallback(id: number, callback: (buffer: Uint8Array, length: number) => void) {
+  registerCallback(id: number, callback: (buffer: Uint8Array, offset: number, length: number) => void) {
     this.#callbacks.set(id, callback)
   }
   removeCallback(id: number) {
@@ -213,32 +218,66 @@ type DynamixelConstructorParam = {
   baudrate?: number
 }
 
+type PendingCommand = {
+  instruction: Instruction
+  address: Address | null
+  parameters: number[]
+  waitForResponse: boolean
+  expectedResponseMinLength: number
+  resolve: (value: number | undefined) => void
+  reject: (reason: unknown) => void
+}
+
 class Dynamixel {
   static packetHandler: PacketHandler
   static setBaud(baud: number): void {
-    // Dynamixel.packetHandler?.close()
-    // Dynamixel.packetHandler = new PacketHandler({
     packetHandler?.close()
     packetHandler = new PacketHandler({
       receive: config.serial?.receive ?? 6,
       transmit: config.serial?.transmit ?? 7,
-      baud: baud,
+      baud,
       port: 1,
     })
   }
+
   #id: number
-  #onCommandRead: (buffer: Uint8Array, length: number) => void
+  #onCommandRead: (buffer: Uint8Array, offset: number, length: number) => void
   #txBuf: Uint8Array
-  #waitSlot: SingleWaitSlot<Uint8Array>
-  #queueTail: Promise<void>
+  #responseBuffer: Uint8Array
+  #responseLength: number
+  #expectedResponseMinLength: number
+  #waitSlot: SingleWaitSlot<number>
+  #queue: PendingCommand[]
+  #queueRunning: boolean
+
   constructor({ id, baudrate = 1_000_000 }: DynamixelConstructorParam) {
     this.#id = id
-    this.#waitSlot = new SingleWaitSlot<Uint8Array>(Timer.set, Timer.clear)
-    this.#queueTail = Promise.resolve()
-    this.#onCommandRead = (values, _length) => {
-      this.#waitSlot.resolve(values)
-    }
     this.#txBuf = new Uint8Array(64)
+    this.#responseBuffer = new Uint8Array(16)
+    this.#responseLength = 0
+    this.#expectedResponseMinLength = 0
+    this.#waitSlot = new SingleWaitSlot<number>(Timer.set, Timer.clear)
+    this.#queue = []
+    this.#queueRunning = false
+    this.#onCommandRead = (buffer, offset, length) => {
+      if (!this.#waitSlot.isWaiting) {
+        return
+      }
+      if (length < this.#expectedResponseMinLength) {
+        return
+      }
+      if (buffer[offset] !== INSTRUCTION.STATUS) {
+        return
+      }
+      if (this.#responseBuffer.length < length) {
+        this.#responseBuffer = new Uint8Array(length)
+      }
+      for (let i = 0; i < length; i++) {
+        this.#responseBuffer[i] = buffer[offset + i]
+      }
+      this.#responseLength = length
+      this.#waitSlot.resolve(length)
+    }
     if (packetHandler == null) {
       packetHandler = new PacketHandler({
         receive: config.serial?.receive ?? 6,
@@ -252,93 +291,138 @@ class Dynamixel {
     }
     packetHandler.registerCallback(this.#id, this.#onCommandRead)
   }
+
   teardown(): void {
     packetHandler.removeCallback(this.#id)
   }
+
   get id(): number {
     return this.#id
   }
 
-  async #dispatchCommand(
-    instruction: Instruction,
-    address?: Address,
-    ...parameters: number[]
-  ): Promise<Uint8Array | undefined> {
+  #writeCommandPacket(command: PendingCommand): void {
     this.#txBuf[0] = 0xff
     this.#txBuf[1] = 0xff
     this.#txBuf[2] = 0xfd
     this.#txBuf[3] = 0x00
     this.#txBuf[4] = this.#id
-
-    this.#txBuf[7] = instruction // write or read
+    this.#txBuf[7] = command.instruction
     let idx = 8
-    if (address) {
-      this.#txBuf[idx++] = address & 0xff
-      this.#txBuf[idx++] = (address >> 8) & 0xff
+
+    if (command.address != null) {
+      this.#txBuf[idx++] = command.address & 0xff
+      this.#txBuf[idx++] = (command.address >> 8) & 0xff
     }
 
-    if (instruction === INSTRUCTION.READ) {
-      const numRead = parameters[0] ?? 1
+    if (command.instruction === INSTRUCTION.READ) {
+      const numRead = command.parameters[0] ?? 1
       this.#txBuf[idx++] = numRead & 0xff
       this.#txBuf[idx++] = (numRead >> 8) & 0xff
     } else {
-      for (const v of parameters) {
-        this.#txBuf[idx++] = v
+      for (let i = 0; i < command.parameters.length; i++) {
+        this.#txBuf[idx++] = command.parameters[i]
       }
     }
 
-    const len = idx - 5 // instruction(1) + params(0~) + crc(2)
+    const len = idx - 5
     this.#txBuf[5] = len & 0xff
     this.#txBuf[6] = (len >> 8) & 0xff
-
     const crc = checksum(this.#txBuf, 0, idx)
     this.#txBuf[idx++] = crc & 0xff
     this.#txBuf[idx++] = (crc >> 8) & 0xff
-    /*
-    trace('writing: ')
-    for (const n of this.#txBuf.subarray(0, idx)) {
-      trace(Number(n).toString(16).padStart(2, '0'))
-      trace(' ')
+    packetHandler.write(this.#txBuf.subarray(0, idx))
+  }
+
+  #dispatchCommandWithWait(command: PendingCommand): Promise<number | undefined> {
+    this.#writeCommandPacket(command)
+    this.#responseLength = 0
+    this.#expectedResponseMinLength = command.expectedResponseMinLength
+    return this.#waitSlot.wait(60)
+  }
+
+  async #processQueue(): Promise<void> {
+    while (this.#queue.length > 0) {
+      const command = this.#queue.shift()
+      if (command == null) {
+        continue
+      }
+      try {
+        if (!command.waitForResponse) {
+          this.#writeCommandPacket(command)
+          command.resolve(undefined)
+          continue
+        }
+        const result = await this.#dispatchCommandWithWait(command)
+        command.resolve(result)
+      } catch (error) {
+        command.reject(error)
+      }
     }
-    trace('\n')
-    */
-    const originalFormat = packetHandler.format
-    packetHandler.format = 'buffer'
-    try {
-      packetHandler.write(this.#txBuf.subarray(0, idx))
-    } finally {
-      packetHandler.format = originalFormat
-    }
-    return this.#waitSlot.wait(200, () => {
-      trace('timeout.\n')
+    this.#queueRunning = false
+  }
+
+  #sendCommand(
+    instruction: Instruction,
+    address: Address | null,
+    waitForResponse: boolean,
+    expectedResponseMinLength: number,
+    ...parameters: number[]
+  ): Promise<number | undefined> {
+    return new Promise((resolve, reject) => {
+      this.#queue.push({
+        instruction,
+        address,
+        parameters,
+        waitForResponse,
+        expectedResponseMinLength,
+        resolve,
+        reject,
+      })
+      if (!this.#queueRunning) {
+        this.#queueRunning = true
+        void this.#processQueue()
+      }
     })
   }
 
-  async #sendCommand(
+  #sendReadCommand(address: Address, readLength: number): Promise<number | undefined> {
+    return this.#sendCommand(INSTRUCTION.READ, address, true, 2 + readLength, readLength)
+  }
+
+  #sendWriteCommand(address: Address, ...parameters: number[]): Promise<number | undefined> {
+    return this.#sendCommand(INSTRUCTION.WRITE, address, false, 0, ...parameters)
+  }
+
+  #sendInstructionCommand(
     instruction: Instruction,
-    address?: Address,
+    waitForResponse = true,
+    expectedResponseMinLength = 2,
     ...parameters: number[]
-  ): Promise<Uint8Array | undefined> {
-    const run = this.#queueTail.then(() => this.#dispatchCommand(instruction, address, ...parameters))
-    this.#queueTail = run.then(
-      () => undefined,
-      () => undefined,
-    )
-    return run
+  ): Promise<number | undefined> {
+    return this.#sendCommand(instruction, null, waitForResponse, expectedResponseMinLength, ...parameters)
+  }
+
+  #hasValidResponse(minLength: number): boolean {
+    return this.#responseLength >= minLength && this.#responseBuffer[0] === INSTRUCTION.STATUS
+  }
+
+  #readSignedWord(offset: number): number {
+    const value = this.#responseBuffer[offset] | (this.#responseBuffer[offset + 1] << 8)
+    return value >= 0x8000 ? value - 0x10000 : value
   }
 
   /**
    * resets values to factory default
    */
   async factoryReset(): Promise<unknown> {
-    return this.#sendCommand(INSTRUCTION.FACTORY_RESET, null, 0x01 /* reset values except id and baudrate*/)
+    return this.#sendInstructionCommand(INSTRUCTION.FACTORY_RESET, true, 2, 0x01)
   }
 
   /**
    * reboots servo
    */
   async reboot(): Promise<unknown> {
-    return this.#sendCommand(INSTRUCTION.REBOOT)
+    return this.#sendInstructionCommand(INSTRUCTION.REBOOT, true, 2)
   }
 
   /**
@@ -348,7 +432,7 @@ class Dynamixel {
    */
   async setOperatingMode(mode: OperatingMode): Promise<unknown> {
     await this.setTorque(false)
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.OPERATING_MODE, mode)
+    return this.#sendWriteCommand(ADDRESS.OPERATING_MODE, mode)
   }
 
   /**
@@ -357,7 +441,11 @@ class Dynamixel {
    */
   async setBaudrate(baudrate: Baudrate): Promise<unknown> {
     await this.setTorque(false)
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.BAUDRATE, baudrate)
+    return this.#sendWriteCommand(ADDRESS.BAUDRATE, baudrate)
+  }
+
+  async setStatusReturnLevel(level: 0 | 1 | 2): Promise<unknown> {
+    return this.#sendWriteCommand(ADDRESS.STATUS_RETURN_LEVEL, level)
   }
 
   /**
@@ -369,7 +457,7 @@ class Dynamixel {
     const b = (accel >> 8) & 0xff
     const c = (accel >> 16) & 0xff
     const d = (accel >> 24) & 0xff
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.PROFILE_ACCELERATION, a, b, c, d)
+    return this.#sendWriteCommand(ADDRESS.PROFILE_ACCELERATION, a, b, c, d)
   }
 
   /**
@@ -382,7 +470,7 @@ class Dynamixel {
     const b = (velocity >> 8) & 0xff
     const c = (velocity >> 16) & 0xff
     const d = (velocity >> 24) & 0xff
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.PROFILE_VELOCITY, a, b, c, d)
+    return this.#sendWriteCommand(ADDRESS.PROFILE_VELOCITY, a, b, c, d)
   }
 
   /**
@@ -392,7 +480,7 @@ class Dynamixel {
   async setGoalCurrent(current: number): Promise<unknown> {
     const a = current & 0xff
     const b = (current >> 8) & 0xff
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.GOAL_CURRENT, a, b)
+    return this.#sendWriteCommand(ADDRESS.GOAL_CURRENT, a, b)
   }
 
   /**
@@ -404,8 +492,7 @@ class Dynamixel {
     const b = (position >> 8) & 0xff
     const c = (position >> 16) & 0xff
     const d = (position >> 24) & 0xff
-    // trace(`${a}, ${b}, ${c}, ${d}\n`)
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.GOAL_POSITION, a, b, c, d)
+    return this.#sendWriteCommand(ADDRESS.GOAL_POSITION, a, b, c, d)
   }
 
   /**
@@ -419,7 +506,7 @@ class Dynamixel {
   }
 
   async setLED(on: boolean): Promise<unknown> {
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.LED, Number(on))
+    return this.#sendWriteCommand(ADDRESS.LED, Number(on))
   }
 
   /**
@@ -428,7 +515,7 @@ class Dynamixel {
    */
   async setOffsetAngle(angle: number): Promise<unknown> {
     const value = (Math.abs(angle) * 360) / 4096
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.HOMING_OFFSET, ...le(value))
+    return this.#sendWriteCommand(ADDRESS.HOMING_OFFSET, ...le(value))
   }
 
   setId(id: number): void {
@@ -444,7 +531,7 @@ class Dynamixel {
       throw new Error(`id(${id}) is already used\n`)
     }
     await this.setTorque(false)
-    const promise = this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.ID, id)
+    const promise = this.#sendWriteCommand(ADDRESS.ID, id)
     const oldId = this.#id
     this.#id = id
     packetHandler.registerCallback(this.#id, this.#onCommandRead)
@@ -458,7 +545,7 @@ class Dynamixel {
    * @param enable - enable
    */
   async setTorque(enable: boolean): Promise<unknown> {
-    return this.#sendCommand(INSTRUCTION.WRITE, ADDRESS.TORQUE_ENABLE, Number(enable))
+    return this.#sendWriteCommand(ADDRESS.TORQUE_ENABLE, Number(enable))
   }
 
   /**
@@ -466,15 +553,14 @@ class Dynamixel {
    * @returns Model number
    */
   async readModelNumber(): Promise<number> {
-    const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.MODEL_NUMBER, 2)
-    if (values == null || values.length < 4) {
+    const length = await this.#sendReadCommand(ADDRESS.MODEL_NUMBER, 2)
+    if (length == null || !this.#hasValidResponse(4)) {
       throw new Error('failed to read model number')
     }
-    if (values[1] !== 0) {
-      throw new Error(`servo returned error code: ${values[1]} while reading model number`)
+    if (this.#responseBuffer[1] !== 0) {
+      throw new Error(`servo returned error code: ${this.#responseBuffer[1]} while reading model number`)
     }
-    // payload layout: [instruction/status, status_code, low, high]
-    return el(values[3], values[2])
+    return el(this.#responseBuffer[3], this.#responseBuffer[2])
   }
 
   /**
@@ -482,12 +568,12 @@ class Dynamixel {
    * @returns Firmware version
    */
   async readFirmwareVersion(): Promise<Maybe<{ version: number }>> {
-    const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.VERSION_OF_FIRMWARE, 1)
-    if (values != null && values.length >= 3 && values[1] === 0) {
+    const length = await this.#sendReadCommand(ADDRESS.VERSION_OF_FIRMWARE, 1)
+    if (length != null && this.#hasValidResponse(3) && this.#responseBuffer[1] === 0) {
       return {
         success: true,
         value: {
-          version: values[2],
+          version: this.#responseBuffer[2],
         },
       }
     }
@@ -502,15 +588,11 @@ class Dynamixel {
    * @returns offset angle
    */
   async readOffsetAngle(): Promise<number> {
-    const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.HOMING_OFFSET, 2)
-    if (values == null || values.length < 2) {
+    const length = await this.#sendReadCommand(ADDRESS.HOMING_OFFSET, 2)
+    if (length == null || !this.#hasValidResponse(4)) {
       throw new Error('failed to read offset angle')
     }
-    const isCcw = Boolean(values[0] & 0x8000)
-    let offset = ((values[1] & 0x7fff) << 8) | values[0]
-    if (isCcw) {
-      offset *= -1
-    }
+    const offset = this.#readSignedWord(2)
     return offset
   }
 
@@ -519,19 +601,18 @@ class Dynamixel {
    * @returns current value
    */
   async readPresentCurrent(): Promise<Maybe<{ current: number }>> {
-    const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_CURRENT, 2)
-    if (values != null && values.length >= 4) {
-      if (values[1] !== 0) {
+    const length = await this.#sendReadCommand(ADDRESS.PRESENT_CURRENT, 2)
+    if (length != null && this.#hasValidResponse(4)) {
+      if (this.#responseBuffer[1] !== 0) {
         return {
           success: false,
-          reason: `servo returned error code: ${values[1]}`,
+          reason: `servo returned error code: ${this.#responseBuffer[1]}`,
         }
       }
-      const current = values[2] | (values[3] << 8)
       return {
         success: true,
         value: {
-          current: current >= 0x8000 ? current - 0x10000 : current,
+          current: this.#readSignedWord(2),
         },
       }
     }
@@ -546,18 +627,17 @@ class Dynamixel {
    * @returns velocity value
    */
   async readPresentVelocity(): Promise<Maybe<number>> {
-    const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_VELOCITY, 4)
-    if (values != null && values.length >= 4) {
-      if (values[1] !== 0) {
+    const length = await this.#sendReadCommand(ADDRESS.PRESENT_VELOCITY, 4)
+    if (length != null && this.#hasValidResponse(4)) {
+      if (this.#responseBuffer[1] !== 0) {
         return {
           success: false,
-          reason: `servo returned error code: ${values[1]}`,
+          reason: `servo returned error code: ${this.#responseBuffer[1]}`,
         }
       }
-      const velocity = values[2] | (values[3] << 8)
       return {
         success: true,
-        value: velocity >= 0x8000 ? velocity - 0x10000 : velocity,
+        value: this.#readSignedWord(2),
       }
     }
     return {
@@ -565,27 +645,31 @@ class Dynamixel {
     }
   }
 
+  async readPresentPositionValue(): Promise<number | undefined> {
+    const length = await this.#sendReadCommand(ADDRESS.PRESENT_POSITION, 4)
+    if (length == null || !this.#hasValidResponse(4)) {
+      return undefined
+    }
+    if (this.#responseBuffer[1] !== 0) {
+      return undefined
+    }
+    return this.#readSignedWord(2)
+  }
+
   /**
    * reads present position (4096 per rotation)
    * @returns position value
    */
   async readPresentPosition(): Promise<Maybe<number>> {
-    const values = await this.#sendCommand(INSTRUCTION.READ, ADDRESS.PRESENT_POSITION, 4)
-    if (values != null && values.length >= 4) {
-      if (values[1] !== 0) {
-        return {
-          success: false,
-          reason: `servo returned error code: ${values[1]}`,
-        }
-      }
-      const position = values[2] | (values[3] << 8)
+    const position = await this.readPresentPositionValue()
+    if (position == null) {
       return {
-        success: true,
-        value: position >= 0x8000 ? position - 0x10000 : position,
+        success: false,
       }
     }
     return {
-      success: false,
+      success: true,
+      value: position,
     }
   }
 }

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -87,6 +87,10 @@ const RX_STATE = {
 } as const
 type RxState = (typeof RX_STATE)[keyof typeof RX_STATE]
 
+function assertNeverRxState(state: never): never {
+  throw new Error(`Unknown RX state: ${state}`)
+}
+
 class PacketHandler extends Serial {
   #callbacks: Map<number, (buffer: Uint8Array, offset: number, length: number) => void>
   #rxBuffer: Uint8Array
@@ -173,10 +177,7 @@ class PacketHandler extends Serial {
           }
           break
         default:
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore 6113
-          // eslint-disable-next-line no-case-declarations, @typescript-eslint/no-unused-vars
-          let _state: never
+          assertNeverRxState(this.#state)
       }
     }
   }

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -13,11 +13,11 @@ type Maybe<T> =
       reason?: string
     }
 
-function le(v: number): [number, number] {
-  return [(v & 0xff00) >> 8, v & 0xff]
-}
 function el(h: number, l: number) {
   return ((h << 8) & 0xff00) + (l & 0xff)
+}
+function dwordLe(v: number): [number, number, number, number] {
+  return [v & 0xff, (v >> 8) & 0xff, (v >> 16) & 0xff, (v >> 24) & 0xff]
 }
 
 let packetHandler: PacketHandler = null
@@ -259,6 +259,7 @@ class Dynamixel {
   #responseLength: number
   #expectedResponseMinLength: number
   #waitSlot: SingleWaitSlot<number>
+  #statusReturnLevel: 0 | 1 | 2
 
   constructor({ id, baudrate = 1_000_000 }: DynamixelConstructorParam) {
     this.#id = id
@@ -267,14 +268,16 @@ class Dynamixel {
     this.#responseLength = 0
     this.#expectedResponseMinLength = 0
     this.#waitSlot = new SingleWaitSlot<number>(Timer.set, Timer.clear)
+    this.#statusReturnLevel = 2
     this.#onCommandRead = (buffer, offset, length) => {
       if (!this.#waitSlot.isWaiting) {
         return
       }
-      if (length < this.#expectedResponseMinLength) {
+      if (buffer[offset] !== INSTRUCTION.STATUS) {
         return
       }
-      if (buffer[offset] !== INSTRUCTION.STATUS) {
+      const minLength = length >= 2 && buffer[offset + 1] !== 0 ? 2 : this.#expectedResponseMinLength
+      if (length < minLength) {
         return
       }
       if (this.#responseBuffer.length < length) {
@@ -401,7 +404,8 @@ class Dynamixel {
   }
 
   #sendWriteCommand(address: Address, ...parameters: number[]): Promise<number | undefined> {
-    return this.#sendCommand(INSTRUCTION.WRITE, address, false, 0, ...parameters)
+    const waitForResponse = this.#statusReturnLevel === 2
+    return this.#sendCommand(INSTRUCTION.WRITE, address, waitForResponse, waitForResponse ? 2 : 0, ...parameters)
   }
 
   #sendInstructionCommand(
@@ -414,7 +418,13 @@ class Dynamixel {
   }
 
   #hasValidResponse(minLength: number): boolean {
-    return this.#responseLength >= minLength && this.#responseBuffer[0] === INSTRUCTION.STATUS
+    if (this.#responseBuffer[0] !== INSTRUCTION.STATUS) {
+      return false
+    }
+    if (this.#responseLength >= minLength) {
+      return true
+    }
+    return this.#responseLength >= 2 && this.#responseBuffer[1] !== 0
   }
 
   #readSignedWord(offset: number): number {
@@ -465,7 +475,16 @@ class Dynamixel {
   }
 
   async setStatusReturnLevel(level: 0 | 1 | 2): Promise<unknown> {
-    return this.#sendWriteCommand(ADDRESS.STATUS_RETURN_LEVEL, level)
+    const waitForResponse = this.#statusReturnLevel === 2
+    const result = await this.#sendCommand(
+      INSTRUCTION.WRITE,
+      ADDRESS.STATUS_RETURN_LEVEL,
+      waitForResponse,
+      waitForResponse ? 2 : 0,
+      level,
+    )
+    this.#statusReturnLevel = level
+    return result
   }
 
   /**
@@ -534,8 +553,9 @@ class Dynamixel {
    * @param angle - offset angle
    */
   async setOffsetAngle(angle: number): Promise<unknown> {
-    const value = (Math.abs(angle) * 360) / 4096
-    return this.#sendWriteCommand(ADDRESS.HOMING_OFFSET, ...le(value))
+    const raw = (angle * 4096) / 360
+    const value = raw < 0 ? Math.ceil(raw) : Math.floor(raw)
+    return this.#sendWriteCommand(ADDRESS.HOMING_OFFSET, ...dwordLe(value))
   }
 
   setId(id: number): void {
@@ -608,12 +628,11 @@ class Dynamixel {
    * @returns offset angle
    */
   async readOffsetAngle(): Promise<number> {
-    const length = await this.#sendReadCommand(ADDRESS.HOMING_OFFSET, 2)
-    if (length == null || !this.#hasValidResponse(4)) {
+    const length = await this.#sendReadCommand(ADDRESS.HOMING_OFFSET, 4)
+    if (length == null || !this.#hasValidResponse(6)) {
       throw new Error('failed to read offset angle')
     }
-    const offset = this.#readSignedWord(2)
-    return offset
+    return this.#readSignedDword(2)
   }
 
   /**

--- a/firmware/stackchan/drivers/dynamixel.ts
+++ b/firmware/stackchan/drivers/dynamixel.ts
@@ -163,6 +163,13 @@ class PacketHandler extends Serial {
         case RX_STATE.BODY:
           this.#count -= 1
           if (this.#count <= 0) {
+            const packetLength = this.#idx
+            const receivedCrc = rxBuf[packetLength - 2] | (rxBuf[packetLength - 1] << 8)
+            const expectedCrc = checksum(rxBuf, 0, packetLength - 2) & 0xffff
+            if (receivedCrc !== expectedCrc) {
+              this.#resetSeek()
+              break
+            }
             const command = rxBuf[7] as Instruction
             if (command !== INSTRUCTION.WRITE && command !== INSTRUCTION.READ) {
               const callback = this.#callbacks.get(rxBuf[4])
@@ -220,6 +227,8 @@ type DynamixelConstructorParam = {
 }
 
 type PendingCommand = {
+  target: Dynamixel
+  id: number
   instruction: Instruction
   address: Address | null
   parameters: number[]
@@ -230,6 +239,8 @@ type PendingCommand = {
 }
 
 class Dynamixel {
+  static #queue: PendingCommand[] = []
+  static #queueRunning = false
   static packetHandler: PacketHandler
   static setBaud(baud: number): void {
     packetHandler?.close()
@@ -248,8 +259,6 @@ class Dynamixel {
   #responseLength: number
   #expectedResponseMinLength: number
   #waitSlot: SingleWaitSlot<number>
-  #queue: PendingCommand[]
-  #queueRunning: boolean
 
   constructor({ id, baudrate = 1_000_000 }: DynamixelConstructorParam) {
     this.#id = id
@@ -258,8 +267,6 @@ class Dynamixel {
     this.#responseLength = 0
     this.#expectedResponseMinLength = 0
     this.#waitSlot = new SingleWaitSlot<number>(Timer.set, Timer.clear)
-    this.#queue = []
-    this.#queueRunning = false
     this.#onCommandRead = (buffer, offset, length) => {
       if (!this.#waitSlot.isWaiting) {
         return
@@ -306,7 +313,7 @@ class Dynamixel {
     this.#txBuf[1] = 0xff
     this.#txBuf[2] = 0xfd
     this.#txBuf[3] = 0x00
-    this.#txBuf[4] = this.#id
+    this.#txBuf[4] = command.id
     this.#txBuf[7] = command.instruction
     let idx = 8
 
@@ -335,31 +342,32 @@ class Dynamixel {
   }
 
   #dispatchCommandWithWait(command: PendingCommand): Promise<number | undefined> {
-    this.#writeCommandPacket(command)
     this.#responseLength = 0
     this.#expectedResponseMinLength = command.expectedResponseMinLength
-    return this.#waitSlot.wait(60)
+    const waitPromise = this.#waitSlot.wait(60)
+    this.#writeCommandPacket(command)
+    return waitPromise
   }
 
-  async #processQueue(): Promise<void> {
-    while (this.#queue.length > 0) {
-      const command = this.#queue.shift()
+  static async #processQueue(): Promise<void> {
+    while (Dynamixel.#queue.length > 0) {
+      const command = Dynamixel.#queue.shift()
       if (command == null) {
         continue
       }
       try {
         if (!command.waitForResponse) {
-          this.#writeCommandPacket(command)
+          command.target.#writeCommandPacket(command)
           command.resolve(undefined)
           continue
         }
-        const result = await this.#dispatchCommandWithWait(command)
+        const result = await command.target.#dispatchCommandWithWait(command)
         command.resolve(result)
       } catch (error) {
         command.reject(error)
       }
     }
-    this.#queueRunning = false
+    Dynamixel.#queueRunning = false
   }
 
   #sendCommand(
@@ -370,7 +378,9 @@ class Dynamixel {
     ...parameters: number[]
   ): Promise<number | undefined> {
     return new Promise((resolve, reject) => {
-      this.#queue.push({
+      Dynamixel.#queue.push({
+        target: this,
+        id: this.#id,
         instruction,
         address,
         parameters,
@@ -379,9 +389,9 @@ class Dynamixel {
         resolve,
         reject,
       })
-      if (!this.#queueRunning) {
-        this.#queueRunning = true
-        void this.#processQueue()
+      if (!Dynamixel.#queueRunning) {
+        Dynamixel.#queueRunning = true
+        void Dynamixel.#processQueue()
       }
     })
   }
@@ -410,6 +420,15 @@ class Dynamixel {
   #readSignedWord(offset: number): number {
     const value = this.#responseBuffer[offset] | (this.#responseBuffer[offset + 1] << 8)
     return value >= 0x8000 ? value - 0x10000 : value
+  }
+
+  #readSignedDword(offset: number): number {
+    return (
+      this.#responseBuffer[offset] |
+      (this.#responseBuffer[offset + 1] << 8) |
+      (this.#responseBuffer[offset + 2] << 16) |
+      (this.#responseBuffer[offset + 3] << 24)
+    )
   }
 
   /**
@@ -629,7 +648,7 @@ class Dynamixel {
    */
   async readPresentVelocity(): Promise<Maybe<number>> {
     const length = await this.#sendReadCommand(ADDRESS.PRESENT_VELOCITY, 4)
-    if (length != null && this.#hasValidResponse(4)) {
+    if (length != null && this.#hasValidResponse(6)) {
       if (this.#responseBuffer[1] !== 0) {
         return {
           success: false,
@@ -638,7 +657,7 @@ class Dynamixel {
       }
       return {
         success: true,
-        value: this.#readSignedWord(2),
+        value: this.#readSignedDword(2),
       }
     }
     return {
@@ -648,13 +667,13 @@ class Dynamixel {
 
   async readPresentPositionValue(): Promise<number | undefined> {
     const length = await this.#sendReadCommand(ADDRESS.PRESENT_POSITION, 4)
-    if (length == null || !this.#hasValidResponse(4)) {
+    if (length == null || !this.#hasValidResponse(6)) {
       return undefined
     }
     if (this.#responseBuffer[1] !== 0) {
       return undefined
     }
-    return this.#readSignedWord(2)
+    return this.#readSignedDword(2)
   }
 
   /**


### PR DESCRIPTION
## Summary
- Recreate the Dynamixel driver portion of #370 on top of develop.
- Switch Dynamixel serial reads to buffered packet parsing and queue commands to reduce allocation/copy overhead.
- Add configurable baudrate, feedback, and interval handling in the Dynamixel driver loop.

## Scope
This intentionally excludes the chat, renderer, and robot feedback-loop changes from #370 so the PR stays focused on Dynamixel driver behavior.

## Validation
- npm test --prefix firmware
- npm run lint --prefix firmware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible serial configuration (`baud` or `baudrate`), optional control interval, and feedback-mode control to improve servo behavior.
  * Enabled feedback-aware control-loop operation that switches between position/current behavior and applies feedback-current updates.
* **Bug Fixes**
  * Improved Dynamixel packet receive handling with buffered parsing, CRC validation, and safer response handling via shared buffer decoding.
  * Refined command/response queuing to ensure sequential execution and more consistent status/error interpretation.
  * Reworked control-loop initialization and scheduling to reduce timing drift and correctly handle enable/disable transitions.
* **Tests**
  * Increased the default LIN smoke-test timeout to better accommodate slower runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->