### PR TITLE
ci: update Emscripten to 5.0.1

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,7 +29,7 @@ runs:
       if: inputs.install-emscripten == 'true'
       uses: mymindstorm/setup-emsdk@v16
       with:
-        version: 3.1.2
+        version: 5.0.1
     - name: Install Moddable Linux tool dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
## Summary

Update the Emscripten SDK version used by the shared firmware setup action from `3.1.2` to `5.0.1`.

## Root Cause

The firmware setup action installs Emscripten before running `npm run setup` when `install-emscripten: true`.

With Emscripten `3.1.2`, `mymindstorm/setup-emsdk@v16` prepends Emscripten's bundled Node.js `14.18.2` to `PATH`. That causes `npm run setup` to run `xs-dev@1.12.1` on Node 14, but `xs-dev` requires modern Node syntax and fails on:

```text
SyntaxError: Unexpected token 'with'
```

Emscripten `5.0.1` uses a Node 22 based SDK environment, so `xs-dev` setup no longer falls back to Node 14.

## Validation

- PR CI: `Build Stack-chan Firmware / build (wasm, npm run build:wasm)` passed.
- PR CI: firmware device build matrix passed.
- PR CI: `Bundle Stack-chan Firmware / build` passed.
- Local: `npm run build:wasm` passed with Emscripten `5.0.1`.

## Notes

This fixes the CI setup failure caused by Node 14 in the Emscripten environment.

The separate browser runtime issue (`RuntimeError: unreachable`) is caused by a Moddable SDK `fxGet*` signature mismatch and is being handled upstream separately.
