### PR TITLE
fix(ci): build the intended targets in the firmware build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,13 +73,15 @@ jobs:
       matrix:
         include:
           - name: m5stack
-            command: npm run build --target=esp32/m5stack
+            command: npm run build:m5stack
           - name: m5stack_cores3
-            command: npm run build --target=esp32/m5stack_cores3
+            command: npm run build:m5stack_cores3
           - name: m5stackchan_cores3
             command: npm run build:m5stackchan_cores3
           - name: stackchan_rt
             command: npm run build:stackchan_rt
+          - name: takao_core2_sg90
+            command: npm run build:takao_core2_sg90
           - name: wasm
             command: npm run build:wasm
     steps:

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -22,6 +22,8 @@
     "build:m5stackchan_cores3": "node scripts/firmware.mjs build m5stackchan_cores3",
     "build:stackchan_rt": "node scripts/firmware.mjs build stackchan_rt",
     "build:takao_core2_sg90": "node scripts/firmware.mjs build takao_core2_sg90",
+    "build:m5stack": "mcconfig -d -m -p esp32/m5stack -t build \"$PWD/host/app/manifest_local.json\"",
+    "build:m5stack_cores3": "mcconfig -d -m -p esp32/m5stack_cores3 -t build \"$PWD/host/app/manifest_local.json\"",
     "build:lin": "mcconfig -d -m -p lin -t build \"$PWD/host/app/manifest_local.json\"",
     "smoke:lin": "bash scripts/smoke-lin.sh",
     "build:wasm": "mcconfig -d -m -p wasm -t build \"$PWD/host/app/manifest_wasm.json\" && mkdir -p ../web/simulator && cp $MODDABLE/build/bin/wasm/debug/app/mc.js $MODDABLE/build/bin/wasm/debug/app/mc.wasm ../web/simulator/",

--- a/firmware/scripts/firmware.mjs
+++ b/firmware/scripts/firmware.mjs
@@ -44,6 +44,16 @@ if (targetOption) {
   process.exit(1)
 }
 
+// npm swallows `--target=...` into this env var instead of argv; without this
+// guard the wrapper would silently fall back to the default device.
+if (process.env.npm_config_target) {
+  console.error(`[stack-chan] --target is not supported by this command wrapper: ${process.env.npm_config_target}`)
+  console.error(
+    '[stack-chan] Use a named script such as npm run build:m5stack, npm run build:m5stackchan_cores3, or npm run flash:takao_core2_sg90.',
+  )
+  process.exit(1)
+}
+
 const deviceName = resolveDevice(
   readOption(rawArgs, 'device') ?? process.env.STACKCHAN_DEVICE ?? firstDeviceArg(rawArgs),
 )


### PR DESCRIPTION
## Summary

CIのbuildマトリクスのうち m5stack / m5stack_cores3 レグが `npm run build --target=esp32/...` を使っていましたが、npm は `--target` を argv ではなく `npm_config_target` 環境変数に変換し、`scripts/firmware.mjs` はこれを参照しないため、**両レグともデフォルトの m5stackchan_cores3 に沈黙フォールバック**していました(素のm5stack系はCIで一度もビルドされておらず、m5stackchan_cores3 が3回ビルドされていた)。

- `build:m5stack` / `build:m5stack_cores3` スクリプトを追加(リアーキ前のbuildと同じく `manifest_local.json` を mcconfig 直接呼び出しでビルド)
- CIマトリクスを名前付きスクリプトに変更し、欠落していた `takao_core2_sg90` レグを追加
- `firmware.mjs` に `npm_config_target` 検知ガードを追加し、`--target=` 形式を沈黙フォールバックではなくエラーにする

## Release impact

none

CI設定と開発用ビルドラッパのみの変更で、出荷ファームウェアのコードには影響しません。リリースノート・changesetは不要です。

## Validation

- `source ~/.local/share/xs-dev-export.sh && npm run build:m5stack` → OK
- `source ~/.local/share/xs-dev-export.sh && npm run build:m5stack_cores3` → OK
- `npm run build --target=esp32/m5stack` → 新ガードによりエラーメッセージを出して失敗することを確認
- `STACKCHAN_DRY_RUN=1 npm run build` → 既存のデフォルトビルド(m5stackchan_cores3)が従来どおり動作
- `npx biome check scripts/firmware.mjs package.json` → OK

takao_core2_sg90 レグは本PRのCI実行で初回検証されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional firmware build targets, including a new target for the Takao Core2 SG90 and updated M5Stack build commands.

* **Bug Fixes**
  * Improved handling of unsupported build target arguments so the build process now stops with a clear message instead of falling back to the wrong device.
  * Updated automated build jobs to use the correct per-target build steps for firmware variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->