### PR TITLE
fix(ui): correct LISTENING/SPEAKING state mapping in chat-status-bar

### DIFF
--- a/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
+++ b/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
@@ -50,18 +50,18 @@ behavior.onChatState?.(bar, ChatStatusBarState.CONNECTING)
 assert(statusIndicator.visible === true, 'connecting indicator should be visible')
 assert(statusIcon.visible === false, 'status icon should be hidden while connecting')
 
-behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
-assert(levelTrack.visible === true, 'level track should be visible in SPEAKING')
-assert(statusIcon.visible === true, 'status icon should be visible in SPEAKING')
-equal(statusIcon.state, 0, 'SPEAKING should use microphone input icon state')
+behavior.onChatState?.(bar, ChatStatusBarState.LISTENING)
+assert(levelTrack.visible === true, 'level track should be visible in LISTENING')
+assert(statusIcon.visible === true, 'status icon should be visible in LISTENING')
+equal(statusIcon.state, 0, 'LISTENING should use microphone input icon state')
 
 behavior.onChatInputLevel?.(bar, 1000)
 equal(levelFill.height, 8, 'half input level should fill half the track')
 
-behavior.onChatState?.(bar, ChatStatusBarState.LISTENING)
-assert(levelTrack.visible === false, 'level track should be hidden in LISTENING')
-assert(statusIcon.visible === true, 'status icon should be visible in LISTENING')
-equal(statusIcon.state, 1, 'LISTENING should use output icon state')
+behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
+assert(levelTrack.visible === false, 'level track should be hidden in SPEAKING')
+assert(statusIcon.visible === true, 'status icon should be visible in SPEAKING')
+equal(statusIcon.state, 1, 'SPEAKING should use output icon state')
 
 const normalFillSkin = levelFill.skin
 behavior.onChatState?.(bar, ChatStatusBarState.FAILED, 'boom')

--- a/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
+++ b/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
@@ -103,8 +103,8 @@ class ChatStatusBarBehavior extends Behavior {
 
   updateUI() {
     if (!this.#levelTrack || !this.#levelFill || !this.#statusIcon || !this.#indicator) return
-    const isListening = this.#state === ChatStatusBarState.SPEAKING
-    const isSpeaking = this.#state === ChatStatusBarState.LISTENING
+    const isListening = this.#state === ChatStatusBarState.LISTENING
+    const isSpeaking = this.#state === ChatStatusBarState.SPEAKING
     const isConnecting = this.#state === ChatStatusBarState.CONNECTING
     this.#levelTrack.visible = isListening
     this.#statusIcon.visible = isListening || isSpeaking


### PR DESCRIPTION
## 概要

`chat-status-bar.ts` の `updateUI()` で `LISTENING` / `SPEAKING` の状態判定が入れ替わっており、入力レベルメーター(`levelTrack`)が SPEAKING 中に表示され、ステータスアイコンの state も逆になっていた問題を修正します(#399 指摘#10 の子Issue)。

Closes #509

## 変更内容

- `firmware/host/modules/ui/components/status-bar/chat-status-bar.ts`
  - `isListening` / `isSpeaking` の比較対象を正しい `ChatStatusBarState` 定数に入れ替え
  - 修正後: LISTENING でレベルメーター表示+マイクアイコン(state 0)、SPEAKING で出力アイコン(state 1)、レベルメーター非表示
- `firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts`
  - 既存の Moddable テストが反転した挙動をそのまま検証していたため、正しい state → UI マッピングを検証するようアサーションを修正(再発時に検知できる回帰テスト)

## 検証

以下を `firmware/` で実行し、いずれも成功しました:

- `npm run lint` — pass(388 files, エラーなし)
- `npm run test:unit` — pass(148 tests / 0 fail)
- `npm run check:architecture` — pass(79 tests / 0 fail)

注意: Moddable ビルド(`mcconfig`)および実機確認は未実施です。修正対象の Moddable テスト(`manifest.test.json` 経由の `test:moddable`)もローカル環境に Moddable SDK がないため未実行です。

## リリース影響

**patch** — ユーザー可視のUI不具合修正のためリリースノート推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected chat status behavior so the listening and speaking states now show the right visual indicators.
  * Updated the chat status bar so the level track and icon state match the current conversation mode more reliably.
  * Adjusted related test expectations to reflect the updated visibility and icon behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->