### PR TITLE
feat: add voice telemetry

### DIFF
--- a/docs/specs/log-schema.md
+++ b/docs/specs/log-schema.md
@@ -1,0 +1,97 @@
+# Log Schema
+
+Stack-chan firmware telemetry is emitted as one JSON object per line, prefixed
+with `@stackchan-telemetry `. The prefix lets serial logs, xsbug output, CI
+logs, and local tools distinguish machine-readable records from ordinary trace
+messages.
+
+Telemetry is diagnostic data, not a public MOD API. Additive fields are allowed
+within the same schema version, but existing field names and error codes should
+remain stable enough for tools and issue templates to aggregate failures.
+
+## Record Format
+
+Each telemetry line has this shape:
+
+```text
+@stackchan-telemetry {"v":1,"seq":1,"t":1234,"mod":"tts","ev":"playback.begin"}
+```
+
+Fields:
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `v` | number | yes | Schema version. Current version is `1`. |
+| `seq` | number | yes | Monotonic sequence number within the emitting channel. |
+| `t` | number | yes | Milliseconds since boot. |
+| `mod` | string | yes | Subsystem name, such as `tts`, `mic`, or `speaker`. |
+| `ev` | string | yes | Event name. Span events use `.begin`, `.end`, or `.fail`. |
+| `id` | number | no | Correlation id shared by one span and its marks. |
+| `dur` | number | no | Elapsed milliseconds since the span began. |
+| `err` | string | no | Stable error code. Error codes start with `E_`. |
+| `mem` | number | no | Free memory in bytes when a sampler is installed. |
+| `data` | object | no | Event payload. Values are strings, numbers, or booleans. |
+
+## Event Vocabulary
+
+TTS playback:
+
+| Event | Meaning |
+| --- | --- |
+| `playback.begin` | TTS playback was accepted and a playback span started. |
+| `playback.audio_open` | `AudioOut` was opened for the stream. |
+| `playback.first_audio` | The first ready signal arrived and playback started. |
+| `playback.stall` | Playback resumed after a buffer underrun. |
+| `playback.end` | Playback finished successfully. |
+| `playback.fail` | Playback failed. |
+| `playback.rejected` | Playback was rejected before a span could start. |
+
+TTS query:
+
+| Event | Meaning |
+| --- | --- |
+| `query.begin` | A provider-specific synthesis or query request started. |
+| `query.end` | The query finished successfully. |
+| `query.fail` | The query failed. |
+
+Microphone:
+
+| Event | Meaning |
+| --- | --- |
+| `record.begin` | Recording started. |
+| `record.end` | Recording completed and produced a WAV buffer. |
+| `record.fail` | Recording failed or was aborted. |
+| `record.rejected` | Recording was rejected before a span could start. |
+
+Speaker:
+
+| Event | Meaning |
+| --- | --- |
+| `play.begin` | Borrowed-buffer playback started. |
+| `play.end` | Borrowed-buffer playback completed. |
+| `play.fail` | Borrowed-buffer playback failed. |
+| `play.rejected` | Playback input was rejected before a span could start. |
+
+## Error Codes
+
+| Code | Meaning |
+| --- | --- |
+| `E_TTS_BUSY` | TTS playback was already active. |
+| `E_TTS_HTTP` | TTS provider returned an HTTP/server error. |
+| `E_TTS_NET` | TTS provider failed due to network, socket, DNS, or connection trouble. |
+| `E_TTS_ABORTED` | TTS work was aborted. |
+| `E_TTS_ERROR` | TTS failed for an uncategorized reason. |
+| `E_MIC_BUSY` | Recording was already active. |
+| `E_MIC_ABORTED` | Recording was aborted by lifecycle shutdown or stop. |
+| `E_MIC_ERROR` | Recording failed for an uncategorized reason. |
+| `E_SPK_FORMAT` | Speaker input buffer was not a supported WAV payload. |
+| `E_SPK_ERROR` | Speaker playback failed for an uncategorized reason. |
+
+## Payload Conventions
+
+- Use short stable keys in `data`.
+- Store durations in milliseconds and suffix those keys with `Ms`.
+- Store byte counts in bytes and name those keys `bytes`.
+- Store provider labels under `engine`.
+- Store truncated human-readable failure details under `reason`.
+- Do not put secrets, API keys, Wi-Fi passwords, or full request URLs in telemetry.

--- a/firmware/host/modules/audio/__tests__/tts-playback-lifecycle-telemetry.test.ts
+++ b/firmware/host/modules/audio/__tests__/tts-playback-lifecycle-telemetry.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { writeAliasPackage, writeAliasPackageSubpath } from '../../testing/node-alias-package.js'
+import type { TelemetryEvent } from '../../util/telemetry.js'
+
+type FakeTimeModule = typeof import('../../testing/fakes/time.js')
+
+function installBareSpecifierPackages(): void {
+  const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+  writeAliasPackage(modulesRoot, 'calculate-power', resolve(modulesRoot, 'testing/fakes/calculate-power.js'), {
+    hasDefaultExport: true,
+  })
+  writeAliasPackageSubpath(modulesRoot, 'pins', 'audioout', resolve(modulesRoot, 'testing/fakes/audio-out.js'), {
+    hasDefaultExport: true,
+  })
+  writeAliasPackage(modulesRoot, 'tts-types', resolve(modulesRoot, 'audio/tts-types.js'))
+  writeAliasPackage(modulesRoot, 'telemetry', resolve(modulesRoot, 'util/telemetry.js'))
+  writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), { hasDefaultExport: true })
+}
+
+async function setup() {
+  installBareSpecifierPackages()
+  const [lifecycle, telemetry, time, audioOut] = await Promise.all([
+    import('../tts-playback-lifecycle.js'),
+    import('../../util/telemetry.js'),
+    import('../../testing/fakes/time.js') as Promise<FakeTimeModule>,
+    import('../../testing/fakes/audio-out.js'),
+  ])
+  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = () => {}
+  audioOut.resetAudioOut()
+  time.default.reset()
+  return { ...lifecycle, ...telemetry, Time: time.default }
+}
+
+function collect(events: TelemetryEvent[], subscribe: (sink: (event: TelemetryEvent) => void) => () => void) {
+  return subscribe((event) => events.push(event))
+}
+
+test('TTS playback telemetry reports first audio, stalls, and played gaps', async () => {
+  const { beginTTSPlayback, getTelemetry, Time } = await setup()
+  const events: TelemetryEvent[] = []
+  const unsubscribe = collect(events, (sink) => getTelemetry().subscribe(sink))
+
+  const owner = { streaming: false, telemetryName: 'test-engine' }
+  const lifecycle = beginTTSPlayback(owner)
+  assert.ok(lifecycle)
+  lifecycle.openAudio({ streams: 1, sampleRate: 24000 }, 0.5)
+  Time.set(50)
+  lifecycle.onReady(true)
+  Time.set(60)
+  lifecycle.onPlayed(Uint8Array.of(1, 2).buffer)
+  Time.set(80)
+  lifecycle.onReady(false)
+  Time.set(130)
+  lifecycle.onReady(true)
+  Time.set(150)
+  lifecycle.onPlayed(Uint8Array.of(3, 4).buffer)
+  Time.set(200)
+  lifecycle.onDone()
+  unsubscribe()
+
+  assert.deepEqual(
+    events.map((event) => event.ev),
+    ['playback.begin', 'playback.audio_open', 'playback.first_audio', 'playback.stall', 'playback.end'],
+  )
+  const [begin, audioOpen, firstAudio, stall, end] = events
+  assert.deepEqual(begin.data, { engine: 'test-engine' })
+  assert.equal(audioOpen.id, begin.id)
+  assert.deepEqual(audioOpen.data, { sampleRate: 24000 })
+  assert.equal(firstAudio.dur, 50)
+  assert.deepEqual(stall.data, { stallMs: 50 })
+  assert.equal(end.dur, 200)
+  assert.deepEqual(end.data, {
+    played: 2,
+    stalls: 1,
+    stallMs: 50,
+    maxGapMs: 90,
+    firstAudioMs: 50,
+  })
+})
+
+test('TTS playback telemetry counts a stall that is still open at failure time', async () => {
+  const { beginTTSPlayback, getTelemetry, Time } = await setup()
+  const events: TelemetryEvent[] = []
+  const unsubscribe = collect(events, (sink) => getTelemetry().subscribe(sink))
+
+  const owner = { streaming: false, telemetryName: 'test-engine' }
+  const lifecycle = beginTTSPlayback(owner)
+  assert.ok(lifecycle)
+  lifecycle.openAudio({ streams: 1, sampleRate: 11025 }, 0.5)
+  Time.set(10)
+  lifecycle.onReady(true)
+  Time.set(30)
+  lifecycle.onReady(false)
+  Time.set(70)
+  lifecycle.onError('server returned 500')
+  unsubscribe()
+
+  const fail = events.at(-1)
+  assert.ok(fail)
+  assert.equal(fail.ev, 'playback.fail')
+  assert.equal(fail.err, 'E_TTS_HTTP')
+  assert.equal(fail.data?.stalls, 1)
+  assert.equal(fail.data?.stallMs, 40)
+  assert.equal(fail.data?.reason, 'server returned 500')
+})
+
+test('TTS playback telemetry reports busy rejections', async () => {
+  const { beginTTSPlayback, getTelemetry } = await setup()
+  const events: TelemetryEvent[] = []
+
+  const owner = { streaming: false, telemetryName: 'test-engine' }
+  const active = beginTTSPlayback(owner)
+  assert.ok(active)
+  const unsubscribe = collect(events, (sink) => getTelemetry().subscribe(sink))
+  const duplicate = beginTTSPlayback(owner)
+  unsubscribe()
+  active.onDone()
+
+  assert.equal(duplicate, undefined)
+  assert.equal(events.length, 1)
+  assert.equal(events[0].ev, 'playback.rejected')
+  assert.equal(events[0].err, 'E_TTS_BUSY')
+  assert.deepEqual(events[0].data, { engine: 'test-engine' })
+})
+
+test('classifyTTSError maps raw errors onto the stable vocabulary', async () => {
+  const { classifyTTSError } = await setup()
+  assert.equal(classifyTTSError(new Error('already playing')), 'E_TTS_BUSY')
+  assert.equal(classifyTTSError('server returned 404'), 'E_TTS_HTTP')
+  assert.equal(classifyTTSError(new Error('socket closed')), 'E_TTS_NET')
+  assert.equal(classifyTTSError('DNS lookup failed'), 'E_TTS_NET')
+  assert.equal(classifyTTSError(new Error('request aborted')), 'E_TTS_ABORTED')
+  assert.equal(classifyTTSError(new Error('boom')), 'E_TTS_ERROR')
+})

--- a/firmware/host/modules/audio/__tests__/tts-playback-lifecycle.test.ts
+++ b/firmware/host/modules/audio/__tests__/tts-playback-lifecycle.test.ts
@@ -16,6 +16,8 @@ function installBareSpecifierPackages(): void {
     hasDefaultExport: true,
   })
   writeAliasPackage(modulesRoot, 'tts-types', resolve(modulesRoot, 'audio/tts-types.js'))
+  writeAliasPackage(modulesRoot, 'telemetry', resolve(modulesRoot, 'util/telemetry.js'))
+  writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), { hasDefaultExport: true })
 }
 
 async function setup() {

--- a/firmware/host/modules/audio/microphone.ts
+++ b/firmware/host/modules/audio/microphone.ts
@@ -1,5 +1,6 @@
 import { type OwnedAudioBuffer, ownAudioBuffer } from 'audio-buffer'
 import AudioIn from 'audio-in'
+import { getTelemetry, truncateReason } from 'telemetry'
 
 const CHANNELS = 1
 
@@ -41,9 +42,11 @@ export default class Microphone {
 
   async record(durationMilliSec = 3000): Promise<OwnedAudioBuffer> {
     if (this.recording) {
+      getTelemetry().emit('mic', 'record.rejected', { err: 'E_MIC_BUSY' })
       throw new Error('already recording')
     }
     this.recording = true
+    const span = getTelemetry().begin('mic', 'record', { durationMs: durationMilliSec })
     const HEADER_SIZE = 44
 
     return new Promise((resolve, reject) => {
@@ -58,6 +61,7 @@ export default class Microphone {
         this.#abortRecording = null
         audioin?.close()
         this.recording = false
+        span.end({ data: { bytes: writeOffset } })
         resolve(ownAudioBuffer(wavBuffer))
       }
       const fail = (error: unknown) => {
@@ -66,6 +70,9 @@ export default class Microphone {
         this.#abortRecording = null
         audioin?.close()
         this.recording = false
+        span.fail(String(error).includes('abort') ? 'E_MIC_ABORTED' : 'E_MIC_ERROR', {
+          data: { reason: truncateReason(String(error)) },
+        })
         reject(error)
       }
       // Lets stop() abort a finite recording so close() never leaves the microphone held.
@@ -94,6 +101,7 @@ export default class Microphone {
       } catch (error) {
         this.#abortRecording = null
         this.recording = false
+        span.fail('E_MIC_ERROR', { data: { reason: truncateReason(String(error)) } })
         reject(error)
         return
       }

--- a/firmware/host/modules/audio/speaker.ts
+++ b/firmware/host/modules/audio/speaker.ts
@@ -2,6 +2,7 @@
 
 import type { BorrowedAudioBuffer } from 'audio-buffer'
 import AudioOut from 'pins/audioout'
+import { getTelemetry, truncateReason } from 'telemetry'
 
 const WAV_HEADER_SIZE = 44
 
@@ -36,14 +37,21 @@ export default class Speaker {
   }
 
   async play(buffer: BorrowedAudioBuffer): Promise<boolean> {
-    if (buffer.byteLength <= WAV_HEADER_SIZE) return false
+    const telemetry = getTelemetry()
+    if (buffer.byteLength <= WAV_HEADER_SIZE) {
+      telemetry.emit('speaker', 'play.rejected', { err: 'E_SPK_FORMAT', data: { bytes: buffer.byteLength } })
+      return false
+    }
+    const span = telemetry.begin('speaker', 'play', { bytes: buffer.byteLength })
     try {
       const view = new DataView(buffer)
       const numChannels = view.getUint16(22, true)
       const sampleRate = view.getUint32(24, true)
       const bitsPerSample = view.getUint16(34, true)
-      if (bitsPerSample !== 16 || (numChannels !== 1 && numChannels !== 2)) return false
-      if (sampleRate < 8000 || sampleRate > 48000) return false
+      if (bitsPerSample !== 16 || (numChannels !== 1 && numChannels !== 2) || sampleRate < 8000 || sampleRate > 48000) {
+        span.fail('E_SPK_FORMAT', { data: { sampleRate, numChannels, bitsPerSample } })
+        return false
+      }
 
       // AudioOut.RawSamples requires a non-relocatable buffer; a plain ArrayBuffer is
       // relocatable and rejected, so copy the PCM payload into a SharedArrayBuffer.
@@ -62,11 +70,12 @@ export default class Speaker {
         audio.start()
         audio.callback = () => {
           audio.close()
+          span.end({ data: { sampleRate } })
           resolve(true)
         }
       })
     } catch (error) {
-      trace(`Speaker.play error ${error}\n`)
+      span.fail('E_SPK_ERROR', { data: { reason: truncateReason(String(error)) } })
       return false
     }
   }

--- a/firmware/host/modules/audio/tts-elevenlabs.ts
+++ b/firmware/host/modules/audio/tts-elevenlabs.ts
@@ -27,6 +27,7 @@ export type TTSProperty = {
 }
 
 export class TTS {
+  readonly telemetryName = 'elevenlabs'
   audio?: AudioOut
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener

--- a/firmware/host/modules/audio/tts-local.ts
+++ b/firmware/host/modules/audio/tts-local.ts
@@ -15,6 +15,7 @@ export type TTSProperty = {
 }
 
 export class TTS {
+  readonly telemetryName = 'local'
   audio?: AudioOut
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener

--- a/firmware/host/modules/audio/tts-openai.ts
+++ b/firmware/host/modules/audio/tts-openai.ts
@@ -19,6 +19,7 @@ export type TTSProperty = {
 }
 
 export class TTS {
+  readonly telemetryName = 'openai'
   audio?: AudioOut
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener

--- a/firmware/host/modules/audio/tts-playback-lifecycle.ts
+++ b/firmware/host/modules/audio/tts-playback-lifecycle.ts
@@ -1,5 +1,6 @@
 import calculatePower from 'calculate-power'
 import AudioOut from 'pins/audioout'
+import { type TelemetryFields, getTelemetry, truncateReason } from 'telemetry'
 import type { TTSCompletion, TTSDoneListener, TTSPlaybackListener } from 'tts-types'
 
 type AudioOutOptions = {
@@ -18,6 +19,8 @@ export type TTSPlaybackOwner = {
   streaming: boolean
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener
+  /** Engine label recorded in telemetry events, e.g. "voicevox" */
+  telemetryName?: string
 }
 
 export type TTSPlaybackLifecycle = {
@@ -31,6 +34,19 @@ export type TTSPlaybackLifecycle = {
   fail(error: unknown): void
 }
 
+/**
+ * Maps a raw playback error onto the stable error-code vocabulary of
+ * docs/specs/log-schema.md so failures can be aggregated across engines.
+ */
+export function classifyTTSError(error: unknown): string {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase()
+  if (message.includes('already playing')) return 'E_TTS_BUSY'
+  if (message.includes('server returned')) return 'E_TTS_HTTP'
+  if (message.includes('socket') || message.includes('connect') || message.includes('dns')) return 'E_TTS_NET'
+  if (message.includes('abort')) return 'E_TTS_ABORTED'
+  return 'E_TTS_ERROR'
+}
+
 function closeResource(close: (() => void) | undefined): void {
   try {
     close?.()
@@ -40,9 +56,24 @@ function closeResource(close: (() => void) | undefined): void {
 }
 
 export function createTTSPlaybackLifecycle(owner: TTSPlaybackOwner, callback?: TTSCompletion): TTSPlaybackLifecycle {
+  const telemetry = getTelemetry()
+  const span = telemetry.begin('tts', 'playback', { engine: owner.telemetryName ?? 'tts' })
   let completed = false
   let streamer: Closable | undefined
   const cleanupTasks: (() => void)[] = []
+
+  // Distinguishes TTS dropout causes: `stalls`/`stallMs` count buffer
+  // underruns (onReady false→true round trips after playback started),
+  // `maxGapMs` exposes scheduling delays between played blocks, and
+  // `firstAudioMs` captures network/synthesis latency before first audio.
+  let audioStarted = false
+  let stallStartedAt = -1
+  let stallCount = 0
+  let stallTotalMs = 0
+  let firstAudioMs = -1
+  let playedCount = 0
+  let lastPlayedAt = -1
+  let maxPlayedGapMs = 0
 
   const finish = (error?: unknown): void => {
     if (completed) return
@@ -56,6 +87,25 @@ export function createTTSPlaybackLifecycle(owner: TTSPlaybackOwner, callback?: T
     closeResource(() => owner.audio?.close())
     owner.audio = undefined
 
+    if (stallStartedAt >= 0) {
+      stallCount += 1
+      stallTotalMs += telemetry.now() - stallStartedAt
+      stallStartedAt = -1
+    }
+    const summary: TelemetryFields = {
+      played: playedCount,
+      stalls: stallCount,
+      stallMs: stallTotalMs,
+      maxGapMs: maxPlayedGapMs,
+    }
+    if (firstAudioMs >= 0) summary.firstAudioMs = firstAudioMs
+    if (error == null) {
+      span.end({ data: summary })
+    } else {
+      summary.reason = truncateReason(String(error))
+      span.fail(classifyTTSError(error), { data: summary })
+    }
+
     owner.onDone?.()
     callback?.(error)
   }
@@ -65,6 +115,7 @@ export function createTTSPlaybackLifecycle(owner: TTSPlaybackOwner, callback?: T
       const audio = new AudioOut(options)
       audio.enqueue(0, AudioOut.Volume, Math.round(volume * 256))
       owner.audio = audio
+      span.mark('playback.audio_open', { data: { sampleRate: options.sampleRate ?? 0 } })
       return audio
     },
     attach<T extends Closable>(nextStreamer: T): T {
@@ -76,24 +127,39 @@ export function createTTSPlaybackLifecycle(owner: TTSPlaybackOwner, callback?: T
     },
     onPlayed(buffer: ArrayBuffer): void {
       if (completed) return
+      const now = telemetry.now()
+      if (lastPlayedAt >= 0 && now - lastPlayedAt > maxPlayedGapMs) maxPlayedGapMs = now - lastPlayedAt
+      lastPlayedAt = now
+      playedCount += 1
       owner.onPlayed?.(calculatePower(buffer))
     },
     onReady(state: boolean): void {
       if (completed || !owner.audio) return
-      trace(`Ready: ${state}\n`)
-      if (state) owner.audio.start()
-      else owner.audio.stop()
+      if (state) {
+        if (!audioStarted) {
+          audioStarted = true
+          firstAudioMs = span.elapsed()
+          span.mark('playback.first_audio')
+        } else if (stallStartedAt >= 0) {
+          const stallMs = telemetry.now() - stallStartedAt
+          stallStartedAt = -1
+          stallCount += 1
+          stallTotalMs += stallMs
+          span.mark('playback.stall', { data: { stallMs } })
+        }
+        owner.audio.start()
+      } else {
+        if (audioStarted && stallStartedAt < 0) stallStartedAt = telemetry.now()
+        owner.audio.stop()
+      }
     },
     onError(error: unknown): void {
-      trace('ERROR: ', String(error), '\n')
       finish(error)
     },
     onDone(): void {
-      trace('DONE\n')
       finish()
     },
     fail(error: unknown): void {
-      trace('ERROR: ', String(error), '\n')
       finish(error)
     },
   }
@@ -101,6 +167,10 @@ export function createTTSPlaybackLifecycle(owner: TTSPlaybackOwner, callback?: T
 
 export function beginTTSPlayback(owner: TTSPlaybackOwner, callback?: TTSCompletion): TTSPlaybackLifecycle | undefined {
   if (owner.streaming) {
+    getTelemetry().emit('tts', 'playback.rejected', {
+      err: 'E_TTS_BUSY',
+      data: { engine: owner.telemetryName ?? 'tts' },
+    })
     callback?.(new Error('already playing'))
     return undefined
   }

--- a/firmware/host/modules/audio/tts-remote.ts
+++ b/firmware/host/modules/audio/tts-remote.ts
@@ -27,6 +27,7 @@ export type TTSProperty = {
 }
 
 export class TTS {
+  readonly telemetryName = 'remote'
   audio?: AudioOut
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener

--- a/firmware/host/modules/audio/tts-voicevox-web.ts
+++ b/firmware/host/modules/audio/tts-voicevox-web.ts
@@ -4,7 +4,8 @@ import type HTTPClient from 'embedded:network/http/client'
 import { fetch } from 'fetch'
 import MP3Streamer from 'mp3streamer'
 import type AudioOut from 'pins/audioout'
-import { beginTTSPlayback } from 'tts-playback-lifecycle'
+import { getTelemetry, truncateReason } from 'telemetry'
+import { beginTTSPlayback, classifyTTSError } from 'tts-playback-lifecycle'
 import type { TTSCompletion, TTSDoneListener, TTSPlaybackListener } from 'tts-types'
 import { URL } from 'url'
 
@@ -29,6 +30,7 @@ export type TTSProperty = {
 }
 
 export class TTS {
+  readonly telemetryName = 'voicevox-web'
   audio?: AudioOut
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener
@@ -68,8 +70,10 @@ export class TTS {
     if (!lifecycle) return
 
     const speakerId = this.speakerId
+    const querySpan = getTelemetry().begin('tts', 'query', { engine: this.telemetryName })
     this.getQuery(key, speakerId).then(
       (streamUrl) => {
+        querySpan.end()
         try {
           const url = new URL(streamUrl)
           const audio = lifecycle.openAudio(
@@ -97,6 +101,7 @@ export class TTS {
         }
       },
       (error) => {
+        querySpan.fail(classifyTTSError(error), { data: { reason: truncateReason(String(error)) } })
         lifecycle.fail(new Error(`getQuery failed: ${error}`))
       },
     )

--- a/firmware/host/modules/audio/tts-voicevox.ts
+++ b/firmware/host/modules/audio/tts-voicevox.ts
@@ -5,7 +5,8 @@ import { File } from 'file'
 import Headers from 'headers'
 import config from 'mc/config'
 import type AudioOut from 'pins/audioout'
-import { beginTTSPlayback } from 'tts-playback-lifecycle'
+import { getTelemetry, truncateReason } from 'telemetry'
+import { beginTTSPlayback, classifyTTSError } from 'tts-playback-lifecycle'
 import type { TTSCompletion, TTSDoneListener, TTSPlaybackListener } from 'tts-types'
 import WavStreamer from 'wavstreamer'
 
@@ -33,6 +34,7 @@ export type TTSProperty = {
 }
 
 export class TTS {
+  readonly telemetryName = 'voicevox'
   audio?: AudioOut
   onPlayed?: TTSPlaybackListener
   onDone?: TTSDoneListener
@@ -108,12 +110,13 @@ export class TTS {
     const host = this.host
     const port = this.port
     const speakerId = this.speakerId
+    const querySpan = getTelemetry().begin('tts', 'query', { engine: this.telemetryName })
     this.getQuery(key, speakerId).then(
       () => {
         try {
           const file = new File(QUERY_PATH)
           lifecycle.addCleanup(() => file.close())
-          trace(`file opened. length: ${file.length}, position: ${file.position}`)
+          querySpan.end({ data: { bytes: file.length } })
           const audio = lifecycle.openAudio(
             { streams: 1, bitsPerSample: 16, sampleRate: this.sampleRate },
             volume ?? this.volume,
@@ -153,6 +156,7 @@ export class TTS {
         }
       },
       (error) => {
+        querySpan.fail(classifyTTSError(error), { data: { reason: truncateReason(String(error)) } })
         lifecycle.fail(error)
       },
     )

--- a/firmware/host/modules/util/__tests__/telemetry/manifest.test.json
+++ b/firmware/host/modules/util/__tests__/telemetry/manifest.test.json
@@ -1,0 +1,11 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "$(MODDABLE)/examples/manifest_typings.json",
+    "../../manifest.json",
+    "../../../testing/manifest.json"
+  ],
+  "modules": {
+    "main": "./telemetry.test"
+  }
+}

--- a/firmware/host/modules/util/__tests__/telemetry/telemetry.test.ts
+++ b/firmware/host/modules/util/__tests__/telemetry/telemetry.test.ts
@@ -1,0 +1,37 @@
+import { TELEMETRY_TRACE_PREFIX, TelemetryChannel, createTraceSink, getTelemetry } from 'telemetry'
+import { assert, equal } from 'testing/assert'
+
+let now = 0
+const channel = new TelemetryChannel({ now: () => now })
+const lines: string[] = []
+channel.subscribe(createTraceSink((line) => lines.push(line)))
+
+now = 5
+const span = channel.begin('tts', 'playback', { engine: 'test' })
+now = 25
+span.mark('playback.first_audio')
+now = 45
+span.end({ data: { played: 2 } })
+span.fail('E_TTS_ERROR')
+
+const history = channel.history()
+equal(history.length, 3, 'span emits begin, mark, and end exactly once')
+equal(history[0].ev, 'playback.begin', 'begin event name')
+equal(history[0].id, span.id, 'begin event carries the span id')
+equal(history[1].dur, 20, 'mark duration')
+equal(history[2].ev, 'playback.end', 'end event name')
+equal(history[2].dur, 40, 'end duration')
+
+equal(lines.length, 3, 'trace sink received every event')
+assert(lines[0].indexOf(TELEMETRY_TRACE_PREFIX) === 0, 'trace lines carry the machine-readable prefix')
+const parsed = JSON.parse(lines[2].slice(TELEMETRY_TRACE_PREFIX.length))
+equal(parsed.ev, 'playback.end', 'trace lines are valid JSON')
+equal(parsed.v, 1, 'schema version')
+
+// the shared channel is created at runtime even though this module is preloaded
+const shared = getTelemetry()
+assert(shared === getTelemetry(), 'shared channel is a singleton')
+shared.emit('tts', 'playback.begin')
+equal(shared.history().length, 1, 'shared channel records events')
+
+trace('ok\n')

--- a/firmware/host/modules/util/manifest.json
+++ b/firmware/host/modules/util/manifest.json
@@ -6,9 +6,10 @@
   ],
   "modules": {
     "stackchan-util": "./stackchan-util",
+    "telemetry": "./telemetry",
     "mac-address": "./sim/mac-address"
   },
-  "preload": ["stackchan-util", "mac-address"],
+  "preload": ["stackchan-util", "telemetry", "mac-address"],
   "platforms": {
     "esp32": {
       "modules": {

--- a/firmware/host/modules/util/telemetry.test.ts
+++ b/firmware/host/modules/util/telemetry.test.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { writeAliasPackage } from '../testing/node-alias-package.js'
+
+type FakeTimeModule = typeof import('../testing/fakes/time.js')
+
+function installBareSpecifierPackages(): void {
+  const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), { hasDefaultExport: true })
+}
+
+async function setup() {
+  installBareSpecifierPackages()
+  const [telemetry, time] = await Promise.all([
+    import('./telemetry.js'),
+    import('../testing/fakes/time.js') as Promise<FakeTimeModule>,
+  ])
+  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = () => {}
+  time.default.reset()
+  return { ...telemetry, Time: time.default }
+}
+
+test('telemetry events carry schema version, sequence, and timestamp', async () => {
+  const { TelemetryChannel, Time } = await setup()
+  const channel = new TelemetryChannel()
+
+  Time.set(120)
+  const first = channel.emit('tts', 'playback.begin')
+  Time.set(150)
+  const second = channel.emit('tts', 'playback.end', { err: 'E_TTS_ERROR', dur: 30, data: { engine: 'test' } })
+
+  assert.equal(first.v, 1)
+  assert.equal(first.seq, 1)
+  assert.equal(first.t, 120)
+  assert.equal(first.mod, 'tts')
+  assert.equal(first.ev, 'playback.begin')
+  assert.equal(first.mem, undefined)
+  assert.equal(second.seq, 2)
+  assert.equal(second.t, 150)
+  assert.equal(second.err, 'E_TTS_ERROR')
+  assert.equal(second.dur, 30)
+  assert.deepEqual(second.data, { engine: 'test' })
+})
+
+test('telemetry spans settle once and correlate events by id', async () => {
+  const { TelemetryChannel, Time } = await setup()
+  const channel = new TelemetryChannel()
+
+  Time.set(1000)
+  const span = channel.begin('tts', 'playback', { engine: 'test' })
+  Time.set(1040)
+  span.mark('playback.first_audio')
+  Time.set(1100)
+  span.end({ data: { played: 3 } })
+  span.fail('E_TTS_ERROR')
+  span.end()
+
+  const events = channel.history()
+  assert.deepEqual(
+    events.map((event) => event.ev),
+    ['playback.begin', 'playback.first_audio', 'playback.end'],
+  )
+  const [begin, mark, end] = events
+  assert.equal(begin.id, span.id)
+  assert.equal(begin.id, begin.seq)
+  assert.deepEqual(begin.data, { engine: 'test' })
+  assert.equal(mark.id, span.id)
+  assert.equal(mark.dur, 40)
+  assert.equal(end.id, span.id)
+  assert.equal(end.dur, 100)
+  assert.deepEqual(end.data, { played: 3 })
+})
+
+test('telemetry span fail records the error code and duration', async () => {
+  const { TelemetryChannel, Time } = await setup()
+  const channel = new TelemetryChannel()
+
+  Time.set(0)
+  const span = channel.begin('mic', 'record')
+  Time.set(25)
+  assert.equal(span.elapsed(), 25)
+  span.fail('E_MIC_ABORTED', { data: { reason: 'stopped' } })
+
+  const fail = channel.history().at(-1)
+  assert.ok(fail)
+  assert.equal(fail.ev, 'record.fail')
+  assert.equal(fail.err, 'E_MIC_ABORTED')
+  assert.equal(fail.dur, 25)
+  assert.deepEqual(fail.data, { reason: 'stopped' })
+})
+
+test('telemetry history keeps only the newest events', async () => {
+  const { TelemetryChannel } = await setup()
+  const channel = new TelemetryChannel({ historySize: 3 })
+
+  for (let index = 0; index < 5; index += 1) {
+    channel.emit('tts', `event.${index}`)
+  }
+
+  assert.deepEqual(
+    channel.history().map((event) => event.ev),
+    ['event.2', 'event.3', 'event.4'],
+  )
+  assert.equal(channel.history().at(-1)?.seq, 5)
+})
+
+test('telemetry sinks are isolated and can unsubscribe', async () => {
+  const { TelemetryChannel } = await setup()
+  const channel = new TelemetryChannel()
+  const seen: string[] = []
+
+  channel.subscribe(() => {
+    throw new Error('broken sink')
+  })
+  const unsubscribe = channel.subscribe((event) => seen.push(event.ev))
+
+  channel.emit('tts', 'playback.begin')
+  unsubscribe()
+  channel.emit('tts', 'playback.end')
+
+  assert.deepEqual(seen, ['playback.begin'])
+})
+
+test('telemetry samples memory when a sampler is installed', async () => {
+  const { TelemetryChannel } = await setup()
+  const channel = new TelemetryChannel({ memory: () => 4096 })
+
+  assert.equal(channel.emit('tts', 'playback.begin').mem, 4096)
+  channel.setMemorySampler(undefined)
+  assert.equal(channel.emit('tts', 'playback.end').mem, undefined)
+})
+
+test('telemetry trace sink writes prefixed JSON lines', async () => {
+  const { TelemetryChannel, createTraceSink, TELEMETRY_TRACE_PREFIX } = await setup()
+  const channel = new TelemetryChannel()
+  const lines: string[] = []
+  channel.subscribe(createTraceSink((line) => lines.push(line)))
+
+  channel.emit('speaker', 'play.begin', { data: { bytes: 128 } })
+
+  assert.equal(lines.length, 1)
+  assert.ok(lines[0].startsWith(TELEMETRY_TRACE_PREFIX))
+  const parsed = JSON.parse(lines[0].slice(TELEMETRY_TRACE_PREFIX.length))
+  assert.equal(parsed.mod, 'speaker')
+  assert.equal(parsed.ev, 'play.begin')
+  assert.deepEqual(parsed.data, { bytes: 128 })
+})
+
+test('telemetry shared channel is a lazily created singleton', async () => {
+  const { getTelemetry } = await setup()
+  const traced: string[] = []
+  ;(globalThis as typeof globalThis & { trace: (message: string) => void }).trace = (message: string) =>
+    traced.push(message)
+
+  const channel = getTelemetry()
+  assert.equal(getTelemetry(), channel)
+  channel.emit('tts', 'playback.begin')
+
+  assert.ok(traced.some((line) => line.includes('"ev":"playback.begin"')))
+})
+
+test('telemetry truncates long failure reasons', async () => {
+  const { truncateReason } = await setup()
+  const long = 'x'.repeat(200)
+  assert.equal(truncateReason('short'), 'short')
+  assert.equal(truncateReason(long).length, 123)
+  assert.ok(truncateReason(long).endsWith('...'))
+})

--- a/firmware/host/modules/util/telemetry.ts
+++ b/firmware/host/modules/util/telemetry.ts
@@ -1,0 +1,207 @@
+import Time from 'time'
+
+export const TELEMETRY_SCHEMA_VERSION = 1
+export const TELEMETRY_TRACE_PREFIX = '@stackchan-telemetry '
+
+const DEFAULT_HISTORY_SIZE = 32
+const MAX_REASON_LENGTH = 120
+
+export type TelemetryValue = string | number | boolean
+export type TelemetryFields = Record<string, TelemetryValue>
+
+/**
+ * One structured telemetry record. Serialized as a single JSON line so that
+ * humans (xsbug/serial), CI, and LLM agents can all consume the same output.
+ * See docs/specs/log-schema.md for the field and vocabulary contract.
+ */
+export type TelemetryEvent = {
+  /** Schema version of this record */
+  v: number
+  /** Monotonic sequence number within the emitting channel */
+  seq: number
+  /** Timestamp in milliseconds since boot */
+  t: number
+  /** Subsystem that emitted the event, e.g. "tts", "mic", "speaker" */
+  mod: string
+  /** Event name, e.g. "playback.begin" */
+  ev: string
+  /** Correlation id shared by all events of one span */
+  id?: number
+  /** Stable machine-readable error code (E_*) */
+  err?: string
+  /** Milliseconds elapsed since the owning span began */
+  dur?: number
+  /** Free memory in bytes, present when a memory sampler is installed */
+  mem?: number
+  /** Event-specific payload */
+  data?: TelemetryFields
+}
+
+export type TelemetrySink = (event: TelemetryEvent) => void
+export type MemorySampler = () => number
+
+export type TelemetryEmitOptions = {
+  id?: number
+  err?: string
+  dur?: number
+  data?: TelemetryFields
+}
+
+/**
+ * A timed unit of work. `end`/`fail` settle the span exactly once;
+ * `mark` records intermediate events sharing the span id.
+ */
+export type TelemetrySpan = {
+  readonly id: number
+  elapsed(): number
+  mark(ev: string, options?: TelemetryEmitOptions): void
+  end(options?: TelemetryEmitOptions): void
+  fail(err: string, options?: TelemetryEmitOptions): void
+}
+
+export type TelemetryOptions = {
+  now?: () => number
+  memory?: MemorySampler
+  historySize?: number
+}
+
+export function truncateReason(reason: string): string {
+  return reason.length > MAX_REASON_LENGTH ? `${reason.slice(0, MAX_REASON_LENGTH)}...` : reason
+}
+
+export function formatTelemetryLine(event: TelemetryEvent): string {
+  return `${TELEMETRY_TRACE_PREFIX}${JSON.stringify(event)}`
+}
+
+export function createTraceSink(write?: (line: string) => void): TelemetrySink {
+  const emitLine =
+    write ??
+    ((line: string) => {
+      if (typeof trace === 'function') trace(`${line}\n`)
+    })
+  return (event) => emitLine(formatTelemetryLine(event))
+}
+
+export class TelemetryChannel {
+  #now: () => number
+  #memory: MemorySampler | undefined
+  #historySize: number
+  #history: TelemetryEvent[]
+  #sinks: TelemetrySink[]
+  #seq: number
+
+  constructor(options: TelemetryOptions = {}) {
+    this.#now = options.now ?? (() => Time.ticks)
+    this.#memory = options.memory
+    this.#historySize = options.historySize ?? DEFAULT_HISTORY_SIZE
+    this.#history = []
+    this.#sinks = []
+    this.#seq = 0
+  }
+
+  now(): number {
+    return this.#now()
+  }
+
+  setMemorySampler(sampler: MemorySampler | undefined): void {
+    this.#memory = sampler
+  }
+
+  subscribe(sink: TelemetrySink): () => void {
+    this.#sinks.push(sink)
+    return () => {
+      const index = this.#sinks.indexOf(sink)
+      if (index >= 0) this.#sinks.splice(index, 1)
+    }
+  }
+
+  /** Recent events, oldest first, capped at `historySize` */
+  history(): TelemetryEvent[] {
+    return this.#history.slice()
+  }
+
+  emit(mod: string, ev: string, options: TelemetryEmitOptions = {}): TelemetryEvent {
+    this.#seq += 1
+    const event: TelemetryEvent = {
+      v: TELEMETRY_SCHEMA_VERSION,
+      seq: this.#seq,
+      t: this.#now(),
+      mod,
+      ev,
+    }
+    if (options.id !== undefined) event.id = options.id
+    if (options.err !== undefined) event.err = options.err
+    if (options.dur !== undefined) event.dur = options.dur
+    const mem = this.#memory?.()
+    if (mem !== undefined) event.mem = mem
+    if (options.data !== undefined) event.data = options.data
+    this.#history.push(event)
+    if (this.#history.length > this.#historySize) this.#history.shift()
+    for (const sink of this.#sinks) {
+      try {
+        sink(event)
+      } catch {
+        // a broken sink must never break the instrumented code path
+      }
+    }
+    return event
+  }
+
+  begin(mod: string, name: string, data?: TelemetryFields): TelemetrySpan {
+    const startedAt = this.#now()
+    // the span id doubles as the begin event's own seq for correlation
+    const begin = this.emit(mod, `${name}.begin`, { id: this.#seq + 1, data })
+    const id = begin.seq
+    const channel = this
+    let settled = false
+    const settle = (ev: string, options: TelemetryEmitOptions): void => {
+      if (settled) return
+      settled = true
+      channel.emit(mod, ev, options)
+    }
+    return {
+      id,
+      elapsed(): number {
+        return channel.#now() - startedAt
+      },
+      mark(ev: string, options: TelemetryEmitOptions = {}): void {
+        channel.emit(mod, ev, {
+          id,
+          err: options.err,
+          dur: options.dur ?? channel.#now() - startedAt,
+          data: options.data,
+        })
+      },
+      end(options: TelemetryEmitOptions = {}): void {
+        settle(`${name}.end`, {
+          id,
+          err: options.err,
+          dur: options.dur ?? channel.#now() - startedAt,
+          data: options.data,
+        })
+      },
+      fail(err: string, options: TelemetryEmitOptions = {}): void {
+        settle(`${name}.fail`, {
+          id,
+          err,
+          dur: options.dur ?? channel.#now() - startedAt,
+          data: options.data,
+        })
+      },
+    }
+  }
+}
+
+let sharedTelemetry: TelemetryChannel | undefined
+
+/**
+ * Shared device-wide channel. Created lazily at runtime so the module
+ * stays preloadable; the default sink writes JSON lines to `trace`.
+ */
+export function getTelemetry(): TelemetryChannel {
+  if (sharedTelemetry === undefined) {
+    sharedTelemetry = new TelemetryChannel()
+    sharedTelemetry.subscribe(createTraceSink())
+  }
+  return sharedTelemetry
+}

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -207,6 +207,9 @@
       "mac-address": [
         "./host/modules/util/esp32/mac-address"
       ],
+      "telemetry": [
+        "./host/modules/util/telemetry"
+      ],
       "mcp-client": [
         "./host/modules/connectivity/mcp-client/mcp-client"
       ],

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -144,6 +144,9 @@
       ],
       "stackchan-util": [
         "host/modules/util/stackchan-util.ts"
+      ],
+      "telemetry": [
+        "host/modules/util/telemetry.ts"
       ]
     },
     "types": [


### PR DESCRIPTION
## Summary

- add a shared structured telemetry channel that emits prefixed JSON trace lines
- instrument microphone, speaker, and TTS playback/query paths with latency, stall, gap, and failure telemetry
- document the telemetry log schema, event vocabulary, and stable error codes

## Impact

Release impact: patch.

This does not change the public MOD API, but it adds structured diagnostic output for voice/audio failures and playback quality analysis. The telemetry records are intended for serial/xsbug logs, CI, and future tooling.

## Validation

- `npm run format`
- `npm run lint`
- `npm run test:unit`
- `npm run check:architecture`
- `npm run test:moddable`