### PR TITLE
refactor(ui): clarify chat status bar state names

### DIFF
--- a/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
+++ b/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
@@ -51,17 +51,17 @@ assert(statusIndicator.visible === true, 'connecting indicator should be visible
 assert(statusIcon.visible === false, 'status icon should be hidden while connecting')
 
 behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
-assert(levelTrack.visible === true, 'level track should be visible in SPEAKING')
-assert(statusIcon.visible === true, 'status icon should be visible in SPEAKING')
-equal(statusIcon.state, 0, 'SPEAKING should use microphone input icon state')
+assert(levelTrack.visible === true, 'level track should be visible while user is speaking')
+assert(statusIcon.visible === true, 'status icon should be visible while user is speaking')
+equal(statusIcon.state, 0, 'user speaking should use microphone input icon state')
 
 behavior.onChatInputLevel?.(bar, 1000)
 equal(levelFill.height, 8, 'half input level should fill half the track')
 
 behavior.onChatState?.(bar, ChatStatusBarState.LISTENING)
-assert(levelTrack.visible === false, 'level track should be hidden in LISTENING')
-assert(statusIcon.visible === true, 'status icon should be visible in LISTENING')
-equal(statusIcon.state, 1, 'LISTENING should use output icon state')
+assert(levelTrack.visible === false, 'level track should be hidden while user is listening')
+assert(statusIcon.visible === true, 'status icon should be visible while user is listening')
+equal(statusIcon.state, 1, 'user listening should use output icon state')
 
 const normalFillSkin = levelFill.skin
 behavior.onChatState?.(bar, ChatStatusBarState.FAILED, 'boom')

--- a/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
+++ b/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
@@ -103,12 +103,13 @@ class ChatStatusBarBehavior extends Behavior {
 
   updateUI() {
     if (!this.#levelTrack || !this.#levelFill || !this.#statusIcon || !this.#indicator) return
-    const isListening = this.#state === ChatStatusBarState.SPEAKING
-    const isSpeaking = this.#state === ChatStatusBarState.LISTENING
+    // ChatAudioIO.SPEAKING means user input; LISTENING means assistant output.
+    const isUserSpeaking = this.#state === ChatStatusBarState.SPEAKING
+    const isUserListening = this.#state === ChatStatusBarState.LISTENING
     const isConnecting = this.#state === ChatStatusBarState.CONNECTING
-    this.#levelTrack.visible = isListening
-    this.#statusIcon.visible = isListening || isSpeaking
-    this.#statusIcon.state = isSpeaking ? 1 : 0
+    this.#levelTrack.visible = isUserSpeaking
+    this.#statusIcon.visible = isUserSpeaking || isUserListening
+    this.#statusIcon.state = isUserListening ? 1 : 0
     this.#indicator.visible = isConnecting
     if (isConnecting) {
       this.#indicator.interval = 250


### PR DESCRIPTION
## Summary

- keep the existing ChatStatusBar behavior for `SPEAKING` and `LISTENING`
- rename local booleans to `isUserSpeaking` and `isUserListening`
- clarify test messages so `SPEAKING` is read as user input and `LISTENING` as user listening to output

## Why

Moddable `ChatAudioIO` defines `SPEAKING` as user audio input and `LISTENING` as user receiving output audio. The previous local names (`isListening` / `isSpeaking`) were easy to read backwards and caused confusion in #517.

## Validation

- `cd firmware && npm run test:moddable -- ./host/modules/ui/components/status-bar/__tests__/chat-status-bar/manifest.test.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved status bar state handling for speaking and listening with clearer logic and labels.
  * Kept the existing microphone and listening indicator behavior intact.

* **Tests**
  * Updated status bar tests to verify the speaking and listening states with more specific expectations.
  * Confirmed input level display behavior remains correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->