### PR TITLE
fix(connectivity): guard BLE preference writes

### DIFF
--- a/firmware/host/app/setup-mode.ts
+++ b/firmware/host/app/setup-mode.ts
@@ -8,6 +8,8 @@ import { connectStoredWiFi, stopStoredWiFiConnection } from 'stored-wifi'
 
 type SetupApplication = Parameters<typeof buildSettingsView>[0]
 
+const BLE_PREFERENCE_WRITE_WINDOW_MS = 5 * 60 * 1000
+
 function settingsWifiStatusFromNetworkState(state: NetworkState): SettingsStatusValue {
   switch (state) {
     case NetworkConnectionState.SCANNING:
@@ -73,5 +75,5 @@ export function startSetupMode(application: SetupApplication): void {
     },
     keys: PREF_KEYS,
   })
-  preferenceServer.enableWrites()
+  preferenceServer.enableWrites(BLE_PREFERENCE_WRITE_WINDOW_MS)
 }

--- a/firmware/host/app/setup-mode.ts
+++ b/firmware/host/app/setup-mode.ts
@@ -57,7 +57,7 @@ export function startSetupMode(application: SetupApplication): void {
   }
   const labels = buildSettingsView(application, status, { onConnect: testConnection })
 
-  new PreferenceServer({
+  const preferenceServer = new PreferenceServer({
     onPreferenceChanged: (key, value) => {
       trace(`preference changed! ${key}: ${value}\n`)
       status[key] = value
@@ -73,4 +73,5 @@ export function startSetupMode(application: SetupApplication): void {
     },
     keys: PREF_KEYS,
   })
+  preferenceServer.enableWrites()
 }

--- a/firmware/host/modules/connectivity/__tests__/fakes/uartserver.ts
+++ b/firmware/host/modules/connectivity/__tests__/fakes/uartserver.ts
@@ -1,0 +1,17 @@
+export const SERVICE_UUID = '00000000-0000-0000-0000-000000000000'
+
+export class UARTServer {
+  deviceName = ''
+  advertisingStarts = 0
+  notifications: Array<{ characteristic: unknown; value: ArrayBuffer }> = []
+
+  onConnected(): void {}
+
+  startAdvertising(_options?: unknown): void {
+    this.advertisingStarts += 1
+  }
+
+  notifyValue(characteristic: unknown, value: ArrayBuffer): void {
+    this.notifications.push({ characteristic, value })
+  }
+}

--- a/firmware/host/modules/connectivity/__tests__/preference-write-guard.test.ts
+++ b/firmware/host/modules/connectivity/__tests__/preference-write-guard.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { writeAliasPackage } from '../../testing/node-alias-package.js'
+import { PreferenceWriteRejection, validatePreferenceWrite } from '../preference-write-guard.js'
+
+type FakePreference = {
+  default: {
+    get(domain: string, name: string): unknown
+  }
+  resetPreference(values?: Record<string, unknown>): void
+}
+
+type FakeTimer = {
+  default: {
+    advance(milliseconds: number): void
+    reset(): void
+  }
+}
+
+function installBareSpecifierPackages(): void {
+  const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+  writeAliasPackage(modulesRoot, 'consts', resolve(modulesRoot, 'preferences/consts.js'))
+  writeAliasPackage(modulesRoot, 'preference', resolve(modulesRoot, 'testing/fakes/preference.js'), {
+    hasDefaultExport: true,
+  })
+  writeAliasPackage(
+    modulesRoot,
+    'preference-write-guard',
+    resolve(modulesRoot, 'connectivity/preference-write-guard.js'),
+  )
+  writeAliasPackage(modulesRoot, 'timer', resolve(modulesRoot, 'testing/fakes/timer.js'), { hasDefaultExport: true })
+  writeAliasPackage(modulesRoot, 'uartserver', resolve(modulesRoot, 'connectivity/__tests__/fakes/uartserver.js'))
+}
+
+async function setup() {
+  installBareSpecifierPackages()
+  const [{ PreferenceServer }, { PREF_KEYS }, preference, timer] = await Promise.all([
+    import('../preference-server.js'),
+    import('../../preferences/consts.js'),
+    import('../../testing/fakes/preference.js') as Promise<FakePreference>,
+    import('../../testing/fakes/timer.js') as Promise<FakeTimer>,
+  ])
+  const traces: string[] = []
+  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = (...messages) => {
+    traces.push(messages.map(String).join(''))
+  }
+  preference.resetPreference()
+  timer.default.reset()
+  return { PreferenceServer, PREF_KEYS, preference: preference.default, timer: timer.default, traces }
+}
+
+const allowedKeys = [
+  ['wifi', 'ssid', String],
+  ['wifi', 'password', String],
+] as const
+
+test('validatePreferenceWrite accepts whitelisted keys while writes are enabled', () => {
+  assert.deepEqual(
+    validatePreferenceWrite({
+      allowedKeys,
+      writesEnabled: true,
+      domain: 'wifi',
+      key: 'ssid',
+    }),
+    { allowed: true },
+  )
+})
+
+test('validatePreferenceWrite rejects unknown domains', () => {
+  assert.deepEqual(
+    validatePreferenceWrite({
+      allowedKeys,
+      writesEnabled: true,
+      domain: 'secrets',
+      key: 'token',
+    }),
+    { allowed: false, reason: PreferenceWriteRejection.UNKNOWN_PREFERENCE },
+  )
+})
+
+test('validatePreferenceWrite rejects writes while the write window is closed', () => {
+  assert.deepEqual(
+    validatePreferenceWrite({
+      allowedKeys,
+      writesEnabled: false,
+      domain: 'wifi',
+      key: 'ssid',
+    }),
+    { allowed: false, reason: PreferenceWriteRejection.WRITES_DISABLED },
+  )
+})
+
+test('PreferenceServer rejects BLE preference writes until the write window is opened', async () => {
+  const { PreferenceServer, PREF_KEYS, preference, traces } = await setup()
+  let changed = false
+  const server = new PreferenceServer({
+    keys: PREF_KEYS,
+    onPreferenceChanged: () => {
+      changed = true
+    },
+  })
+
+  server.receiveAndSetPreference('wifi', 'ssid', 'stackchan-ap')
+
+  assert.equal(preference.get('wifi', 'ssid'), undefined)
+  assert.equal(changed, false)
+  assert.ok(traces.includes('rejected BLE preference write (writes-disabled): wifi.ssid\n'))
+})
+
+test('PreferenceServer accepts whitelisted BLE preference writes while the write window is open', async () => {
+  const { PreferenceServer, PREF_KEYS, preference } = await setup()
+  const changes: Array<{ key: string; value: unknown }> = []
+  const server = new PreferenceServer({
+    keys: PREF_KEYS,
+    onPreferenceChanged: (key: string, value: unknown) => changes.push({ key, value }),
+  })
+
+  server.enableWrites()
+  server.receiveAndSetPreference('wifi', 'ssid', 'stackchan-ap')
+
+  assert.equal(preference.get('wifi', 'ssid'), 'stackchan-ap')
+  assert.deepEqual(changes, [{ key: 'wifi.ssid', value: 'stackchan-ap' }])
+})
+
+test('PreferenceServer rejects non-whitelisted preference keys even while writes are enabled', async () => {
+  const { PreferenceServer, PREF_KEYS, preference, traces } = await setup()
+  const server = new PreferenceServer({ keys: PREF_KEYS })
+
+  server.enableWrites()
+  server.receiveAndSetPreference('wifi', 'evil', 'stackchan-ap')
+
+  assert.equal(preference.get('wifi', 'evil'), undefined)
+  assert.ok(traces.includes('rejected BLE preference write (unknown-preference): wifi.evil\n'))
+})
+
+test('PreferenceServer closes the BLE preference write window after the requested duration', async () => {
+  const { PreferenceServer, PREF_KEYS, preference, timer, traces } = await setup()
+  const server = new PreferenceServer({ keys: PREF_KEYS })
+
+  server.enableWrites(1000)
+  server.receiveAndSetPreference('wifi', 'ssid', 'first-ap')
+  timer.advance(1000)
+  server.receiveAndSetPreference('wifi', 'password', 'secret')
+
+  assert.equal(preference.get('wifi', 'ssid'), 'first-ap')
+  assert.equal(preference.get('wifi', 'password'), undefined)
+  assert.ok(traces.includes('BLE preference write window closed\n'))
+  assert.ok(traces.includes('rejected BLE preference write (writes-disabled): wifi.password\n'))
+})

--- a/firmware/host/modules/connectivity/preference-server.ts
+++ b/firmware/host/modules/connectivity/preference-server.ts
@@ -1,5 +1,6 @@
 import type { PREF_KEYS } from 'consts'
 import Preference from 'preference'
+import { validatePreferenceWrite } from 'preference-write-guard'
 import Timer from 'timer'
 import { SERVICE_UUID, UARTServer } from 'uartserver'
 
@@ -16,6 +17,8 @@ export class PreferenceServer extends UARTServer {
   #keys
   #rxBuffer = ''
   #timeout
+  #writesEnabled = false
+  #writeWindowTimer
   #handlePreferenceChanged?: (key: string, value: PreferenceValue) => void
   #handleConnected?: () => void
   #handleDisconnected?: () => void
@@ -29,6 +32,37 @@ export class PreferenceServer extends UARTServer {
     }
     this.#keys = Array.isArray(option.keys) ? option.keys.slice() : []
   }
+
+  /**
+   * Opens the opt-in write window. BLE preference writes are rejected unless
+   * this window is open. When `durationMs` is given the window closes
+   * automatically after that time; otherwise it stays open until
+   * `disableWrites()` is called.
+   */
+  enableWrites(durationMs?: number) {
+    this.#clearWriteWindowTimer()
+    this.#writesEnabled = true
+    if (durationMs != null && durationMs > 0) {
+      this.#writeWindowTimer = Timer.set(() => {
+        this.#writeWindowTimer = undefined
+        this.#writesEnabled = false
+        trace('BLE preference write window closed\n')
+      }, durationMs)
+    }
+  }
+
+  disableWrites() {
+    this.#clearWriteWindowTimer()
+    this.#writesEnabled = false
+  }
+
+  #clearWriteWindowTimer() {
+    if (this.#writeWindowTimer != null) {
+      Timer.clear(this.#writeWindowTimer)
+      this.#writeWindowTimer = undefined
+    }
+  }
+
   onConnected() {
     super.onConnected()
     this.#handleConnected?.()
@@ -119,6 +153,16 @@ export class PreferenceServer extends UARTServer {
   }
 
   receiveAndSetPreference(domain: string, key: string, value: PreferenceValue) {
+    const decision = validatePreferenceWrite({
+      allowedKeys: this.#keys,
+      writesEnabled: this.#writesEnabled,
+      domain,
+      key,
+    })
+    if (decision.allowed === false) {
+      trace(`rejected BLE preference write (${decision.reason}): ${domain}.${key}\n`)
+      return
+    }
     const currentValue = Preference.get(domain, key)
     if (currentValue !== value) {
       trace(`changing preference ... ${domain}.${key}: ${value}\n`)

--- a/firmware/host/modules/connectivity/preference-write-guard.ts
+++ b/firmware/host/modules/connectivity/preference-write-guard.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure validation helpers that decide whether a BLE-received preference write
+ * may be applied. Kept free of Moddable dependencies so Node.js unit tests can
+ * exercise the logic directly.
+ */
+
+export type PreferenceKeyList = readonly (readonly [string, string, ...unknown[]])[]
+
+export const PreferenceWriteRejection = {
+  WRITES_DISABLED: 'writes-disabled',
+  UNKNOWN_PREFERENCE: 'unknown-preference',
+} as const
+export type PreferenceWriteRejection = (typeof PreferenceWriteRejection)[keyof typeof PreferenceWriteRejection]
+
+export type PreferenceWriteDecision = { allowed: true } | { allowed: false; reason: PreferenceWriteRejection }
+
+export function isAllowedPreferenceKey(allowedKeys: PreferenceKeyList, domain: string, key: string): boolean {
+  return allowedKeys.some(([allowedDomain, allowedKey]) => allowedDomain === domain && allowedKey === key)
+}
+
+export function validatePreferenceWrite(options: {
+  allowedKeys: PreferenceKeyList
+  writesEnabled: boolean
+  domain: string
+  key: string
+}): PreferenceWriteDecision {
+  if (!options.writesEnabled) {
+    return { allowed: false, reason: PreferenceWriteRejection.WRITES_DISABLED }
+  }
+  if (!isAllowedPreferenceKey(options.allowedKeys, options.domain, options.key)) {
+    return { allowed: false, reason: PreferenceWriteRejection.UNKNOWN_PREFERENCE }
+  }
+  return { allowed: true }
+}

--- a/firmware/host/modules/connectivity/wasm/preference-server.ts
+++ b/firmware/host/modules/connectivity/wasm/preference-server.ts
@@ -1,5 +1,7 @@
 export class PreferenceServer {
   // biome-ignore lint/complexity/noUselessConstructor: wasm stub keeps constructor options compatible with native services.
   constructor(_options?: unknown) {}
+  enableWrites(_durationMs?: number) {}
+  disableWrites() {}
   close() {}
 }

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -79,6 +79,12 @@
       "stored-wifi": [
         "host/modules/connectivity/stored-wifi.ts"
       ],
+      "preference-server": [
+        "host/modules/connectivity/preference-server.ts"
+      ],
+      "preference-write-guard": [
+        "host/modules/connectivity/preference-write-guard.ts"
+      ],
       "network-service": [
         "host/modules/connectivity/network-service.ts"
       ],
@@ -111,6 +117,9 @@
       ],
       "sntp": [
         "host/modules/connectivity/__tests__/fakes/sntp.ts"
+      ],
+      "uartserver": [
+        "host/modules/connectivity/__tests__/fakes/uartserver.ts"
       ],
       "embedded:network/interface/wifi": [
         "host/modules/connectivity/__tests__/fakes/ecma-wifi.ts"


### PR DESCRIPTION
## 概要
BLE preference server が任意の Preference 書き込みを受け付けないよう、書き込み window と whitelist を追加します。

## 変更内容
- BLE preference 書き込みをデフォルト拒否
- setup mode 中だけ明示的に write window を有効化
- PREF_KEYS ベースで domain/key を whitelist 検証
- 純粋 validation helper と unit test を追加
- unknown domain / unknown key / window 期限切れの拒否を検証

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass, 32 tests
- cd firmware && npm run check:architecture: pass, 13 tests
- git diff --check: pass

## 未実施
- 実機 BLE での動作確認
- Moddable 実ビルド / test:moddable

## リリース影響
patch。脆弱な書き込み経路を制限する修正のため、リリースノート記載が必要です。

Closes #505
関連 #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BLE preference changes can now be enabled in a controlled write window.
  * Added support for safely applying only approved preference updates.

* **Bug Fixes**
  * Preference writes are now blocked until write access is explicitly enabled.
  * Invalid or unsupported preference changes are rejected instead of being applied.
  * Write access can automatically close again after a set time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->