### PR TITLE
fix(motion): expose calibration API for mods

### DIFF
--- a/firmware/host/app/capabilities.ts
+++ b/firmware/host/app/capabilities.ts
@@ -3,7 +3,7 @@ import type { RobotCamera } from 'camera'
 import type { Emotion, FaceState, FaceThemeKey } from 'face-state'
 import type IMU from 'imu'
 import type { ButtonInputEvent } from 'input-event'
-import type { MotionControllerPose, MotionDurationSeconds } from 'motion-controller'
+import type { MotionCalibrationCapability, MotionControllerPose, MotionDurationSeconds } from 'motion-controller'
 import type { Container as PiuContainer, Content as PiuContent } from 'piu/MC'
 import type { Maybe, Pose, Vector3 } from 'stackchan-util'
 import type Touch from 'touch'
@@ -79,6 +79,7 @@ export type FaceCapability = {
 
 export type MotionCapability = {
   pose: MotionControllerPose
+  calibration?: MotionCalibrationCapability
   lookAt(position: Vector3): void
   lookAway(): void
   setPose(pose: Pose, time?: MotionDurationSeconds): Promise<void>

--- a/firmware/host/app/runtime-context.ts
+++ b/firmware/host/app/runtime-context.ts
@@ -13,7 +13,11 @@ import type {
   StackchanContext,
 } from 'capabilities'
 import type { Emotion, FaceThemeKey } from 'face-state'
-import { MotionController, type MotionControllerConstructorParam } from 'motion-controller'
+import {
+  type MotionCalibrationCapability,
+  MotionController,
+  type MotionControllerConstructorParam,
+} from 'motion-controller'
 import { type RuntimeAudioConstructorParam, StackchanRuntimeAudio } from 'runtime-audio'
 import { type RuntimeCameraConstructorParam, StackchanRuntimeCamera } from 'runtime-camera'
 import { type RuntimeInputConstructorParam, StackchanRuntimeInput } from 'runtime-input'
@@ -170,6 +174,10 @@ export class StackchanRuntimeContext implements StackchanContext {
    */
   get pose() {
     return this.#motionController.pose
+  }
+
+  get calibration(): MotionCalibrationCapability | undefined {
+    return this.#motionController.calibration
   }
 
   /**
@@ -400,6 +408,9 @@ export class StackchanRuntimeContext implements StackchanContext {
     return {
       get pose() {
         return context.pose
+      },
+      get calibration() {
+        return context.calibration
       },
       lookAt(position) {
         context.lookAt(position)

--- a/firmware/host/modules/motion/__tests__/motion-controller.test.ts
+++ b/firmware/host/modules/motion/__tests__/motion-controller.test.ts
@@ -5,7 +5,12 @@ import { fileURLToPath } from 'node:url'
 
 import type { Maybe, Pose, Rotation } from 'stackchan-util'
 import { writeAliasPackage } from '../../testing/node-alias-package.js'
-import type { MotionCompletion, MotionDriver, MotionResultCallback } from '../motion-controller.js'
+import type {
+  MotionCalibrationCapability,
+  MotionCompletion,
+  MotionDriver,
+  MotionResultCallback,
+} from '../motion-controller.js'
 
 type FakeTimer = {
   advance(milliseconds: number): void
@@ -20,6 +25,7 @@ class FakeMotionDriver implements MotionDriver {
   getRotationCalls = 0
   rotation: Rotation = { y: 0, p: 0, r: 0 }
   torqueStates: boolean[] = []
+  calibration?: MotionCalibrationCapability
 
   applyRotation(rotation: Rotation, time?: number, callback?: MotionCompletion): void {
     this.appliedRotation = rotation
@@ -192,6 +198,44 @@ test('MotionController delegates driver replacement, torque, and explicit pose u
   assert.equal(nextDriver.appliedRotation?.y, 0.2)
   assert.equal(nextDriver.appliedRotation?.p, -0.1)
   assert.equal(nextDriver.appliedTime, 0.25)
+})
+
+test('MotionController exposes calibration from the active driver only', async () => {
+  installBareSpecifierPackages()
+  const { MotionController } = await import('../motion-controller.js')
+  const calibration: MotionCalibrationCapability = {
+    pan: {
+      readAngle: (callback) => callback({ success: true, value: 0 }),
+      setAngle: (_angle, timeOrCallback?: number | MotionCompletion, callback?: MotionCompletion) => {
+        if (typeof timeOrCallback === 'function') {
+          timeOrCallback()
+          return
+        }
+        callback?.()
+      },
+      setTorque: (_torque, callback) => callback?.(),
+    },
+    tilt: {
+      readAngle: (callback) => callback({ success: true, value: 0 }),
+      setAngle: (_angle, timeOrCallback?: number | MotionCompletion, callback?: MotionCompletion) => {
+        if (typeof timeOrCallback === 'function') {
+          timeOrCallback()
+          return
+        }
+        callback?.()
+      },
+      setTorque: (_torque, callback) => callback?.(),
+    },
+  }
+  const driver = new FakeMotionDriver()
+  driver.calibration = calibration
+  const controller = new MotionController({ driver }, { isPaused: () => false })
+
+  assert.equal(controller.calibration, calibration)
+
+  controller.useDriver(new FakeMotionDriver())
+  assert.equal(controller.calibration, undefined)
+  controller.close()
 })
 
 test('motion duration conversion helpers name protocol time units', async () => {

--- a/firmware/host/modules/motion/motion-calibration-servo.ts
+++ b/firmware/host/modules/motion/motion-calibration-servo.ts
@@ -1,0 +1,41 @@
+import type {
+  MotionCalibrationServo,
+  MotionCompletion,
+  MotionDurationSeconds,
+  MotionResultCallback,
+} from 'motion-controller'
+import type { Maybe } from 'stackchan-util'
+
+type CalibrationServoOptions = {
+  readAngle(callback: MotionResultCallback<Maybe<number>>): void
+  setAngle(angle: number, callback?: MotionCompletion): void
+  setAngleInTime(angle: number, time: number, callback?: MotionCompletion): void
+  setTorque(torque: boolean, callback?: MotionCompletion): void
+  convertDuration(duration: MotionDurationSeconds): number
+  flashId?(id: number, callback?: MotionCompletion): void
+  readOffsetAngle?(callback: MotionResultCallback<Maybe<number>>): void
+  setOffsetAngle?(angle: number, callback?: MotionCompletion): void
+  saveSettings?(callback?: MotionCompletion): void
+}
+
+export function createMotionCalibrationServo(options: CalibrationServoOptions): MotionCalibrationServo {
+  return {
+    readAngle: options.readAngle,
+    setAngle(angle, timeOrCallback?: MotionDurationSeconds | MotionCompletion, callback?: MotionCompletion) {
+      if (typeof timeOrCallback === 'function') {
+        options.setAngle(angle, timeOrCallback)
+        return
+      }
+      if (timeOrCallback == null) {
+        options.setAngle(angle, callback)
+        return
+      }
+      options.setAngleInTime(angle, options.convertDuration(timeOrCallback), callback)
+    },
+    setTorque: options.setTorque,
+    ...(options.flashId ? { flashId: options.flashId } : {}),
+    ...(options.readOffsetAngle ? { readOffsetAngle: options.readOffsetAngle } : {}),
+    ...(options.setOffsetAngle ? { setOffsetAngle: options.setOffsetAngle } : {}),
+    ...(options.saveSettings ? { saveSettings: options.saveSettings } : {}),
+  }
+}

--- a/firmware/host/modules/motion/motion-controller.ts
+++ b/firmware/host/modules/motion/motion-controller.ts
@@ -17,11 +17,28 @@ export type ServoGoalTimeMilliseconds = number
 export type ServoGoalTimeCentiseconds = number
 export type MotionCompletion = (error?: unknown) => void
 export type MotionResultCallback<T> = (result: T) => void
+export type MotionCalibrationAxis = 'pan' | 'tilt'
+
+export type MotionCalibrationServo = {
+  readAngle(callback: MotionResultCallback<Maybe<number>>): void
+  setAngle: {
+    (angle: number, callback?: MotionCompletion): void
+    (angle: number, time: MotionDurationSeconds, callback?: MotionCompletion): void
+  }
+  setTorque(torque: boolean, callback?: MotionCompletion): void
+  flashId?(id: number, callback?: MotionCompletion): void
+  readOffsetAngle?(callback: MotionResultCallback<Maybe<number>>): void
+  setOffsetAngle?(angle: number, callback?: MotionCompletion): void
+  saveSettings?(callback?: MotionCompletion): void
+}
+
+export type MotionCalibrationCapability = Record<MotionCalibrationAxis, MotionCalibrationServo>
 
 export type MotionDriver = {
   applyRotation: (ori: RotationType, time?: MotionDurationSeconds, callback?: MotionCompletion) => void
   getRotation: (callback: MotionResultCallback<Maybe<RotationType>>) => void
   setTorque: (torque: boolean, callback?: MotionCompletion) => void
+  calibration?: MotionCalibrationCapability
   onAttached?: () => void
   onDetached?: () => void
 }
@@ -117,6 +134,10 @@ export class MotionController {
 
   get driver(): MotionDriver {
     return this.#driver
+  }
+
+  get calibration(): MotionCalibrationCapability | undefined {
+    return this.#driver.calibration
   }
 
   get gazePoint(): Vector3 | null {

--- a/firmware/host/modules/motion/rs30x-driver.ts
+++ b/firmware/host/modules/motion/rs30x-driver.ts
@@ -1,3 +1,4 @@
+import { createMotionCalibrationServo } from 'motion-calibration-servo'
 import {
   type MotionCalibrationCapability,
   type MotionCompletion,
@@ -5,7 +6,6 @@ import {
   type MotionResultCallback,
   motionDurationSecondsToCentiseconds,
 } from 'motion-controller'
-import { createMotionCalibrationServo } from 'motion-calibration-servo'
 import { reasonFromError } from 'motion-driver-callback'
 import RS30X from 'protocols/rs30x'
 import type { Maybe, Rotation } from 'stackchan-util'

--- a/firmware/host/modules/motion/rs30x-driver.ts
+++ b/firmware/host/modules/motion/rs30x-driver.ts
@@ -1,11 +1,11 @@
 import {
   type MotionCalibrationCapability,
-  type MotionCalibrationServo,
   type MotionCompletion,
   type MotionDurationSeconds,
   type MotionResultCallback,
   motionDurationSecondsToCentiseconds,
 } from 'motion-controller'
+import { createMotionCalibrationServo } from 'motion-calibration-servo'
 import { reasonFromError } from 'motion-driver-callback'
 import RS30X from 'protocols/rs30x'
 import type { Maybe, Rotation } from 'stackchan-util'
@@ -16,8 +16,8 @@ type RS30XDriverProps = {
   tiltId: number
 }
 
-function createCalibrationServo(servo: RS30X): MotionCalibrationServo {
-  return {
+function createCalibrationServo(servo: RS30X) {
+  return createMotionCalibrationServo({
     readAngle(callback) {
       servo.readStatus((angle, error) => {
         if (angle == null) {
@@ -27,24 +27,18 @@ function createCalibrationServo(servo: RS30X): MotionCalibrationServo {
         callback({ success: true, value: angle })
       })
     },
-    setAngle(angle, timeOrCallback?: MotionDurationSeconds | MotionCompletion, callback?: MotionCompletion) {
-      if (typeof timeOrCallback === 'function') {
-        servo.setAngle(angle, timeOrCallback)
-        return
-      }
-      if (timeOrCallback == null) {
-        servo.setAngle(angle, callback)
-        return
-      }
-      servo.setAngleInTime(angle, motionDurationSecondsToCentiseconds(timeOrCallback), callback)
+    setAngle(angle, callback) {
+      servo.setAngle(angle, callback)
+    },
+    setAngleInTime(angle, goalTimeCentiseconds, callback) {
+      servo.setAngleInTime(angle, goalTimeCentiseconds, callback)
     },
     setTorque(torque, callback) {
       servo.setTorque(torque, callback)
     },
-    flashId(id, callback) {
-      servo.flashId(id, callback)
-    },
-  }
+    convertDuration: motionDurationSecondsToCentiseconds,
+    flashId: (id, callback) => servo.flashId(id, callback),
+  })
 }
 
 export class RS30XDriver {

--- a/firmware/host/modules/motion/rs30x-driver.ts
+++ b/firmware/host/modules/motion/rs30x-driver.ts
@@ -1,4 +1,6 @@
 import {
+  type MotionCalibrationCapability,
+  type MotionCalibrationServo,
   type MotionCompletion,
   type MotionDurationSeconds,
   type MotionResultCallback,
@@ -14,10 +16,42 @@ type RS30XDriverProps = {
   tiltId: number
 }
 
+function createCalibrationServo(servo: RS30X): MotionCalibrationServo {
+  return {
+    readAngle(callback) {
+      servo.readStatus((angle, error) => {
+        if (angle == null) {
+          callback({ success: false, reason: error == null ? 'response corrupted' : reasonFromError(error) })
+          return
+        }
+        callback({ success: true, value: angle })
+      })
+    },
+    setAngle(angle, timeOrCallback?: MotionDurationSeconds | MotionCompletion, callback?: MotionCompletion) {
+      if (typeof timeOrCallback === 'function') {
+        servo.setAngle(angle, timeOrCallback)
+        return
+      }
+      if (timeOrCallback == null) {
+        servo.setAngle(angle, callback)
+        return
+      }
+      servo.setAngleInTime(angle, motionDurationSecondsToCentiseconds(timeOrCallback), callback)
+    },
+    setTorque(torque, callback) {
+      servo.setTorque(torque, callback)
+    },
+    flashId(id, callback) {
+      servo.flashId(id, callback)
+    },
+  }
+}
+
 export class RS30XDriver {
   _pan: RS30X
   _tilt: RS30X
   _handler: ReturnType<typeof Timer.repeat>
+  calibration: MotionCalibrationCapability
   #rotation: Rotation = { y: 0, p: 0, r: 0 }
   #rotationResult: Maybe<Rotation> = { success: true, value: this.#rotation }
   #rotationErrorResult: { success: false; reason?: string } = { success: false }
@@ -25,6 +59,10 @@ export class RS30XDriver {
   constructor(param: RS30XDriverProps) {
     this._pan = new RS30X({ id: param.panId })
     this._tilt = new RS30X({ id: param.tiltId })
+    this.calibration = {
+      pan: createCalibrationServo(this._pan),
+      tilt: createCalibrationServo(this._tilt),
+    }
   }
 
   setTorque(torque: boolean, callback?: MotionCompletion): void {

--- a/firmware/host/modules/motion/scservo-driver.ts
+++ b/firmware/host/modules/motion/scservo-driver.ts
@@ -1,4 +1,6 @@
 import {
+  type MotionCalibrationCapability,
+  type MotionCalibrationServo,
   type MotionCompletion,
   type MotionDurationSeconds,
   type MotionResultCallback,
@@ -13,10 +15,51 @@ type SCServoDriverProps = {
   tiltId: number
 }
 
+function createCalibrationServo(servo: SCServo): MotionCalibrationServo {
+  return {
+    readAngle(callback) {
+      servo.readStatus((result) => {
+        if (!result.success) {
+          callback({ success: false, reason: result.reason })
+          return
+        }
+        callback({ success: true, value: result.value.angle })
+      })
+    },
+    setAngle(angle, timeOrCallback?: MotionDurationSeconds | MotionCompletion, callback?: MotionCompletion) {
+      if (typeof timeOrCallback === 'function') {
+        servo.setAngle(angle, timeOrCallback)
+        return
+      }
+      if (timeOrCallback == null) {
+        servo.setAngle(angle, callback)
+        return
+      }
+      servo.setAngleInTime(angle, motionDurationSecondsToMilliseconds(timeOrCallback), callback)
+    },
+    setTorque(torque, callback) {
+      servo.setTorque(torque, callback)
+    },
+    flashId(id, callback) {
+      servo.flashId(id, callback)
+    },
+    readOffsetAngle(callback) {
+      servo.readOffsetAngle(callback)
+    },
+    setOffsetAngle(angle, callback) {
+      servo.setOffsetAngle(angle, callback)
+    },
+    saveSettings(callback) {
+      servo.saveSettings(callback)
+    },
+  }
+}
+
 export class SCServoDriver {
   _pan: SCServo
   _tilt: SCServo
   _handler: ReturnType<typeof Timer.repeat>
+  calibration: MotionCalibrationCapability
   #rotation: Rotation = { y: 0, p: 0, r: 0 }
   #rotationResult: Maybe<Rotation> = { success: true, value: this.#rotation }
   #rotationErrorResult: { success: false; reason?: string } = { success: false }
@@ -24,6 +67,10 @@ export class SCServoDriver {
   constructor(param: SCServoDriverProps) {
     this._pan = new SCServo({ id: param.panId })
     this._tilt = new SCServo({ id: param.tiltId })
+    this.calibration = {
+      pan: createCalibrationServo(this._pan),
+      tilt: createCalibrationServo(this._tilt),
+    }
   }
 
   setTorque(torque: boolean, callback?: MotionCompletion): void {

--- a/firmware/host/modules/motion/scservo-driver.ts
+++ b/firmware/host/modules/motion/scservo-driver.ts
@@ -1,3 +1,4 @@
+import { createMotionCalibrationServo } from 'motion-calibration-servo'
 import {
   type MotionCalibrationCapability,
   type MotionCompletion,
@@ -5,7 +6,6 @@ import {
   type MotionResultCallback,
   motionDurationSecondsToMilliseconds,
 } from 'motion-controller'
-import { createMotionCalibrationServo } from 'motion-calibration-servo'
 import SCServo from 'protocols/scservo'
 import type { Maybe, Rotation } from 'stackchan-util'
 import type Timer from 'timer'
@@ -15,15 +15,18 @@ type SCServoDriverProps = {
   tiltId: number
 }
 
+type SCServoStatusFailure = { success: false; reason?: string }
+
 function createCalibrationServo(servo: SCServo) {
   return createMotionCalibrationServo({
     readAngle(callback) {
       servo.readStatus((result) => {
-        if (!result.success) {
-          callback({ success: false, reason: result.reason })
+        if (result.success) {
+          callback({ success: true, value: result.value.angle })
           return
         }
-        callback({ success: true, value: result.value.angle })
+        const failure = result as SCServoStatusFailure
+        callback({ success: false, reason: failure.reason })
       })
     },
     setAngle(angle, callback) {

--- a/firmware/host/modules/motion/scservo-driver.ts
+++ b/firmware/host/modules/motion/scservo-driver.ts
@@ -1,11 +1,11 @@
 import {
   type MotionCalibrationCapability,
-  type MotionCalibrationServo,
   type MotionCompletion,
   type MotionDurationSeconds,
   type MotionResultCallback,
   motionDurationSecondsToMilliseconds,
 } from 'motion-controller'
+import { createMotionCalibrationServo } from 'motion-calibration-servo'
 import SCServo from 'protocols/scservo'
 import type { Maybe, Rotation } from 'stackchan-util'
 import type Timer from 'timer'
@@ -15,8 +15,8 @@ type SCServoDriverProps = {
   tiltId: number
 }
 
-function createCalibrationServo(servo: SCServo): MotionCalibrationServo {
-  return {
+function createCalibrationServo(servo: SCServo) {
+  return createMotionCalibrationServo({
     readAngle(callback) {
       servo.readStatus((result) => {
         if (!result.success) {
@@ -26,23 +26,17 @@ function createCalibrationServo(servo: SCServo): MotionCalibrationServo {
         callback({ success: true, value: result.value.angle })
       })
     },
-    setAngle(angle, timeOrCallback?: MotionDurationSeconds | MotionCompletion, callback?: MotionCompletion) {
-      if (typeof timeOrCallback === 'function') {
-        servo.setAngle(angle, timeOrCallback)
-        return
-      }
-      if (timeOrCallback == null) {
-        servo.setAngle(angle, callback)
-        return
-      }
-      servo.setAngleInTime(angle, motionDurationSecondsToMilliseconds(timeOrCallback), callback)
+    setAngle(angle, callback) {
+      servo.setAngle(angle, callback)
+    },
+    setAngleInTime(angle, goalTimeMilliseconds, callback) {
+      servo.setAngleInTime(angle, goalTimeMilliseconds, callback)
     },
     setTorque(torque, callback) {
       servo.setTorque(torque, callback)
     },
-    flashId(id, callback) {
-      servo.flashId(id, callback)
-    },
+    convertDuration: motionDurationSecondsToMilliseconds,
+    flashId: (id, callback) => servo.flashId(id, callback),
     readOffsetAngle(callback) {
       servo.readOffsetAngle(callback)
     },
@@ -52,7 +46,7 @@ function createCalibrationServo(servo: SCServo): MotionCalibrationServo {
     saveSettings(callback) {
       servo.saveSettings(callback)
     },
-  }
+  })
 }
 
 export class SCServoDriver {

--- a/firmware/mods/examples/calibration/mod.js
+++ b/firmware/mods/examples/calibration/mod.js
@@ -12,17 +12,21 @@ function traceError(context, error) {
 }
 
 function readAngle(servo, label, callback) {
-  servo.readStatus((result) => {
+  servo.readAngle((result) => {
     if (!result.success) {
       trace(`${label} read failed: ${result.reason}\n`)
       callback(undefined)
       return
     }
-    callback(result.value.angle)
+    callback(result.value)
   })
 }
 
 function setOffsetAndSave(servo, label, angle) {
+  if (servo.setOffsetAngle == null || servo.saveSettings == null) {
+    trace(`${label} offset calibration is not supported\n`)
+    return
+  }
   servo.setOffsetAngle(angle - 90, (offsetError) => {
     if (offsetError != null) {
       traceError(`${label} offset failed`, offsetError)
@@ -33,56 +37,74 @@ function setOffsetAndSave(servo, label, angle) {
 }
 
 function onContextCreated(context) {
-  const pan = context._driver._pan
-  const tilt = context._driver._tilt
-  context.button.a.onEvent = (event) => {
-    if (!event.pressed) {
-      return
-    }
-    trace('setting pan offset\n')
-    readAngle(pan, 'pan', (panAngle) => {
-      if (panAngle !== undefined) setOffsetAndSave(pan, 'pan', panAngle)
-    })
-  }
-  context.button.b.onEvent = (event) => {
-    if (!event.pressed) {
-      return
-    }
-    trace('setting tilt offset\n')
-    readAngle(tilt, 'tilt', (tiltAngle) => {
-      if (tiltAngle !== undefined) setOffsetAndSave(tilt, 'tilt', tiltAngle)
-    })
-  }
-  context.button.c.onEvent = (event) => {
-    if (!event.pressed) {
-      return
-    }
-    trace('setting zero\n')
-    tilt.setAngle(100, (tiltError) => {
-      if (tiltError != null) {
-        traceError('tilt angle failed', tiltError)
-        return
-      }
-      pan.setAngle(100, (panError) => {
-        if (panError != null) {
-          traceError('pan angle failed', panError)
-          return
-        }
-        Timer.set(() => {
-          tilt.setTorque(false, (tiltTorqueError) => {
-            if (tiltTorqueError != null) {
-              traceError('tilt torque failed', tiltTorqueError)
-              return
-            }
-            pan.setTorque(false, (panTorqueError) => traceError('pan torque failed', panTorqueError))
-          })
-        }, 500)
-      })
-    })
+  const calibration = context.motion.calibration
+  const pan = calibration?.pan
+  const tilt = calibration?.tilt
+  const buttons = context.input.button
+  const buttonA = buttons?.a
+  const buttonB = buttons?.b
+  const buttonC = buttons?.c
+
+  if (pan == null || tilt == null || buttons == null) {
+    trace('calibration requires motion calibration support and buttons\n')
+    return
   }
 
-  pan.setOffsetAngle(0, (error) => traceError('pan reset offset failed', error))
-  tilt.setOffsetAngle(0, (error) => traceError('tilt reset offset failed', error))
+  if (buttonA != null) {
+    buttonA.onEvent = (event) => {
+      if (!event.pressed) {
+        return
+      }
+      trace('setting pan offset\n')
+      readAngle(pan, 'pan', (panAngle) => {
+        if (panAngle !== undefined) setOffsetAndSave(pan, 'pan', panAngle)
+      })
+    }
+  }
+  if (buttonB != null) {
+    buttonB.onEvent = (event) => {
+      if (!event.pressed) {
+        return
+      }
+      trace('setting tilt offset\n')
+      readAngle(tilt, 'tilt', (tiltAngle) => {
+        if (tiltAngle !== undefined) setOffsetAndSave(tilt, 'tilt', tiltAngle)
+      })
+    }
+  }
+
+  if (buttonC != null) {
+    buttonC.onEvent = (event) => {
+      if (!event.pressed) {
+        return
+      }
+      trace('setting zero\n')
+      tilt.setAngle(100, (tiltError) => {
+        if (tiltError != null) {
+          traceError('tilt angle failed', tiltError)
+          return
+        }
+        pan.setAngle(100, (panError) => {
+          if (panError != null) {
+            traceError('pan angle failed', panError)
+            return
+          }
+          Timer.set(() => {
+            tilt.setTorque(false, (tiltTorqueError) => {
+              if (tiltTorqueError != null) {
+                traceError('tilt torque failed', tiltTorqueError)
+                return
+              }
+              pan.setTorque(false, (panTorqueError) => traceError('pan torque failed', panTorqueError))
+            })
+          }, 500)
+        })
+      })
+    }
+  }
+
+  pan.setOffsetAngle?.(0, (error) => traceError('pan reset offset failed', error))
+  tilt.setOffsetAngle?.(0, (error) => traceError('tilt reset offset failed', error))
 
   let polling = false
   Timer.repeat(() => {
@@ -98,6 +120,11 @@ function onContextCreated(context) {
       readAngle(tilt, 'tilt', (tiltAngle) => {
         if (tiltAngle === undefined) {
           polling = false
+          return
+        }
+        if (pan.readOffsetAngle == null || tilt.readOffsetAngle == null) {
+          polling = false
+          trace(`(pan, tilt) => (${panAngle}, ${tiltAngle}), offset read is not supported\n`)
           return
         }
         pan.readOffsetAngle((panOffsetResult) => {

--- a/firmware/mods/examples/setup_rs30x/mod.js
+++ b/firmware/mods/examples/setup_rs30x/mod.js
@@ -1,20 +1,51 @@
 function onContextCreated(robot) {
-  let isRight = false
-  robot.input.button.a.onEvent = (event) => {
-    if (!event.pressed) {
-      return
-    }
-    trace('flashing id 0x02\n')
-    robot._driver._pan.flashId(0x02)
+  const pan = robot.motion.calibration?.pan
+  const buttonA = robot.input.button?.a
+
+  if (pan == null || buttonA == null) {
+    trace('setup_rs30x requires pan calibration support and button A\n')
+    return
   }
-  robot.input.button.a.onEvent = (event) => {
-    if (!event.pressed) {
-      return
-    }
+
+  if (pan.flashId == null) {
+    trace('setup_rs30x requires flashId calibration support\n')
+    return
+  }
+
+  let didFlashId = false
+  let isRight = false
+
+  function setNextAngle() {
     const angle = isRight ? 10 : -10
     trace(`changing angle to ${angle}\n`)
-    robot._driver._pan.setAngleInTime(angle, 0.3)
-    isRight = !isRight
+    pan.setAngle(angle, 0.3, (error) => {
+      if (error != null) {
+        trace(`setup_rs30x angle failed: ${error}\n`)
+        return
+      }
+      isRight = !isRight
+    })
+  }
+
+  buttonA.onEvent = (event) => {
+    if (!event.pressed) {
+      return
+    }
+
+    if (!didFlashId) {
+      trace('flashing id 0x02\n')
+      pan.flashId(0x02, (error) => {
+        if (error != null) {
+          trace(`setup_rs30x flashId failed: ${error}\n`)
+          return
+        }
+        didFlashId = true
+        setNextAngle()
+      })
+      return
+    }
+
+    setNextAngle()
   }
 }
 


### PR DESCRIPTION
## 概要
calibration / setup_rs30x MOD が raw driver 内部へ触らないよう、公開 calibration API へ移行します。

## 変更内容
- motion.calibration API を追加
- RS30X / SCServo driver に calibration wrapper を追加
- calibration と setup_rs30x MOD から _driver 参照を削除
- optional button capability を安全に扱うよう修正
- motion-controller test を追加

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass, 31 tests
- cd firmware && npm run check:architecture: pass, 13 tests
- git diff --check: pass

## 未実施
- 実機サーボでの較正動作確認
- test:moddable / build

## リリース影響
patch。公式 MOD の内部 API 依存を解消する互換性改善です。

Closes #507
関連 #399 #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added motion calibration support across the runtime and motion drivers.
  * Calibration data is now available through the motion control interface for supported hardware.

* **Bug Fixes**
  * Improved handling when calibration features aren’t supported, avoiding failures and stopping unsupported reads gracefully.
  * Updated example behavior to use safer checks before accessing motion and button controls.

* **Documentation**
  * Updated sample workflows to reflect the new calibration-based motion controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->