### PR TITLE
fix(motion): verify CRC of received Dynamixel status packets

### DIFF
--- a/firmware/host/modules/motion/__tests__/dynamixel-codec.test.ts
+++ b/firmware/host/modules/motion/__tests__/dynamixel-codec.test.ts
@@ -3,12 +3,18 @@ import test from 'node:test'
 
 import {
   angleToDynamixelPosition,
+  dynamixelCrc16,
   dynamixelPositionToAngle,
   dynamixelStatusPayloadHasData,
   int16FromDynamixelPayload,
   int32FromDynamixelPayload,
   int32ToDynamixelBytes,
+  verifyDynamixelPacketCrc,
 } from '../protocols/dynamixel-codec.js'
+
+// Ping status packet example from the Robotis e-manual (Protocol 2.0):
+// header(4) id(1) length(2) instruction(1) error(1) params(3) crc(2)
+const REFERENCE_STATUS_PACKET = [0xff, 0xff, 0xfd, 0x00, 0x01, 0x07, 0x00, 0x55, 0x00, 0x06, 0x04, 0x26, 0x65, 0x5d]
 
 test('Dynamixel codec encodes signed 32-bit little-endian values', () => {
   assert.deepEqual(int32ToDynamixelBytes(1024), [0x00, 0x04, 0x00, 0x00])
@@ -31,4 +37,39 @@ test('Dynamixel codec converts homing offset angles without losing sign', () => 
 test('Dynamixel status payload length check rejects two-byte payloads for four-byte registers', () => {
   assert.equal(dynamixelStatusPayloadHasData(new Uint8Array([0x55, 0x00, 0x34, 0x12]), 4), false)
   assert.equal(dynamixelStatusPayloadHasData(new Uint8Array([0x55, 0x00, 0x78, 0x56, 0x34, 0x12]), 4), true)
+})
+
+test('Dynamixel CRC-16 matches the Robotis protocol 2.0 reference vectors', () => {
+  // Ping instruction packet for id 1 (e-manual example): CRC is 0x4e19
+  const pingPacket = new Uint8Array([0xff, 0xff, 0xfd, 0x00, 0x01, 0x03, 0x00, 0x01])
+  assert.equal(dynamixelCrc16(pingPacket), 0x4e19)
+  // Ping status packet from id 1 (e-manual example): CRC is 0x5d65
+  const statusBody = new Uint8Array(REFERENCE_STATUS_PACKET.slice(0, -2))
+  assert.equal(dynamixelCrc16(statusBody), 0x5d65)
+})
+
+test('Dynamixel packet CRC verification accepts a valid status packet', () => {
+  assert.equal(verifyDynamixelPacketCrc(new Uint8Array(REFERENCE_STATUS_PACKET)), true)
+})
+
+test('Dynamixel packet CRC verification rejects corrupted packets', () => {
+  // Corrupted parameter byte (e.g. present position garbled on a noisy line)
+  const corruptedParam = new Uint8Array(REFERENCE_STATUS_PACKET)
+  corruptedParam[10] ^= 0x40
+  assert.equal(verifyDynamixelPacketCrc(corruptedParam), false)
+  // Corrupted CRC byte
+  const corruptedCrc = new Uint8Array(REFERENCE_STATUS_PACKET)
+  corruptedCrc[corruptedCrc.length - 1] ^= 0x01
+  assert.equal(verifyDynamixelPacketCrc(corruptedCrc), false)
+})
+
+test('Dynamixel packet CRC verification honors the explicit length argument', () => {
+  const packet = new Uint8Array(64)
+  packet.set(REFERENCE_STATUS_PACKET)
+  assert.equal(verifyDynamixelPacketCrc(packet, REFERENCE_STATUS_PACKET.length), true)
+  assert.equal(verifyDynamixelPacketCrc(packet, REFERENCE_STATUS_PACKET.length - 1), false)
+  // Degenerate lengths never pass
+  assert.equal(verifyDynamixelPacketCrc(packet, 0), false)
+  assert.equal(verifyDynamixelPacketCrc(packet, 2), false)
+  assert.equal(verifyDynamixelPacketCrc(packet, packet.length + 1), false)
 })

--- a/firmware/host/modules/motion/protocols/dynamixel-codec.ts
+++ b/firmware/host/modules/motion/protocols/dynamixel-codec.ts
@@ -1,6 +1,40 @@
 const POSITION_UNITS_PER_REVOLUTION = 4096
 const DEGREES_PER_REVOLUTION = 360
 const STATUS_HEADER_LENGTH = 2
+const CRC_LENGTH = 2
+
+/**
+ * calculates the Dynamixel protocol 2.0 CRC-16 (polynomial 0x8005, init 0)
+ * @param values - packet bytes
+ * @param start - first index included in the calculation
+ * @param end - index one past the last byte included in the calculation
+ * @returns 16-bit CRC value
+ */
+export function dynamixelCrc16(values: number[] | Uint8Array, start = 0, end = values.length): number {
+  let crc = 0
+  for (let i = start; i < end; i++) {
+    crc ^= (values[i] & 0xff) << 8
+    for (let bit = 0; bit < 8; bit++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x8005) & 0xffff : (crc << 1) & 0xffff
+    }
+  }
+  return crc
+}
+
+/**
+ * verifies the trailing little-endian CRC-16 of a received Dynamixel packet
+ * @param packet - full packet bytes starting at the 0xff 0xff 0xfd header
+ * @param length - packet length in bytes including the two CRC bytes
+ * @returns true when the CRC matches, false otherwise
+ */
+export function verifyDynamixelPacketCrc(packet: Uint8Array, length = packet.length): boolean {
+  if (length <= CRC_LENGTH || length > packet.length) {
+    return false
+  }
+  const crcOffset = length - CRC_LENGTH
+  const received = (packet[crcOffset] & 0xff) | ((packet[crcOffset + 1] & 0xff) << 8)
+  return dynamixelCrc16(packet, 0, crcOffset) === received
+}
 
 export function int32ToDynamixelBytes(value: number): [number, number, number, number] {
   const signed = Math.trunc(value) | 0

--- a/firmware/host/modules/motion/protocols/dynamixel.ts
+++ b/firmware/host/modules/motion/protocols/dynamixel.ts
@@ -3,11 +3,13 @@ import config from 'mc/config'
 import { PayloadBuffer } from 'payload-buffer'
 import {
   angleToDynamixelPosition,
+  dynamixelCrc16,
   dynamixelPositionToAngle,
   dynamixelStatusPayloadHasData,
   int16FromDynamixelPayload,
   int32FromDynamixelPayload,
   int32ToDynamixelBytes,
+  verifyDynamixelPacketCrc,
 } from 'protocols/dynamixel-codec'
 import { CommandTimeoutError } from 'servo-command-error'
 import SingleWaitSlot from 'single-wait-slot'
@@ -144,6 +146,11 @@ class PacketHandler extends Serial {
               const command = rxBuf[7] as Instruction
               if (command === INSTRUCTION.WRITE || command === INSTRUCTION.READ) {
                 // trace(`got echo.  ... ${rxBuf.subarray(0, this.#idx)} ignoring\n`)
+              } else if (!verifyDynamixelPacketCrc(rxBuf, this.#idx)) {
+                // Discard corrupted packets. The pending command times out and
+                // surfaces a CommandTimeoutError, which the command queue already
+                // handles with a recovery delay (same policy as the SCServo driver).
+                trace(`[dynamixel] crc mismatch for id=${id}. discarding ${rxBuf.subarray(0, this.#idx)}\n`)
               } else if (command === INSTRUCTION.STATUS) {
                 // trace(`got response for ${id}. triggering callback ... ${rxBuf.subarray(0, this.#idx)} \n`)
                 const payloadLength = this.#idx - 8
@@ -189,27 +196,6 @@ class PacketHandler extends Serial {
   removeCallback(id: number) {
     this.#callbacks.delete(id)
   }
-}
-
-/**
- * calculates checksum
- * @param arr - packet array except checksum
- * @returns checksum number
- */
-function checksum(arr: number[] | Uint8Array, start = 0, end = arr.length): number {
-  let crc16 = 0
-  for (let i = start; i < end; i++) {
-    const n = arr[i]
-    crc16 ^= n << 8
-    for (let i = 0; i < 8; i++) {
-      if (crc16 & 0x8000) {
-        crc16 = (crc16 << 1) ^ 0x8005
-      } else {
-        crc16 = crc16 << 1
-      }
-    }
-  }
-  return crc16
 }
 
 type DynamixelSerialConfig = Partial<{
@@ -355,7 +341,7 @@ class Dynamixel {
     this.#txBuf[5] = len & 0xff
     this.#txBuf[6] = (len >> 8) & 0xff
 
-    const crc = checksum(this.#txBuf, 0, idx)
+    const crc = dynamixelCrc16(this.#txBuf, 0, idx)
     this.#txBuf[idx++] = crc & 0xff
     this.#txBuf[idx++] = (crc >> 8) & 0xff
     /*


### PR DESCRIPTION
## 概要
Dynamixel status packet の CRC を検証し、破損 packet を受け付けないようにします。

## 変更内容
- Dynamixel status packet parse 時に CRC 検証を追加
- CRC 不一致 packet を reject
- codec unit test を追加・更新

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass, 31 tests
- cd firmware && npm run check:architecture: pass, 13 tests

## 未実施
- Moddable build
- 実機 Dynamixel サーボでの通信確認

## リリース影響
patch。通信 packet 検証の不具合修正です。

Closes #510
関連 #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packet integrity checks for Dynamixel communication, rejecting corrupted packets instead of processing them.
  * Updated outgoing packet checksums to use the correct CRC-16 method for better protocol compatibility.

* **Tests**
  * Added coverage for CRC validation, including known reference values and error cases for damaged or invalid packets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->