### PR TITLE
perf(ui): reduce face breath distribution churn

### DIFF
--- a/firmware/host/modules/ui/components/effects/__tests__/emoticon-pulse.test.ts
+++ b/firmware/host/modules/ui/components/effects/__tests__/emoticon-pulse.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { spritePulseVariantForFraction } from './emoticon-pulse.js'
+import { spritePulseVariantForFraction } from '../emoticon-pulse.js'
 
 test('sprite pulse variant stays stable across sub-frame ticks', () => {
   assert.equal(spritePulseVariantForFraction(0), 2)

--- a/firmware/host/modules/ui/components/effects/emoticon-pulse.test.ts
+++ b/firmware/host/modules/ui/components/effects/emoticon-pulse.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { spritePulseVariantForFraction } from './emoticon-pulse.js'
+
+test('sprite pulse variant stays stable across sub-frame ticks', () => {
+  assert.equal(spritePulseVariantForFraction(0), 2)
+  assert.equal(spritePulseVariantForFraction((2 * Math.PI) / 100), 2)
+  assert.equal(spritePulseVariantForFraction((2 * Math.PI * 12) / 100), 3)
+})

--- a/firmware/host/modules/ui/components/effects/emoticon-pulse.ts
+++ b/firmware/host/modules/ui/components/effects/emoticon-pulse.ts
@@ -1,0 +1,9 @@
+export const SPRITE_PULSE_FRAME_COUNT = 4
+
+export function spritePulseVariantForFraction(fraction: number): number {
+  const pulse = (Math.sin(fraction) + 1) / 2
+  const variant = Math.round(pulse * (SPRITE_PULSE_FRAME_COUNT - 1))
+  if (variant < 0) return 0
+  if (variant >= SPRITE_PULSE_FRAME_COUNT) return SPRITE_PULSE_FRAME_COUNT - 1
+  return variant
+}

--- a/firmware/host/modules/ui/components/effects/emoticon.ts
+++ b/firmware/host/modules/ui/components/effects/emoticon.ts
@@ -5,6 +5,7 @@ import {
   toPiuColorNumber,
   toPiuColorString,
 } from 'face-state'
+import { spritePulseVariantForFraction, SPRITE_PULSE_FRAME_COUNT } from 'effects/emoticon-pulse'
 import {
   Container,
   type Content as PiuContent,
@@ -77,7 +78,7 @@ type DropConfig = {
 }
 
 const SPRITE_CELL_SIZE = 32
-const SPRITE_FRAME_COUNT = 4
+const SPRITE_FRAME_COUNT = SPRITE_PULSE_FRAME_COUNT
 const CLEAR_COLOR = 'transparent'
 const HEART_ROW = 0
 const ANGRY_ROW = 1
@@ -193,6 +194,7 @@ class SpritePulseBehavior extends Behavior {
   #interval = 33
   #fraction = 0
   #primary = primaryColor()
+  #variant = spritePulseVariantForFraction(0)
 
   onCreate(port: PiuPort, data: EmoticonOptions = {}, row = HEART_ROW) {
     this.#row = row
@@ -213,6 +215,9 @@ class SpritePulseBehavior extends Behavior {
 
   onTimeChanged(port: PiuPort) {
     this.#fraction += (2 * Math.PI) / 100
+    const nextVariant = spritePulseVariantForFraction(this.#fraction)
+    if (nextVariant === this.#variant) return
+    this.#variant = nextVariant
     port.invalidate()
   }
 
@@ -225,9 +230,14 @@ class SpritePulseBehavior extends Behavior {
 
   onDraw(port: PiuPort) {
     port.fillColor(CLEAR_COLOR, 0, 0, this.#width, this.#height)
-    const pulse = (Math.sin(this.#fraction) + 1) / 2
-    const variant = clamp(Math.round(pulse * (SPRITE_FRAME_COUNT - 1)), 0, SPRITE_FRAME_COUNT - 1)
-    drawSpriteCell(port, this.#row, variant, this.#primary, centeredSpriteX(this.#width), centeredSpriteY(this.#height))
+    drawSpriteCell(
+      port,
+      this.#row,
+      this.#variant,
+      this.#primary,
+      centeredSpriteX(this.#width),
+      centeredSpriteY(this.#height),
+    )
   }
 }
 

--- a/firmware/host/modules/ui/components/effects/emoticon.ts
+++ b/firmware/host/modules/ui/components/effects/emoticon.ts
@@ -1,3 +1,4 @@
+import { SPRITE_PULSE_FRAME_COUNT, spritePulseVariantForFraction } from 'effects/emoticon-pulse'
 import {
   DEFAULT_FACE_PRIMARY_COLOR,
   DEFAULT_FACE_SECONDARY_COLOR,
@@ -5,7 +6,6 @@ import {
   toPiuColorNumber,
   toPiuColorString,
 } from 'face-state'
-import { spritePulseVariantForFraction, SPRITE_PULSE_FRAME_COUNT } from 'effects/emoticon-pulse'
 import {
   Container,
   type Content as PiuContent,

--- a/firmware/host/modules/ui/components/face/__tests__/face-rendering/face-rendering.test.ts
+++ b/firmware/host/modules/ui/components/face/__tests__/face-rendering/face-rendering.test.ts
@@ -24,6 +24,7 @@ type PiuNode = {
 
 type BreathRecorder = PiuNode & {
   lastBreath?: number
+  calls?: number
 }
 
 function childAt(container: PiuNode, index: number): PiuNode {
@@ -149,6 +150,7 @@ const breathRecorder = new Content(null, {
   height: 1,
   Behavior: class extends Behavior {
     onFaceState(content: BreathRecorder, face: FaceState) {
+      content.calls = (content.calls ?? 0) + 1
       content.lastBreath = face.breath
     }
   },
@@ -166,6 +168,49 @@ for (let i = 0; i < 32; i++) {
   breathChanged ||= breathRecorder.lastBreath !== initialBreath
 }
 assert(breathChanged, 'default FaceBehavior should update face breath')
+
+let controlledBreath = 0
+const controlledRecorder = new Content(null, {
+  left: 0,
+  top: 0,
+  width: 1,
+  height: 1,
+  Behavior: class extends Behavior {
+    onFaceState(content: BreathRecorder, face: FaceState) {
+      content.calls = (content.calls ?? 0) + 1
+      content.lastBreath = face.breath
+    }
+  },
+}) as BreathRecorder
+const controlledFace = new FaceBase({
+  contents: [controlledRecorder as unknown as PiuContent],
+  intervalMs: 33,
+  motions: [
+    (_tick, face) => {
+      face.breath = controlledBreath
+    },
+  ],
+}) as PiuNode
+const controlledBehavior = controlledFace.behavior as {
+  onCreate?: (node: PiuNode) => void
+  onTimeChanged?: (node: PiuNode) => void
+}
+controlledBehavior.onCreate?.(controlledFace)
+controlledBehavior.onTimeChanged?.(controlledFace)
+const callsAfterZero = controlledRecorder.calls
+controlledBreath = 0.08
+controlledBehavior.onTimeChanged?.(controlledFace)
+equal(
+  controlledRecorder.calls,
+  callsAfterZero,
+  'FaceBehavior should skip onFaceState distribution for sub-pixel breath changes',
+)
+controlledBreath = 0.09
+controlledBehavior.onTimeChanged?.(controlledFace)
+assert(
+  (controlledRecorder.calls ?? 0) > (callsAfterZero ?? 0),
+  'FaceBehavior should distribute onFaceState after breath crosses a rendered pixel',
+)
 
 const movingFace = new SimpleFace({ intervalMs: 33 }) as PiuNode
 const movingLeftEye = childAt(movingFace, 0)

--- a/firmware/host/modules/ui/components/face/behaviors/face.ts
+++ b/firmware/host/modules/ui/components/face/behaviors/face.ts
@@ -1,5 +1,11 @@
 import type { FaceSkinPalette } from 'face-skin'
-import { copyFaceState, copyFaceStateForDistribution, createFaceState, type FaceState, faceStatesEqual } from 'face-state'
+import {
+  copyFaceState,
+  copyFaceStateForDistribution,
+  createFaceState,
+  type FaceState,
+  faceStatesEqual,
+} from 'face-state'
 import { createBlinkMotion } from 'motions/blink'
 import { createBreathMotion } from 'motions/breath'
 import { createSaccadeMotion } from 'motions/saccade'

--- a/firmware/host/modules/ui/components/face/behaviors/face.ts
+++ b/firmware/host/modules/ui/components/face/behaviors/face.ts
@@ -1,5 +1,5 @@
 import type { FaceSkinPalette } from 'face-skin'
-import { copyFaceState, createFaceState, type FaceState, faceStatesEqual } from 'face-state'
+import { copyFaceState, copyFaceStateForDistribution, createFaceState, type FaceState, faceStatesEqual } from 'face-state'
 import { createBlinkMotion } from 'motions/blink'
 import { createBreathMotion } from 'motions/breath'
 import { createSaccadeMotion } from 'motions/saccade'
@@ -45,6 +45,7 @@ export class FaceBehavior extends Behavior {
   #current: FaceState
   #desired: FaceState
   #lastDistributed: FaceState
+  #nextDistributed: FaceState
   #motions: FaceMotion[]
   #baseCoordinates: { left: number; top: number }
   #hasBaseCoordinates: boolean
@@ -63,6 +64,7 @@ export class FaceBehavior extends Behavior {
     this.#current = createFaceState()
     this.#desired = createFaceState()
     this.#lastDistributed = createFaceState()
+    this.#nextDistributed = createFaceState()
     this.#baseCoordinates = { left: 0, top: 0 }
     this.#hasBaseCoordinates = false
     this.#paused = false
@@ -178,9 +180,10 @@ export class FaceBehavior extends Behavior {
   }
 
   private distributeFaceState(container: PiuContainer, force = false): void {
-    if (!force && faceStatesEqual(this.#current, this.#lastDistributed)) return
-    copyFaceState(this.#current, this.#lastDistributed)
-    container.distribute('onFaceState', this.#current)
+    copyFaceStateForDistribution(this.#current, this.#nextDistributed, this.#breathPixels)
+    if (!force && faceStatesEqual(this.#nextDistributed, this.#lastDistributed)) return
+    copyFaceState(this.#nextDistributed, this.#lastDistributed)
+    container.distribute('onFaceState', this.#nextDistributed)
     // container.bubble('onFaceState', this.#current)
   }
 

--- a/firmware/host/modules/ui/state/face-state.test.ts
+++ b/firmware/host/modules/ui/state/face-state.test.ts
@@ -2,10 +2,13 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
 import {
+  copyFaceStateForDistribution,
   copyFaceState,
   createFaceState,
   Emotion,
   emotionFromName,
+  faceStatesEqual,
+  quantizeBreathForPixels,
   setColorRGB,
   toColorString,
   toEmotionName,
@@ -35,4 +38,23 @@ test('FaceState uses plain mutable objects with numeric emotion and ColorRGB the
   assert.equal(copied.emotion, face.emotion)
   assert.equal(toPiuColorNumber(copied.theme.primary), 0x123456)
   assert.equal(toPiuColorNumber(copied.theme.secondary), 0xabcdef)
+})
+
+test('FaceState distribution quantizes breath to rendered pixels', () => {
+  const previous = createFaceState()
+  const next = createFaceState()
+  const previousDistributed = createFaceState()
+  const nextDistributed = createFaceState()
+
+  previous.breath = 0
+  next.breath = 0.08
+  copyFaceStateForDistribution(previous, previousDistributed, 6)
+  copyFaceStateForDistribution(next, nextDistributed, 6)
+  assert.equal(quantizeBreathForPixels(next.breath, 6), 0)
+  assert.equal(faceStatesEqual(previousDistributed, nextDistributed), true)
+
+  next.breath = 0.09
+  copyFaceStateForDistribution(next, nextDistributed, 6)
+  assert.equal(quantizeBreathForPixels(next.breath, 6), 1 / 6)
+  assert.equal(faceStatesEqual(previousDistributed, nextDistributed), false)
 })

--- a/firmware/host/modules/ui/state/face-state.test.ts
+++ b/firmware/host/modules/ui/state/face-state.test.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
 import {
-  copyFaceStateForDistribution,
   copyFaceState,
+  copyFaceStateForDistribution,
   createFaceState,
   Emotion,
   emotionFromName,

--- a/firmware/host/modules/ui/state/face-state.ts
+++ b/firmware/host/modules/ui/state/face-state.ts
@@ -151,6 +151,17 @@ export function copyFaceState(src: Readonly<FaceState>, dst: FaceState): void {
   copyColorRGB(src.theme.secondary, dst.theme.secondary)
 }
 
+export function quantizeBreathForPixels(breath: number, pixels: number): number {
+  if (!Number.isFinite(breath)) return 0
+  const steps = Math.max(1, Math.round(pixels))
+  return Math.round(breath * steps) / steps
+}
+
+export function copyFaceStateForDistribution(src: Readonly<FaceState>, dst: FaceState, breathPixels: number): void {
+  copyFaceState(src, dst)
+  dst.breath = quantizeBreathForPixels(src.breath, breathPixels)
+}
+
 export function faceStatesEqual(left: Readonly<FaceState>, right: Readonly<FaceState>): boolean {
   return (
     left.mouth.open === right.mouth.open &&


### PR DESCRIPTION
## 概要
FaceState の breath 更新と emoticon animation の不要な再描画を抑制します。

## 変更内容
- breath を描画ピクセル単位で量子化してから distribute
- sub-pixel の breath 変化では onFaceState 配布しない
- emoticon pulse の sprite variant が変わらない tick では invalidate しない
- pulse variant helper と unit test を追加

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass, 32 tests
- cd firmware && npm run check:architecture: pass, 13 tests
- git diff --check: pass

## 未実施
- 実機での描画フレームレート計測
- test:moddable / build

## リリース影響
patch。描画負荷を下げるパフォーマンス改善です。リリースノート記載推奨です。

Closes #513
関連 #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved emoticon pulse animation with smoother, more consistent frame selection.
  * Face breathing updates now use pixel-level rounding for more stable visual changes.

* **Bug Fixes**
  * Reduced unnecessary face redraws when breath changes are too small to be visible.
  * Improved consistency in animated face state updates across frames.

* **Tests**
  * Added coverage for pulse animation and breath quantization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->