### PR TITLE
test(ui): cover drawer and face behavior paths

### DIFF
--- a/firmware/host/modules/ui/__tests__/node-piu-harness.ts
+++ b/firmware/host/modules/ui/__tests__/node-piu-harness.ts
@@ -1,0 +1,369 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+
+import { writeAliasPackage, writeAliasPackageSubpath } from '../../testing/node-alias-package.js'
+
+const modulesRoot = resolve('dist-tests')
+
+function dist(path: string): string {
+  return resolve(modulesRoot, path)
+}
+
+function writeFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+}
+
+function writePackageExport(packageRoot: string, exports: Record<string, string>): void {
+  mkdirSync(packageRoot, { recursive: true })
+  writeFileSync(`${packageRoot}/package.json`, JSON.stringify({ type: 'module', exports }))
+}
+
+function relativeImport(fromFile: string, toFile: string): string {
+  const specifier = relative(dirname(fromFile), toFile).replaceAll('\\', '/')
+  return specifier.startsWith('.') ? specifier : `./${specifier}`
+}
+
+function writeReexport(entryPath: string, targetPath: string): void {
+  writeFile(entryPath, `export * from ${JSON.stringify(relativeImport(entryPath, targetPath))};\n`)
+}
+
+function writePiuStub(): void {
+  const packageRoot = resolve(modulesRoot, 'node_modules/piu')
+  writePackageExport(packageRoot, {
+    './MC': './MC.js',
+    './Timeline': './Timeline.js',
+  })
+  writeFile(
+    `${packageRoot}/MC.js`,
+    `
+globalThis.trace ??= () => {};
+globalThis.Math.quadEaseOut ??= (fraction) => 1 - (1 - fraction) * (1 - fraction);
+globalThis.Behavior ??= class {};
+
+function link(container) {
+  let previous = null;
+  for (const child of container.children) {
+    child.container = container;
+    child.previous = previous;
+    if (previous) previous.next = child;
+    previous = child;
+  }
+  container.first = container.children[0] ?? null;
+  container.last = previous;
+  if (previous) previous.next = null;
+}
+
+class PiuNode {
+  constructor(data = null, options = {}) {
+    this.children = [];
+    this.data = data;
+    this.name = options.name;
+    this.active = options.active;
+    this.visible = options.visible ?? true;
+    this.backgroundTouch = options.backgroundTouch;
+    this.skin = options.skin;
+    this.style = options.style;
+    this.string = options.string;
+    this.state = options.state;
+    this.variant = options.variant;
+    this.interval = options.interval;
+    this.duration = options.duration ?? 0;
+    this.time = options.time ?? 0;
+    this.width = options.width ?? 0;
+    this.height = options.height ?? 0;
+    if (options.anchor && data && typeof data === 'object') data[options.anchor] = this;
+    this.left = options.left;
+    this.right = options.right;
+    this.top = options.top;
+    this.bottom = options.bottom;
+    this.coordinates = {
+      left: options.left,
+      right: options.right,
+      top: options.top,
+      bottom: options.bottom,
+      width: options.width,
+      height: options.height,
+    };
+    const BehaviorClass = options.Behavior;
+    this.behavior = BehaviorClass ? new BehaviorClass() : undefined;
+    for (const child of options.contents ?? []) this.add(child);
+    this.behavior?.onCreate?.(this, data);
+  }
+  add(child) {
+    if (!child) return;
+    if (child.container) child.container.remove(child);
+    this.children.push(child);
+    link(this);
+  }
+  insert(child, before) {
+    if (!child) return;
+    if (child.container) child.container.remove(child);
+    const index = this.children.indexOf(before);
+    if (index < 0) this.children.push(child);
+    else this.children.splice(index, 0, child);
+    link(this);
+  }
+  remove(child) {
+    const index = this.children.indexOf(child);
+    if (index < 0) return;
+    this.children.splice(index, 1);
+    child.container = null;
+    child.next = null;
+    child.previous = null;
+    link(this);
+  }
+  empty() {
+    for (const child of this.children) {
+      child.container = null;
+      child.next = null;
+      child.previous = null;
+    }
+    this.children = [];
+    link(this);
+  }
+  get length() {
+    return this.children.length;
+  }
+  start() {
+    this.running = true;
+  }
+  stop() {
+    this.running = false;
+  }
+  moveBy(dx, dy) {
+    this.coordinates = {
+      ...this.coordinates,
+      left: (this.coordinates.left ?? this.left ?? 0) + dx,
+      top: (this.coordinates.top ?? this.top ?? 0) + dy,
+    };
+    this.left = this.coordinates.left;
+    this.top = this.coordinates.top;
+  }
+  bubble(id, ...args) {
+    this.lastBubble = [id, ...args];
+    let current = this.container;
+    while (current) {
+      const handler = current.behavior?.[id];
+      if (typeof handler === 'function') return handler.call(current.behavior, current, ...args);
+      current = current.container;
+    }
+  }
+  distribute(id, ...args) {
+    const handler = this.behavior?.[id];
+    if (typeof handler === 'function') handler.call(this.behavior, this, ...args);
+    for (const child of this.children) child.distribute?.(id, ...args);
+  }
+  invalidate() {
+    this.invalidated = (this.invalidated ?? 0) + 1;
+  }
+  captureTouch(id, x, y, ticks) {
+    this.lastCapturedTouch = [id, x, y, ticks];
+  }
+  scrollTo(x, y) {
+    this.scroll = { x, y };
+  }
+  fillColor(...args) {
+    this.draws ??= [];
+    this.draws.push(['fillColor', ...args]);
+  }
+  drawTexture(...args) {
+    this.draws ??= [];
+    this.draws.push(['drawTexture', ...args]);
+  }
+  set(x, y, width, height) {
+    this.mask = { x, y, width, height };
+    return this;
+  }
+  cut() {
+    this.cutCalled = true;
+    return this;
+  }
+}
+
+function templateFor(Class) {
+  return (factory) =>
+    class extends Class {
+      constructor(data = {}, dictionary = {}) {
+        super(data, { ...factory(data, dictionary), ...dictionary });
+      }
+      static template(nextFactory) {
+        return templateFor(this)((data, dictionary) => ({
+          ...factory(data, dictionary),
+          ...nextFactory(data, dictionary),
+        }));
+      }
+    };
+}
+
+export class Content extends PiuNode {}
+Content.template = templateFor(Content);
+export class Container extends PiuNode {}
+Container.template = templateFor(Container);
+export class Column extends Container {}
+Column.template = templateFor(Column);
+export class Scroller extends Container {
+  constructor(data, options = {}) {
+    super(data, options);
+    this.scroll = { x: 0, y: 0 };
+  }
+}
+Scroller.template = templateFor(Scroller);
+export class Label extends Content {}
+Label.template = templateFor(Label);
+export class Text extends Content {}
+Text.template = templateFor(Text);
+export class Port extends Content {}
+Port.template = templateFor(Port);
+export class Shape extends Content {}
+Shape.template = templateFor(Shape);
+export class Die extends Container {}
+Die.template = templateFor(Die);
+export class Application extends Container {}
+export class Skin {
+  constructor(options = {}) {
+    Object.assign(this, options);
+  }
+}
+export class Style {
+  constructor(options = {}) {
+    Object.assign(this, options);
+  }
+}
+export class Texture {
+  constructor(path) {
+    this.path = path;
+  }
+}
+Object.assign(globalThis, {
+  Content,
+  Container,
+  Column,
+  Scroller,
+  Label,
+  Text,
+  Port,
+  Shape,
+  Die,
+  Application,
+  Skin,
+  Style,
+  Texture,
+});
+`,
+  )
+  writeFile(
+    `${packageRoot}/Timeline.js`,
+    `
+export default class Timeline {
+  duration = 0;
+  on(target, properties, duration) {
+    this.target = target;
+    this.properties = properties;
+    this.duration = duration;
+  }
+  seekTo(time) {
+    if (!this.properties) return;
+    const fraction = this.duration > 0 ? Math.max(0, Math.min(1, time / this.duration)) : 1;
+    for (const [key, range] of Object.entries(this.properties)) {
+      const [from, to] = range;
+      this.target[key] = from + (to - from) * fraction;
+    }
+  }
+}
+`,
+  )
+}
+
+function writeCommodettoStub(): void {
+  const packageRoot = resolve(modulesRoot, 'node_modules/commodetto')
+  writePackageExport(packageRoot, { './outline': './outline.js' })
+  writeFile(
+    `${packageRoot}/outline.js`,
+    `
+class CanvasPath {
+  arc() {}
+  ellipse() {}
+  moveTo() {}
+  lineTo() {}
+  bezierCurveTo() {}
+  quadraticCurveTo() {}
+  closePath() {}
+}
+export const Outline = {
+  CanvasPath,
+  fill(path) {
+    return { kind: 'fill', path };
+  },
+  stroke(path, width) {
+    return { kind: 'stroke', path, width };
+  },
+};
+export default Outline;
+`,
+  )
+}
+
+function writePartsAliases(): void {
+  const packageRoot = resolve(modulesRoot, 'node_modules/parts')
+  const subpaths = [
+    'eye',
+    'mouth',
+    'shape-cache',
+    'shape-utils',
+    'dog/eyebrow',
+    'dog/mouth',
+    'dog/nose',
+    'image/atlas',
+    'image/eye-sprite',
+    'image/eyelid-sprite',
+    'image/image-avatar-face',
+    'image/image-avatar-pack',
+    'image/image-avatar-state',
+    'image/iris-sprite',
+    'image/mouth-sprite',
+  ]
+  writePackageExport(
+    packageRoot,
+    Object.fromEntries(subpaths.map((subpath) => [`./${subpath}`, `./${subpath}.js`])),
+  )
+  for (const subpath of subpaths) {
+    writeReexport(
+      resolve(packageRoot, `${subpath}.js`),
+      dist(`host/modules/ui/components/face/parts/${subpath}.js`),
+    )
+  }
+}
+
+export function installUiNodeTestAliases(): void {
+  writePiuStub()
+  writeCommodettoStub()
+  writePartsAliases()
+
+  writeAliasPackage(modulesRoot, 'face-state', dist('host/modules/ui/state/face-state.js'))
+  writeAliasPackage(modulesRoot, 'face-skin', dist('host/modules/ui/state/face-skin.js'))
+  writeAliasPackage(modulesRoot, 'stackchan-util', dist('host/modules/util/stackchan-util.js'))
+  writeAliasPackage(modulesRoot, 'timer', dist('host/modules/testing/fakes/timer.js'), { hasDefaultExport: true })
+  writeAliasPackage(modulesRoot, 'mac-address', dist('host/modules/util/sim/mac-address.js'), { hasDefaultExport: true })
+  writeAliasPackage(modulesRoot, 'drawer', dist('host/modules/ui/components/drawer/drawer.js'))
+  writeAliasPackage(modulesRoot, 'common-view', dist('host/modules/ui/views/main/common-view.js'))
+  writeAliasPackage(modulesRoot, 'face-view', dist('host/modules/ui/views/main/face-view.js'))
+  writeAliasPackage(modulesRoot, 'template', dist('host/modules/ui/components/face/template.js'))
+  writeAliasPackageSubpath(modulesRoot, 'motions', 'types', dist('host/modules/ui/components/face/motions/types.js'))
+  writeAliasPackageSubpath(modulesRoot, 'motions', 'blink', dist('host/modules/ui/components/face/motions/blink.js'))
+  writeAliasPackageSubpath(modulesRoot, 'motions', 'breath', dist('host/modules/ui/components/face/motions/breath.js'))
+  writeAliasPackageSubpath(modulesRoot, 'motions', 'saccade', dist('host/modules/ui/components/face/motions/saccade.js'))
+  writeAliasPackageSubpath(
+    modulesRoot,
+    'effects',
+    'emoticon',
+    dist('host/modules/ui/components/effects/emoticon.js'),
+  )
+  writeAliasPackageSubpath(
+    modulesRoot,
+    'effects',
+    'multirow-balloon',
+    dist('host/modules/ui/components/bubble/multirow-balloon.js'),
+  )
+  writeAliasPackageSubpath(modulesRoot, 'behaviors', 'face', dist('host/modules/ui/components/face/behaviors/face.js'))
+}

--- a/firmware/host/modules/ui/__tests__/node-piu-harness.ts
+++ b/firmware/host/modules/ui/__tests__/node-piu-harness.ts
@@ -323,15 +323,9 @@ function writePartsAliases(): void {
     'image/iris-sprite',
     'image/mouth-sprite',
   ]
-  writePackageExport(
-    packageRoot,
-    Object.fromEntries(subpaths.map((subpath) => [`./${subpath}`, `./${subpath}.js`])),
-  )
+  writePackageExport(packageRoot, Object.fromEntries(subpaths.map((subpath) => [`./${subpath}`, `./${subpath}.js`])))
   for (const subpath of subpaths) {
-    writeReexport(
-      resolve(packageRoot, `${subpath}.js`),
-      dist(`host/modules/ui/components/face/parts/${subpath}.js`),
-    )
+    writeReexport(resolve(packageRoot, `${subpath}.js`), dist(`host/modules/ui/components/face/parts/${subpath}.js`))
   }
 }
 
@@ -344,7 +338,9 @@ export function installUiNodeTestAliases(): void {
   writeAliasPackage(modulesRoot, 'face-skin', dist('host/modules/ui/state/face-skin.js'))
   writeAliasPackage(modulesRoot, 'stackchan-util', dist('host/modules/util/stackchan-util.js'))
   writeAliasPackage(modulesRoot, 'timer', dist('host/modules/testing/fakes/timer.js'), { hasDefaultExport: true })
-  writeAliasPackage(modulesRoot, 'mac-address', dist('host/modules/util/sim/mac-address.js'), { hasDefaultExport: true })
+  writeAliasPackage(modulesRoot, 'mac-address', dist('host/modules/util/sim/mac-address.js'), {
+    hasDefaultExport: true,
+  })
   writeAliasPackage(modulesRoot, 'drawer', dist('host/modules/ui/components/drawer/drawer.js'))
   writeAliasPackage(modulesRoot, 'common-view', dist('host/modules/ui/views/main/common-view.js'))
   writeAliasPackage(modulesRoot, 'face-view', dist('host/modules/ui/views/main/face-view.js'))
@@ -352,13 +348,13 @@ export function installUiNodeTestAliases(): void {
   writeAliasPackageSubpath(modulesRoot, 'motions', 'types', dist('host/modules/ui/components/face/motions/types.js'))
   writeAliasPackageSubpath(modulesRoot, 'motions', 'blink', dist('host/modules/ui/components/face/motions/blink.js'))
   writeAliasPackageSubpath(modulesRoot, 'motions', 'breath', dist('host/modules/ui/components/face/motions/breath.js'))
-  writeAliasPackageSubpath(modulesRoot, 'motions', 'saccade', dist('host/modules/ui/components/face/motions/saccade.js'))
   writeAliasPackageSubpath(
     modulesRoot,
-    'effects',
-    'emoticon',
-    dist('host/modules/ui/components/effects/emoticon.js'),
+    'motions',
+    'saccade',
+    dist('host/modules/ui/components/face/motions/saccade.js'),
   )
+  writeAliasPackageSubpath(modulesRoot, 'effects', 'emoticon', dist('host/modules/ui/components/effects/emoticon.js'))
   writeAliasPackageSubpath(
     modulesRoot,
     'effects',

--- a/firmware/host/modules/ui/ui-node-coverage.test.ts
+++ b/firmware/host/modules/ui/ui-node-coverage.test.ts
@@ -312,7 +312,10 @@ test('Emoticon variants invalidate, draw atlas frames, and react to theme change
     assert.ok((port.invalidated ?? 0) > 1)
     behavior.onFaceState?.(port, themedFace(0xff00aa, 0x003355))
     behavior.onDraw?.(port)
-    assert.ok(port.draws?.some((entry) => entry[0] === 'drawTexture'), `${key} should draw from the atlas`)
+    assert.ok(
+      port.draws?.some((entry) => entry[0] === 'drawTexture'),
+      `${key} should draw from the atlas`,
+    )
     behavior.onUndisplaying?.(port)
     assert.equal(port.running, false)
   }

--- a/firmware/host/modules/ui/ui-node-coverage.test.ts
+++ b/firmware/host/modules/ui/ui-node-coverage.test.ts
@@ -1,0 +1,403 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { installUiNodeTestAliases } from './__tests__/node-piu-harness.js'
+
+installUiNodeTestAliases()
+
+const piuModule = 'piu/MC'
+const piu = (await import(piuModule)) as unknown as PiuRuntime
+const faceStateModule = await import('face-state')
+const drawerModule = await import('drawer')
+const commonViewModule = await import('common-view')
+const faceViewModule = await import('face-view')
+const multirowModule = await import('effects/multirow-balloon')
+const emoticonModule = await import('effects/emoticon')
+const blinkModule = await import('motions/blink')
+const breathModule = await import('motions/breath')
+const saccadeModule = await import('motions/saccade')
+const faceBehaviorModule = await import('behaviors/face')
+
+const { Container, Content } = piu
+const BehaviorBase = (globalThis as typeof globalThis & { Behavior: new () => object }).Behavior
+const { createFaceState, setColorRGB, toPiuColorNumber } = faceStateModule
+const { Drawer } = drawerModule as unknown as { Drawer: new (data?: unknown) => PiuNode }
+const { CommonView } = commonViewModule as unknown as { CommonView: new (data: Record<string, unknown>) => PiuNode }
+const { FaceView } = faceViewModule as unknown as { FaceView: new (data: Record<string, unknown>) => PiuNode }
+const { MultiRowBalloon } = multirowModule as unknown as { MultiRowBalloon: new (data?: unknown) => PiuNode }
+const { Emoticon } = emoticonModule as unknown as { Emoticon: new (data?: unknown) => PiuNode }
+const { createBlinkMotion } = blinkModule
+const { createBreathMotion } = breathModule
+const { createSaccadeMotion } = saccadeModule
+const { FaceBehavior: BaseFaceBehavior } = faceBehaviorModule
+
+type PiuNode = {
+  name?: string
+  first?: PiuNode | null
+  last?: PiuNode | null
+  next?: PiuNode | null
+  previous?: PiuNode | null
+  children?: PiuNode[]
+  behavior?: BehaviorBag
+  coordinates?: Record<string, number>
+  active?: boolean
+  visible?: boolean
+  backgroundTouch?: boolean
+  skin?: unknown
+  style?: unknown
+  string?: string
+  interval?: number
+  time?: number
+  duration?: number
+  running?: boolean
+  invalidated?: number
+  draws?: unknown[][]
+  lastBubble?: unknown[]
+  top?: number
+}
+
+type PiuRuntime = {
+  Container: new (data?: unknown, options?: Record<string, unknown>) => PiuNode
+  Content: new (data?: unknown, options?: Record<string, unknown>) => PiuNode
+}
+
+type BehaviorBag = Record<string, unknown> & {
+  isOpen?: boolean
+  faceMain?: PiuNode
+  overlay?: PiuNode
+  setOpen?: (node: PiuNode, open: boolean) => void
+  onTimeChanged?: (node: PiuNode) => void
+  setButtonState?: (node: PiuNode, key: string, active: boolean) => boolean
+  addButton?: (node: PiuNode, button: unknown) => boolean
+  removeButton?: (node: PiuNode, key: string) => boolean
+  setButtons?: (node: PiuNode, buttons: unknown[]) => boolean
+  setMain?: (node: PiuNode) => void
+  setDrawerButtonState?: (key: string, active: boolean) => void
+  openDrawer?: () => void
+  setDrawerButtons?: (buttons: unknown[]) => void
+  onFaceUpdate?: (node: PiuNode, faceState: ReturnType<typeof createFaceState>) => void
+  showFace?: () => void
+  onDisplaying?: (node: PiuNode) => void
+  onUndisplaying?: (node: PiuNode) => void
+  onFaceState?: (node: PiuNode, faceState: ReturnType<typeof createFaceState>) => void
+  onDraw?: (node: PiuNode) => void
+  setText?: (node: PiuNode, text: string) => void
+  clear?: (node: PiuNode) => void
+  onCreate?: (node: PiuNode) => void
+  pause?: (node: PiuNode) => void
+  resume?: (node: PiuNode) => void
+  rehydrate?: (node: PiuNode, faceState: ReturnType<typeof createFaceState>) => void
+}
+
+function childArray(node: PiuNode): PiuNode[] {
+  const children: PiuNode[] = []
+  let current = node.first ?? null
+  while (current) {
+    children.push(current)
+    current = current.next ?? null
+  }
+  return children
+}
+
+function childAt(node: PiuNode, index: number): PiuNode {
+  const child = childArray(node)[index]
+  assert.ok(child, `child ${index} should exist`)
+  return child
+}
+
+function findNamed(root: PiuNode, name: string): PiuNode | null {
+  const stack = [root]
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (!node) continue
+    if (node.name === name) return node
+    stack.push(...childArray(node))
+  }
+  return null
+}
+
+function themedFace(primary: number, secondary = 0x000000): ReturnType<typeof createFaceState> {
+  const face = createFaceState()
+  setColorRGB(face.theme.primary, (primary >> 16) & 0xff, (primary >> 8) & 0xff, primary & 0xff)
+  setColorRGB(face.theme.secondary, (secondary >> 16) & 0xff, (secondary >> 8) & 0xff, secondary & 0xff)
+  return face
+}
+
+test('Drawer opens/closes, mutates buttons, and syncs toggle state', () => {
+  const drawer = new Drawer({
+    buttons: [
+      { key: 'speech', label: 'Speech', kind: 'toggle', active: false },
+      { key: 'settings', label: 'Settings' },
+    ],
+  }) as PiuNode
+  const behavior = drawer.behavior
+  assert.ok(behavior)
+  assert.equal(behavior.isOpen, false)
+  assert.equal(drawer.coordinates?.right, -113)
+
+  behavior.setOpen?.(drawer, true)
+  assert.equal(behavior.isOpen, true)
+  drawer.time = drawer.duration
+  behavior.onTimeChanged?.(drawer)
+  assert.equal(drawer.coordinates?.right, 0)
+
+  behavior.setOpen?.(drawer, false)
+  assert.equal(behavior.isOpen, false)
+  drawer.time = drawer.duration
+  behavior.onTimeChanged?.(drawer)
+  assert.equal(drawer.coordinates?.right, -113)
+
+  const list = childAt(childAt(drawer, 0), 0)
+  const firstToggle = childAt(list, 0)
+  const toggleIcon = childAt(firstToggle, 0)
+  const offSkin = toggleIcon.skin
+  assert.equal(behavior.setButtonState?.(drawer, 'speech', true), true)
+  assert.notEqual(toggleIcon.skin, offSkin)
+
+  assert.equal(behavior.addButton?.(drawer, { key: 'extra', label: 'Extra' }), true)
+  assert.ok(findNamed(list, 'extra'))
+  assert.equal(behavior.removeButton?.(drawer, 'extra'), true)
+  assert.equal(findNamed(list, 'extra'), null)
+})
+
+test('CommonView preserves z-order and rebuilds Drawer only on fallback branches', () => {
+  const main = new Container(null, { name: 'main' }) as PiuNode
+  const appBar = new Content(null, { name: 'appBar' }) as PiuNode
+  const view = new CommonView({
+    main,
+    appBar,
+    drawerButtons: [{ key: 'speech', label: 'Speech', kind: 'toggle' }],
+  }) as PiuNode
+  const behavior = view.behavior
+  assert.ok(behavior)
+
+  const initialDrawer = findNamed(view, 'drawer')
+  assert.ok(initialDrawer)
+  assert.deepEqual(
+    childArray(view).map((child) => child.name),
+    ['main', 'appBar', undefined, 'drawer'],
+  )
+
+  let shown = 0
+  let hidden = 0
+  const replacement = new Container(null, {
+    name: 'replacement',
+    Behavior: class extends BehaviorBase {
+      onShow() {
+        shown += 1
+      }
+      onHide() {
+        hidden += 1
+      }
+    },
+  }) as PiuNode
+  behavior.setMain?.(replacement)
+  assert.equal(shown, 1)
+  assert.equal(hidden, 0)
+  assert.deepEqual(
+    childArray(view).map((child) => child.name),
+    ['replacement', 'appBar', undefined, 'drawer'],
+  )
+  behavior.setMain?.(main)
+  assert.equal(hidden, 1)
+  assert.deepEqual(
+    childArray(view).map((child) => child.name),
+    ['main', 'appBar', undefined, 'drawer'],
+  )
+
+  behavior.setDrawerButtonState?.('speech', true)
+  behavior.openDrawer?.()
+  assert.equal(behavior.drawerOpen, true)
+  assert.equal((behavior.overlay as PiuNode).active, true)
+
+  const drawerBehavior = (initialDrawer as PiuNode).behavior
+  assert.ok(drawerBehavior)
+  drawerBehavior.setButtons = () => false
+  behavior.setDrawerButtons?.([
+    { key: 'speech', label: 'Speech', kind: 'toggle' },
+    { key: 'camera', label: 'Camera' },
+  ])
+  const replacementDrawer = findNamed(view, 'drawer')
+  assert.ok(replacementDrawer)
+  assert.notEqual(replacementDrawer, initialDrawer)
+  assert.equal(behavior.drawerOpen, true)
+  assert.equal((replacementDrawer.behavior as Record<string, unknown>).isOpen, true)
+  assert.equal((behavior.overlay as PiuNode).active, true)
+  assert.ok(findNamed(replacementDrawer, 'camera'))
+
+  const speechButton = findNamed(replacementDrawer, 'speech')
+  assert.ok(speechButton)
+  const speechIcon = childAt(speechButton, 0)
+  assert.equal(speechIcon.skin, childAt(speechButton, 0).skin, 'stored toggle state should be applied after replace')
+})
+
+test('FaceView showFace restores the face main layer and rehydrates the cached state', () => {
+  const seenUpdates: number[] = []
+  const rehydrated: number[] = []
+  const face = new Container(null, {
+    left: 16,
+    top: 24,
+    width: 80,
+    height: 48,
+    Behavior: class extends BehaviorBase {
+      get breathPixels() {
+        return 4
+      }
+      onFaceUpdate(_content: PiuNode, faceState: ReturnType<typeof createFaceState>) {
+        seenUpdates.push(toPiuColorNumber(faceState.theme.primary))
+      }
+      rehydrate(_content: PiuNode, faceState: ReturnType<typeof createFaceState>) {
+        rehydrated.push(toPiuColorNumber(faceState.theme.primary))
+      }
+      getBaseCoordinates() {
+        return { left: 4, top: 4 }
+      }
+    },
+  }) as PiuNode
+  const view = new FaceView({ face }) as PiuNode
+  const behavior = view.behavior
+  assert.ok(behavior)
+  const faceMain = behavior.faceMain as PiuNode
+  assert.equal(childAt(view, 0), faceMain)
+
+  const first = themedFace(0x123456, 0x111111)
+  const second = themedFace(0xabcdef, 0x222222)
+  behavior.onFaceUpdate?.(view, first)
+  const modal = new Container(null, { name: 'modal' }) as PiuNode
+  behavior.setMain?.(modal)
+  assert.equal(childAt(view, 0), modal)
+
+  behavior.onFaceUpdate?.(view, second)
+  assert.deepEqual(seenUpdates, [0x123456], 'non-face main should pause MOD-facing face updates')
+
+  behavior.showFace?.()
+  assert.equal(childAt(view, 0), faceMain)
+  assert.equal(rehydrated.at(-1), 0x123456, 'showFace should restore the cached face state from before pause')
+})
+
+test('MultiRowBalloon initializes parts, updates palette, and keeps text controls live', () => {
+  const balloon = new MultiRowBalloon({ text: 'hello', width: 120, height: 32 }) as PiuNode
+  const behavior = balloon.behavior
+  assert.ok(behavior)
+
+  behavior.onDisplaying?.(balloon)
+  const background = childAt(balloon, 0)
+  const bodyText = childAt(balloon, 1)
+  assert.equal(bodyText.string, 'hello')
+  assert.ok(background.invalidated)
+
+  const defaultStyle = bodyText.style
+  behavior.onFaceState?.(balloon, themedFace(0x336699, 0x111111))
+  assert.notEqual(bodyText.style, defaultStyle)
+  assert.ok((background.invalidated ?? 0) > 1)
+
+  behavior.setText?.(balloon, 'updated')
+  assert.equal(bodyText.string, 'updated')
+  behavior.clear?.(balloon)
+  assert.equal(bodyText.string, '')
+})
+
+test('Emoticon variants invalidate, draw atlas frames, and react to theme changes', () => {
+  for (const key of ['heart', 'angry', 'sweat', 'tear', 'sleepy'] as const) {
+    const effect = new Emoticon({ key, width: 64, height: 64, count: 2 }) as PiuNode
+    assert.equal(effect.name, `Emoticon:${key}`)
+    const port = childAt(effect, 0)
+    const behavior = port.behavior
+    assert.ok(behavior)
+
+    behavior.onDisplaying?.(port)
+    assert.equal(port.running, true)
+    assert.ok(port.invalidated)
+    behavior.onTimeChanged?.(port)
+    assert.ok((port.invalidated ?? 0) > 1)
+    behavior.onFaceState?.(port, themedFace(0xff00aa, 0x003355))
+    behavior.onDraw?.(port)
+    assert.ok(port.draws?.some((entry) => entry[0] === 'drawTexture'), `${key} should draw from the atlas`)
+    behavior.onUndisplaying?.(port)
+    assert.equal(port.running, false)
+  }
+})
+
+test('Face motions cover blink, breath, and saccade state transitions', () => {
+  const blink = createBlinkMotion({ openMin: 10, openMax: 10, closeMin: 10, closeMax: 10 })
+  const blinkingFace = createFaceState()
+  blink(10, blinkingFace)
+  blink(5, blinkingFace)
+  blinkingFace.eyes.left.open = 1
+  blinkingFace.eyes.right.open = 1
+  blink(0, blinkingFace)
+  assert.ok(blinkingFace.eyes.left.open < 1)
+  assert.equal(blinkingFace.eyes.left.open, blinkingFace.eyes.right.open)
+
+  const breath = createBreathMotion({ duration: 1000 })
+  const breathingFace = createFaceState()
+  breath(250, breathingFace)
+  assert.equal(breathingFace.breath, 1)
+  breath(500, breathingFace)
+  assert.equal(breathingFace.breath, -1)
+
+  const originalRandom = Math.random
+  const values = [0.5, 0.5, 0.75, 0.5, 0.5, 0.75]
+  Math.random = () => values.shift() ?? 0.5
+  try {
+    const saccade = createSaccadeMotion({ updateMin: 0, updateMax: 0, gain: 0.2 })
+    const saccadeFace = createFaceState()
+    saccade(1, saccadeFace)
+    assert.notEqual(saccadeFace.eyes.left.gazeX, 0)
+    assert.equal(saccadeFace.eyes.left.gazeX, saccadeFace.eyes.right.gazeX)
+    assert.equal(saccadeFace.eyes.left.gazeY, saccadeFace.eyes.right.gazeY)
+  } finally {
+    Math.random = originalRandom
+  }
+})
+
+test('FaceBehavior breath, pause, resume, and rehydrate paths preserve distributed state', () => {
+  const recorded: number[] = []
+  const child = new Content(null, {
+    Behavior: class extends BehaviorBase {
+      onFaceState(_content: PiuNode, faceState: ReturnType<typeof createFaceState>) {
+        recorded.push(toPiuColorNumber(faceState.theme.primary))
+      }
+    },
+  }) as PiuNode
+  const face = new Container(null, {
+    left: 10,
+    top: 20,
+    contents: [child],
+    Behavior: class extends BaseFaceBehavior {
+      constructor() {
+        super({
+          intervalMs: 33,
+          motions: [
+            (_tick: number, faceState: ReturnType<typeof createFaceState>) => {
+              faceState.breath = 1
+            },
+          ],
+        })
+      }
+    },
+  }) as PiuNode
+  const behavior = face.behavior
+  assert.ok(behavior)
+  behavior.onCreate?.(face)
+  behavior.onDisplaying?.(face)
+  const initialTop = face.coordinates?.top
+  behavior.onTimeChanged?.(face)
+  assert.equal(face.coordinates?.top, (initialTop ?? 20) + 6)
+
+  behavior.pause?.(face)
+  assert.equal(face.running, false)
+  assert.equal(face.visible, false)
+  assert.equal(face.active, false)
+  behavior.onTimeChanged?.(face)
+  assert.equal(face.coordinates?.top, (initialTop ?? 20) + 6)
+
+  const restored = themedFace(0x445566, 0x010203)
+  behavior.rehydrate?.(face, restored)
+  behavior.resume?.(face)
+  assert.equal(face.running, true)
+  assert.equal(face.visible, true)
+  assert.equal(face.active, true)
+  assert.equal(recorded.at(-1), 0x445566)
+  assert.deepEqual(face.lastBubble?.slice(0, 2), ['onFaceState', restored])
+})

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -40,8 +40,35 @@
       "face-state": [
         "host/modules/ui/state/face-state.ts"
       ],
+      "face-skin": [
+        "host/modules/ui/state/face-skin.ts"
+      ],
+      "drawer": [
+        "host/modules/ui/components/drawer/drawer.ts"
+      ],
+      "common-view": [
+        "host/modules/ui/views/main/common-view.ts"
+      ],
+      "face-view": [
+        "host/modules/ui/views/main/face-view.ts"
+      ],
+      "effects/*": [
+        "host/modules/ui/components/effects/*.ts"
+      ],
+      "effects/multirow-balloon": [
+        "host/modules/ui/components/bubble/multirow-balloon.ts"
+      ],
+      "effects/speech-balloon": [
+        "host/modules/ui/components/bubble/speech-balloon.ts"
+      ],
+      "behaviors/*": [
+        "host/modules/ui/components/face/behaviors/*.ts"
+      ],
+      "motions/*": [
+        "host/modules/ui/components/face/motions/*.ts"
+      ],
       "parts/*": [
-        "host/modules/ui/components/face/parts/*"
+        "host/modules/ui/components/face/parts/*.ts"
       ],
       "parts/image/image-avatar-pack": [
         "host/modules/ui/components/face/parts/image/image-avatar-pack.ts"
@@ -130,6 +157,9 @@
       "settings-status-model": [
         "host/modules/ui/views/settings/settings-status-model.ts"
       ],
+      "template": [
+        "host/modules/ui/components/face/template.ts"
+      ],
       "app-behavior-resolver": [
         "host/app/app-behavior-resolver.ts"
       ],
@@ -144,6 +174,12 @@
       ],
       "stackchan-util": [
         "host/modules/util/stackchan-util.ts"
+      ],
+      "piu/*": [
+        "node_modules/@moddable/typings/piu/*.d.ts"
+      ],
+      "commodetto/*": [
+        "node_modules/@moddable/typings/commodetto/*.d.ts"
       ]
     },
     "types": [


### PR DESCRIPTION
## 概要
UI module の Node unit test coverage を追加します。

## 追加したテスト
- drawer open/close、button add/remove、toggle state
- CommonView setMain z-order と drawer replaceDrawer fallback
- FaceView showFace の resume / rehydrate
- emoticon / multirow-balloon
- blink / breath / saccade motions
- FaceBehavior breath / pause / resume / rehydrate

## 変更内容
- Node test 用の最小 Piu / Timeline / Outline harness を追加
- UI coverage test を追加
- tsconfig.test.json に UI module 解決 alias を追加

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass, 32 tests
- cd firmware && npm run check:architecture: pass, 13 tests
- git diff --check: pass

## 未カバー / 未実施
- Moddable SDK 前提の test:moddable / build は未実行
- 実機 UI 確認は未実施

## リリース影響
none。テスト追加のみで runtime behavior の変更はありません。

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
