### PR TITLE
fix(mods): migrate examples to namespace API

### DIFF
--- a/firmware/host/app/app-capabilities.architecture.ts
+++ b/firmware/host/app/app-capabilities.architecture.ts
@@ -180,10 +180,15 @@ test('sample MODs use namespaced context capabilities', () => {
   visit(root)
 
   const flatApiPattern =
-    /\brobot\.(say|record|tone|playAudio|useTTS|lookAt|lookAway|setPose|setTorque|setEmotion|setColor|showBalloon|hideBalloon|lightOn|lightOff|lightBlink|lightRainbow|button|touch|touchPanel|imu|led|tts|microphone|drawer)\b/
+    /\brobot\.(say|record|tone|playAudio|useTTS|lookAt|lookAway|setPose|setTorque|setEmotion|setColor|setMouthOpen|showBalloon|hideBalloon|lightOn|lightOff|lightBlink|lightRainbow|button|touch|touchPanel|imu|led|tts|microphone|drawer)\b/
+  const excludedFromIssue515 = new Set(['mods/examples/setup_rs30x/mod.js', 'mods/examples/calibration/mod.js'])
+  const unsafeButtonPattern = /\b(?:robot\.input\.button|context\.button)\.[abc]\.onEvent\b/
 
   for (const file of files) {
     const source = readFileSync(file, 'utf8')
     assert.doesNotMatch(source, flatApiPattern, `${file} should use namespaced StackchanContext capabilities`)
+    if (!excludedFromIssue515.has(file)) {
+      assert.doesNotMatch(source, unsafeButtonPattern, `${file} should guard optional button capabilities`)
+    }
   }
 })

--- a/firmware/host/app/capabilities.ts
+++ b/firmware/host/app/capabilities.ts
@@ -208,14 +208,71 @@ export type StackchanCapabilityNamespaces = {
   ui: RuntimeUICapability
 }
 
-export type StackchanLegacyFlatCapability = FaceCapability &
-  MotionCapability &
-  AudioCapability &
-  InputCapability &
-  LightingCapability &
-  CameraCapability &
-  ConversationCapability &
-  ConnectivityCapability &
-  UICapability
+/**
+ * @deprecated Use the namespaced capabilities on `StackchanCapabilityNamespaces`
+ * (`context.face`, `context.motion`, `context.audio`, etc.) instead.
+ */
+export type StackchanLegacyFlatCapability = {
+  /** @deprecated Use `context.face.setColor(...)` instead. */
+  setColor: FaceCapability['setColor']
+  /** @deprecated Use `context.face.setEmotion(...)` instead. */
+  setEmotion: FaceCapability['setEmotion']
+  /** @deprecated Use `context.face.setMouthOpen(...)` instead. */
+  setMouthOpen: FaceCapability['setMouthOpen']
+  /** @deprecated Use `context.motion.pose` instead. */
+  pose: MotionCapability['pose']
+  /** @deprecated Use `context.motion.lookAt(...)` instead. */
+  lookAt: MotionCapability['lookAt']
+  /** @deprecated Use `context.motion.lookAway()` instead. */
+  lookAway: MotionCapability['lookAway']
+  /** @deprecated Use `context.motion.setPose(...)` instead. */
+  setPose: MotionCapability['setPose']
+  /** @deprecated Use `context.motion.setTorque(...)` instead. */
+  setTorque: MotionCapability['setTorque']
+  /** @deprecated Use `context.audio.tts` instead. */
+  tts: AudioCapability['tts']
+  /** @deprecated Use `context.audio.microphone` instead. */
+  microphone?: AudioCapability['microphone']
+  /** @deprecated Use `context.audio.useTTS(...)` instead. */
+  useTTS: AudioCapability['useTTS']
+  /** @deprecated Use `context.audio.say(...)` instead. */
+  say: AudioCapability['say']
+  /** @deprecated Use `context.audio.record(...)` instead. */
+  record: AudioCapability['record']
+  /** @deprecated Use `context.audio.tone(...)` instead. */
+  tone: AudioCapability['tone']
+  /** @deprecated Use `context.audio.playAudio(...)` instead. */
+  playAudio: AudioCapability['playAudio']
+  /** @deprecated Use `context.input.button` instead. */
+  button?: InputCapability['button']
+  /** @deprecated Use `context.input.touch` instead. */
+  touch?: InputCapability['touch']
+  /** @deprecated Use `context.input.touchPanel` instead. */
+  touchPanel?: InputCapability['touchPanel']
+  /** @deprecated Use `context.input.imu` instead. */
+  imu?: InputCapability['imu']
+  /** @deprecated Use `context.lighting.led` instead. */
+  led: LightingCapability['led']
+  /** @deprecated Use `context.lighting.lightOn(...)` instead. */
+  lightOn: LightingCapability['lightOn']
+  /** @deprecated Use `context.lighting.lightOff(...)` instead. */
+  lightOff: LightingCapability['lightOff']
+  /** @deprecated Use `context.lighting.lightBlink(...)` instead. */
+  lightBlink: LightingCapability['lightBlink']
+  /** @deprecated Use `context.lighting.lightRainbow(...)` instead. */
+  lightRainbow: LightingCapability['lightRainbow']
+  /** @deprecated Use `context.camera` instead. */
+  camera: CameraCapability['camera']
+  /** @deprecated Use `context.connectivity.network` instead. */
+  network?: ConnectivityCapability['network']
+  /** @deprecated Use `context.ui.ui` instead. */
+  ui: UICapability['ui']
+  /** @deprecated Use `context.ui.drawer` instead. */
+  drawer: UICapability['drawer']
+  /** @deprecated Use `context.ui.showBalloon(...)` instead. */
+  showBalloon: UICapability['showBalloon']
+  /** @deprecated Use `context.ui.hideBalloon()` instead. */
+  hideBalloon: UICapability['hideBalloon']
+}
 
 export type StackchanContext = StackchanCapabilityNamespaces & StackchanLegacyFlatCapability

--- a/firmware/host/app/runtime-context.ts
+++ b/firmware/host/app/runtime-context.ts
@@ -318,6 +318,9 @@ export class StackchanRuntimeContext implements StackchanContext {
     this.#uiRuntime.setEmotion(emotion)
   }
 
+  /**
+   * @deprecated Use `context.face.setMouthOpen(...)` instead.
+   */
   setMouthOpen(value: number) {
     this.#uiRuntime.setMouthOpen(value)
   }

--- a/firmware/mods/examples/ai_stackchan/mod.js
+++ b/firmware/mods/examples/ai_stackchan/mod.js
@@ -131,9 +131,12 @@ export function onContextCreated(robot, option) {
     await talk()
   }
 
-  robot.input.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      startTalk().catch((error) => trace(`talk failed: ${error}\n`))
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        startTalk().catch((error) => trace(`talk failed: ${error}\n`))
+      }
     }
   }
 }

--- a/firmware/mods/examples/ai_stackchan_api/mod.js
+++ b/firmware/mods/examples/ai_stackchan_api/mod.js
@@ -88,21 +88,26 @@ function onContextCreated(robot, option) {
     context: CONTEXT,
   })
 
-  robot.input.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      robot.ui.showBalloon('TTS test...')
-      robot.audio.say('TTSテスト。TTSテスト').then(
-        () => robot.ui.hideBalloon(),
-        (error) => {
-          trace(`speech failed: ${error}\n`)
-          robot.ui.hideBalloon()
-        },
-      )
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        robot.ui.showBalloon('TTS test...')
+        robot.audio.say('TTSテスト。TTSテスト').then(
+          () => robot.ui.hideBalloon(),
+          (error) => {
+            trace(`speech failed: ${error}\n`)
+            robot.ui.hideBalloon()
+          },
+        )
+      }
     }
   }
-  robot.input.button.b.onEvent = (event) => {
-    if (event.pressed) {
-      chatAndSay(robot, dialogue, 'おはようございます').catch((error) => trace(`chat failed: ${error}\n`))
+  if (buttons?.b) {
+    buttons.b.onEvent = (event) => {
+      if (event.pressed) {
+        chatAndSay(robot, dialogue, 'おはようございます').catch((error) => trace(`chat failed: ${error}\n`))
+      }
     }
   }
 

--- a/firmware/mods/examples/beacon_advertiser/mod.js
+++ b/firmware/mods/examples/beacon_advertiser/mod.js
@@ -49,16 +49,21 @@ export function onContextCreated(robot) {
     sendCommand(command)
   }
 
-  robot.input.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      const hello = hellos[Math.floor(randomBetween(0, hellos.length))]
-      sayAndSend(hello, 1).catch((error) => trace(`hello failed: ${error}\n`))
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        const hello = hellos[Math.floor(randomBetween(0, hellos.length))]
+        sayAndSend(hello, 1).catch((error) => trace(`hello failed: ${error}\n`))
+      }
     }
   }
-  robot.input.button.b.onEvent = (event) => {
-    if (event.pressed) {
-      const bye = byes[Math.floor(randomBetween(0, byes.length))]
-      sayAndSend(bye, 2).catch((error) => trace(`bye failed: ${error}\n`))
+  if (buttons?.b) {
+    buttons.b.onEvent = (event) => {
+      if (event.pressed) {
+        const bye = byes[Math.floor(randomBetween(0, byes.length))]
+        sayAndSend(bye, 2).catch((error) => trace(`bye failed: ${error}\n`))
+      }
     }
   }
 }

--- a/firmware/mods/examples/chat_audioio/mod.js
+++ b/firmware/mods/examples/chat_audioio/mod.js
@@ -312,7 +312,7 @@ export function onContextCreated(robot) {
   const flushMouthOpen = () => {
     if (pendingMouthStep === lastMouthStep) return
     lastMouthStep = pendingMouthStep
-    robot.setMouthOpen(lastMouthStep * MOUTH_QUANTIZE_STEP)
+    robot.face.setMouthOpen(lastMouthStep * MOUTH_QUANTIZE_STEP)
   }
 
   const queueMouthStep = (step, immediate = false) => {

--- a/firmware/mods/examples/chatgpt/mod.js
+++ b/firmware/mods/examples/chatgpt/mod.js
@@ -71,25 +71,32 @@ export function onContextCreated(robot, option) {
 
   // Event handler
   let isFollowing = false
-  robot.input.button.a.onEvent = function handleButtonAEvent(event) {
-    if (event.pressed) {
-      trace('pressed A\n')
-      trace('Look around\n')
-      isFollowing = !isFollowing
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = function handleButtonAEvent(event) {
+      if (event.pressed) {
+        trace('pressed A\n')
+        trace('Look around\n')
+        isFollowing = !isFollowing
+      }
     }
   }
-  robot.input.button.b.onEvent = function handleButtonBEvent(event) {
-    if (event.pressed) {
-      trace('pressed B\n')
-      trace('Chat test\n')
-      chatAndSay('おはようございます').catch((error) => trace(`chat failed: ${error}\n`))
+  if (buttons?.b) {
+    buttons.b.onEvent = function handleButtonBEvent(event) {
+      if (event.pressed) {
+        trace('pressed B\n')
+        trace('Chat test\n')
+        chatAndSay('おはようございます').catch((error) => trace(`chat failed: ${error}\n`))
+      }
     }
   }
-  robot.input.button.c.onEvent = function handleButtonCEvent(event) {
-    if (event.pressed) {
-      trace('pressed C\n')
-      trace('TTS test\n')
-      sayGreeting().catch((error) => trace(`greeting failed: ${error}\n`))
+  if (buttons?.c) {
+    buttons.c.onEvent = function handleButtonCEvent(event) {
+      if (event.pressed) {
+        trace('pressed C\n')
+        trace('TTS test\n')
+        sayGreeting().catch((error) => trace(`greeting failed: ${error}\n`))
+      }
     }
   }
 

--- a/firmware/mods/examples/dynamixel/mod.js
+++ b/firmware/mods/examples/dynamixel/mod.js
@@ -9,17 +9,20 @@ import Timer from 'timer'
 export function onContextCreated(context) {
   let count = 0
   const driver = context.driver
-  context.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      return
+  const buttons = context.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        return
+      }
+      const ori = {
+        y: count * 0.1 - 1.0,
+        p: 0,
+        r: 0,
+      }
+      driver.applyRotation(ori)
+      count = (count + 1) % 20
     }
-    const ori = {
-      y: count * 0.1 - 1.0,
-      p: 0,
-      r: 0,
-    }
-    driver.applyRotation(ori)
-    count = (count + 1) % 20
   }
 }
 

--- a/firmware/mods/examples/light/mod.js
+++ b/firmware/mods/examples/light/mod.js
@@ -9,23 +9,30 @@ export function onContextCreated(robot) {
     { r: 0, g: 255, b: 0 },
     { r: 0, g: 0, b: 255 },
   ]
-  robot.input.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      const firstColor = colors.shift()
-      colors.push(firstColor)
-      robot.lighting.lightOn('a', firstColor.r, firstColor.g, firstColor.b)
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        const firstColor = colors.shift()
+        colors.push(firstColor)
+        robot.lighting.lightOn('a', firstColor.r, firstColor.g, firstColor.b)
+      }
     }
   }
 
-  robot.input.button.b.onEvent = (event) => {
-    if (event.pressed) {
-      robot.lighting.lightOff('a')
+  if (buttons?.b) {
+    buttons.b.onEvent = (event) => {
+      if (event.pressed) {
+        robot.lighting.lightOff('a')
+      }
     }
   }
 
-  robot.input.button.c.onEvent = (event) => {
-    if (event.pressed) {
-      robot.lighting.lightRainbow('a')
+  if (buttons?.c) {
+    buttons.c.onEvent = (event) => {
+      if (event.pressed) {
+        robot.lighting.lightRainbow('a')
+      }
     }
   }
 }

--- a/firmware/mods/examples/lip_sync/mod.js
+++ b/firmware/mods/examples/lip_sync/mod.js
@@ -13,7 +13,7 @@ export function onContextCreated(robot) {
     this.read(samples.buffer)
 
     const power = calculatePower(samples.buffer)
-    robot.setMouthOpen(Math.min(power / threshold, 1.0))
+    robot.face.setMouthOpen(Math.min(power / threshold, 1.0))
   }
 
   microphone.start()

--- a/firmware/mods/examples/look_around/mod.js
+++ b/firmware/mods/examples/look_around/mod.js
@@ -3,20 +3,27 @@ import Timer from 'timer'
 
 export function onContextCreated(robot) {
   let isFollowing = false
-  robot.input.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      trace('pressed A\n')
-      isFollowing = !isFollowing
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        trace('pressed A\n')
+        isFollowing = !isFollowing
+      }
     }
   }
-  robot.input.button.b.onEvent = (event) => {
-    if (event.pressed) {
-      trace('pressed B\n')
+  if (buttons?.b) {
+    buttons.b.onEvent = (event) => {
+      if (event.pressed) {
+        trace('pressed B\n')
+      }
     }
   }
-  robot.input.button.c.onEvent = (event) => {
-    if (event.pressed) {
-      trace('pressed C\n')
+  if (buttons?.c) {
+    buttons.c.onEvent = (event) => {
+      if (event.pressed) {
+        trace('pressed C\n')
+      }
     }
   }
   const targetLoop = () => {

--- a/firmware/mods/examples/monologue/mod.js
+++ b/firmware/mods/examples/monologue/mod.js
@@ -11,9 +11,12 @@ async function sayMonologue(robot) {
 }
 
 function onContextCreated(robot) {
-  robot.input.button.a.onEvent = (event) => {
-    if (event.pressed) {
-      sayMonologue(robot)
+  const buttons = robot.input.button
+  if (buttons?.a) {
+    buttons.a.onEvent = (event) => {
+      if (event.pressed) {
+        sayMonologue(robot)
+      }
     }
   }
 }


### PR DESCRIPTION
## 概要
公式 example MOD を namespaced API へ移行し、optional button capability を安全に扱うようにします。

## 変更内容
- lip_sync / chat_audioio の robot.setMouthOpen を robot.face.setMouthOpen へ移行
- look_around / light / ai_stackchan / ai_stackchan_api / chatgpt / beacon_advertiser / monologue / dynamixel の button 参照を存在確認付きに変更
- setup_rs30x / calibration は #507 対応のため意図的に除外
- flat compat member に @deprecated JSDoc を追加
- architecture check に flat setMouthOpen と未ガード button 直参照の検出を追加

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass, 31 tests
- cd firmware && npm run check:architecture: pass, 13 tests
- cd firmware && npm run check:legacy-names: pass
- git diff --check: pass

## 未実施
- 実機での MOD 動作確認
- test:moddable / build

## リリース影響
patch。公式サンプルの API 移行と安全性改善です。リリースノート記載推奨です。

Closes #515
関連 #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
