### PR TITLE
fix(ui): correct LISTENING/SPEAKING state mapping

### DIFF
--- a/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
+++ b/firmware/host/modules/ui/components/status-bar/__tests__/chat-status-bar/chat-status-bar.test.ts
@@ -50,18 +50,18 @@ behavior.onChatState?.(bar, ChatStatusBarState.CONNECTING)
 assert(statusIndicator.visible === true, 'connecting indicator should be visible')
 assert(statusIcon.visible === false, 'status icon should be hidden while connecting')
 
-behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
-assert(levelTrack.visible === true, 'level track should be visible in SPEAKING')
-assert(statusIcon.visible === true, 'status icon should be visible in SPEAKING')
-equal(statusIcon.state, 0, 'SPEAKING should use microphone input icon state')
+behavior.onChatState?.(bar, ChatStatusBarState.LISTENING)
+assert(levelTrack.visible === true, 'level track should be visible in LISTENING')
+assert(statusIcon.visible === true, 'status icon should be visible in LISTENING')
+equal(statusIcon.state, 0, 'LISTENING should use microphone input icon state')
 
 behavior.onChatInputLevel?.(bar, 1000)
 equal(levelFill.height, 8, 'half input level should fill half the track')
 
-behavior.onChatState?.(bar, ChatStatusBarState.LISTENING)
-assert(levelTrack.visible === false, 'level track should be hidden in LISTENING')
-assert(statusIcon.visible === true, 'status icon should be visible in LISTENING')
-equal(statusIcon.state, 1, 'LISTENING should use output icon state')
+behavior.onChatState?.(bar, ChatStatusBarState.SPEAKING)
+assert(levelTrack.visible === false, 'level track should be hidden in SPEAKING')
+assert(statusIcon.visible === true, 'status icon should be visible in SPEAKING')
+equal(statusIcon.state, 1, 'SPEAKING should use output icon state')
 
 const normalFillSkin = levelFill.skin
 behavior.onChatState?.(bar, ChatStatusBarState.FAILED, 'boom')

--- a/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
+++ b/firmware/host/modules/ui/components/status-bar/chat-status-bar.ts
@@ -103,8 +103,8 @@ class ChatStatusBarBehavior extends Behavior {
 
   updateUI() {
     if (!this.#levelTrack || !this.#levelFill || !this.#statusIcon || !this.#indicator) return
-    const isListening = this.#state === ChatStatusBarState.SPEAKING
-    const isSpeaking = this.#state === ChatStatusBarState.LISTENING
+    const isListening = this.#state === ChatStatusBarState.LISTENING
+    const isSpeaking = this.#state === ChatStatusBarState.SPEAKING
     const isConnecting = this.#state === ChatStatusBarState.CONNECTING
     this.#levelTrack.visible = isListening
     this.#statusIcon.visible = isListening || isSpeaking


### PR DESCRIPTION
## 概要
chat status bar の LISTENING / SPEAKING 表示マッピングを修正します。

## 変更内容
- LISTENING 中は level meter を表示し、icon state を listening 側に設定
- SPEAKING 中は level meter を非表示にし、icon state を speaking 側に設定
- chat-status-bar test を期待値に合わせて更新

## 検証
- cd firmware && npm run lint: pass
- cd firmware && npm run test:unit: pass
- cd firmware && npm run check:architecture: pass
- GitHub Checks: deploy skip 以外 pass（旧 PR #517 時点）

## 未実施
- 実機での表示確認

## リリース影響
patch。UI 状態表示の不具合修正です。

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected chat status bar behavior so the UI now matches the active chat state.
  * When listening, the level indicator and microphone-style icon are shown as expected.
  * When speaking, the level indicator is hidden and the output-style icon is shown.
  * Updated the related test coverage to reflect the corrected state transition sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->