### PR TITLE
feat(web): unify web tool UI

### DIFF
--- a/web/editor/editor.css
+++ b/web/editor/editor.css
@@ -1,147 +1,165 @@
-:root {
-  color-scheme: light;
-  --bg: #f4f1ea;
-  --card: #ffffff;
-  --ink: #2b2620;
-  --accent: #e2792f;
-  --accent-ink: #ffffff;
-  --line: #d8d0c2;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 body {
-  margin: 0;
-  font-family: 'Hiragino Sans', 'Noto Sans JP', system-ui, sans-serif;
-  background: var(--bg);
-  color: var(--ink);
+  overflow: hidden;
 }
-
 .editor-shell {
+  display: grid;
+  grid-template-rows: var(--header-height) minmax(0, 1fr);
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+}
+.workspace-actions {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  height: 100vh;
+  gap: 5px;
+  margin-left: auto;
 }
-
-.editor-header h1 {
-  margin: 0 0 4px;
-  font-size: 1.4rem;
+.workspace-actions + .tool-nav {
+  margin-left: 0;
+  padding-left: 8px;
+  border-left: 1px solid var(--line);
 }
-
-.editor-header p {
-  margin: 0;
-  font-size: 0.9rem;
-}
-
 .editor-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 360px;
-  gap: 12px;
-  flex: 1;
+  grid-template-columns: minmax(0, 1fr) 340px;
   min-height: 0;
-}
-
-.workspace-card {
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 12px;
   overflow: hidden;
+}
+.workspace {
+  min-width: 0;
   min-height: 480px;
+  overflow: hidden;
+  background: #e7ebed;
 }
-
-.side-panel {
+.editor-inspector {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  overflow-y: auto;
+  min-width: 0;
   min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border-left: 1px solid var(--line);
+  background: var(--surface);
 }
-
-.panel-card {
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 12px;
+.build-section {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-bottom: 1px solid var(--line);
 }
-
-.panel-card h2 {
-  margin: 0 0 8px;
-  font-size: 1rem;
-}
-
-.button-row {
+.section-heading {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-bottom: 8px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
-
-button {
-  font: inherit;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--line);
-  background: #faf7f0;
-  cursor: pointer;
+.section-heading h1 {
+  margin: 0;
+  color: #c5ccd2;
+  font-size: 0.82rem;
+  letter-spacing: 0;
 }
-
-button.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--accent-ink);
+.section-heading .status-line {
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-
-button:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.baud-row {
-  display: block;
-  font-size: 0.85rem;
-  margin-bottom: 8px;
-}
-
-.status {
-  margin: 4px 0;
-  font-size: 0.9rem;
-}
-
-.hint {
-  margin: 4px 0 0;
-  font-size: 0.8rem;
-  color: #6d6558;
-}
-
-progress {
+.build-section > button {
   width: 100%;
 }
-
+.install-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+.install-grid button {
+  min-width: 0;
+  padding: 8px;
+  font-size: 0.78rem;
+}
+.install-grid button:last-child {
+  grid-column: 1 / -1;
+}
+progress {
+  width: 100%;
+  height: 8px;
+  accent-color: var(--accent);
+}
+.output-section {
+  display: grid;
+  grid-template-rows: 42px minmax(0, 1fr);
+  min-height: 180px;
+  flex: 1;
+}
+.output-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--line);
+}
+.output-tab {
+  min-height: 42px;
+  flex: 1;
+  padding: 8px;
+  border: 0;
+  border-right: 1px solid var(--line);
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+.output-tab[aria-selected='true'] {
+  box-shadow: inset 0 -2px var(--accent);
+  color: var(--text);
+}
+.output-panel {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
 #code-preview,
 #log-output {
+  width: 100%;
+  height: 100%;
   margin: 0;
-  padding: 8px;
-  background: #221d18;
-  color: #e8e2d6;
-  border-radius: 8px;
-  font-size: 0.75rem;
-  line-height: 1.5;
+  padding: 12px;
   overflow: auto;
-  max-height: 240px;
+  background: #101214;
+  color: #cbd2d8;
+  font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', monospace;
+  font-size: 0.72rem;
+  line-height: 1.5;
   white-space: pre-wrap;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
-
-@media (max-width: 960px) {
+@media (max-width: 760px) {
+  body {
+    overflow: auto;
+  }
+  .editor-shell {
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
+  }
   .editor-layout {
     grid-template-columns: 1fr;
+    grid-template-rows: minmax(480px, 64vh) 460px;
+    overflow: visible;
   }
-
-  .workspace-card {
-    min-height: 60vh;
+  .editor-inspector {
+    overflow: hidden;
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+  .workspace-actions + .tool-nav {
+    padding-left: 3px;
+    border-left: 0;
+  }
+  .workspace-actions .icon-button {
+    width: 36px;
+    min-width: 36px;
+    min-height: 36px;
+  }
+}
+@media (max-width: 430px) {
+  .brand-link span {
+    display: none;
   }
 }

--- a/web/editor/editor.mjs
+++ b/web/editor/editor.mjs
@@ -22,6 +22,17 @@ const installProgress = document.getElementById('install-progress')
 const sampleButton = document.getElementById('sample-button')
 const clearButton = document.getElementById('clear-button')
 const logOutput = document.getElementById('log-output')
+const outputTabs = [...document.querySelectorAll('[role="tab"]')]
+
+for (const tab of outputTabs) {
+  tab.addEventListener('click', () => {
+    for (const candidate of outputTabs) {
+      const selected = candidate === tab
+      candidate.setAttribute('aria-selected', String(selected))
+      document.getElementById(candidate.getAttribute('aria-controls')).hidden = !selected
+    }
+  })
+}
 
 const logLines = []
 function log(text) {

--- a/web/editor/editor.mjs
+++ b/web/editor/editor.mjs
@@ -22,17 +22,34 @@ const installProgress = document.getElementById('install-progress')
 const sampleButton = document.getElementById('sample-button')
 const clearButton = document.getElementById('clear-button')
 const logOutput = document.getElementById('log-output')
-const outputTabs = [...document.querySelectorAll('[role="tab"]')]
+const outputTabs = [...document.querySelectorAll('.output-tabs [role="tab"]')]
+
+function selectOutputTab(tab) {
+  for (const candidate of outputTabs) {
+    const selected = candidate === tab
+    candidate.setAttribute('aria-selected', String(selected))
+    candidate.tabIndex = selected ? 0 : -1
+    const panel = document.getElementById(candidate.getAttribute('aria-controls'))
+    if (panel != null) panel.hidden = !selected
+  }
+}
 
 for (const tab of outputTabs) {
-  tab.addEventListener('click', () => {
-    for (const candidate of outputTabs) {
-      const selected = candidate === tab
-      candidate.setAttribute('aria-selected', String(selected))
-      document.getElementById(candidate.getAttribute('aria-controls')).hidden = !selected
-    }
+  tab.addEventListener('click', () => selectOutputTab(tab))
+  tab.addEventListener('keydown', (event) => {
+    const index = outputTabs.indexOf(tab)
+    let nextIndex
+    if (event.key === 'ArrowRight') nextIndex = (index + 1) % outputTabs.length
+    else if (event.key === 'ArrowLeft') nextIndex = (index - 1 + outputTabs.length) % outputTabs.length
+    else if (event.key === 'Home') nextIndex = 0
+    else if (event.key === 'End') nextIndex = outputTabs.length - 1
+    else return
+    event.preventDefault()
+    outputTabs[nextIndex].focus()
+    selectOutputTab(outputTabs[nextIndex])
   })
 }
+selectOutputTab(outputTabs.find((tab) => tab.getAttribute('aria-selected') === 'true') ?? outputTabs[0])
 
 const logLines = []
 function log(text) {

--- a/web/editor/index.html
+++ b/web/editor/index.html
@@ -8,11 +8,31 @@
     <title>ブロックエディタ | ｽﾀｯｸﾁｬﾝ</title>
     <link rel="stylesheet" href="../global.css" />
     <link rel="stylesheet" href="./editor.css" />
-    <script src="https://unpkg.com/blockly@11.2.2/blockly_compressed.js"></script>
-    <script src="https://unpkg.com/blockly@11.2.2/blocks_compressed.js"></script>
-    <script src="https://unpkg.com/blockly@11.2.2/javascript_compressed.js"></script>
-    <script src="https://unpkg.com/blockly@11.2.2/msg/ja.js"></script>
-    <script src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"></script>
+    <script
+      src="https://unpkg.com/blockly@11.2.2/blockly_compressed.js"
+      integrity="sha384-nXdS/O1XBg7d1iom7upZrVOtjvQfnVGDx67ecaCgU823024LIITNe/9Vf3o9ouRl"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://unpkg.com/blockly@11.2.2/blocks_compressed.js"
+      integrity="sha384-HrJy1eOfAncgHWDhGobRG4+LW7lqYE6yk+XU5mArpfriaJP69d+R+sdziP7jswuL"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://unpkg.com/blockly@11.2.2/javascript_compressed.js"
+      integrity="sha384-De44udSvZv11/XTEpKugzXvo25LZZR95qk6vZAXaPLMDt3QWmp6ZAZX4tmQvyZG3"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://unpkg.com/blockly@11.2.2/msg/ja.js"
+      integrity="sha384-vwDwBIqpZ3trnzftlXPz5I2KLW59rnUE3qmcgJ/PRqFMMtz0GRpLJcwHfc0X7s2r"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"
+      integrity="sha384-mooE85Luwgx+AyykX7e90VcN8/QCFTSIwPuHLmvcsLVoA0en7lKYb9XlOzn5G2co"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <main class="editor-shell">
@@ -44,10 +64,12 @@
         </div>
         <nav class="tool-nav" aria-label="ツール">
           <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
-          ><a href="../flash/" title="書き込み"><i data-lucide="cpu"></i></a
-          ><a href="../preference/" title="設定"><i data-lucide="sliders-horizontal"></i></a
-          ><a href="../simulator/" title="シミュレーター"><i data-lucide="box"></i></a
-          ><a href="../editor/" aria-current="page" title="エディタ"><i data-lucide="blocks"></i></a>
+          ><a href="../flash/" title="書き込み" aria-label="書き込み"><i data-lucide="cpu"></i></a
+          ><a href="../preference/" title="設定" aria-label="設定"><i data-lucide="sliders-horizontal"></i></a
+          ><a href="../simulator/" title="シミュレーター" aria-label="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" aria-current="page" title="エディタ" aria-label="エディタ"
+            ><i data-lucide="blocks"></i
+          ></a>
         </nav>
       </header>
       <div class="editor-layout">

--- a/web/editor/index.html
+++ b/web/editor/index.html
@@ -4,67 +4,112 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png" />
-    <title>ｽﾀｯｸﾁｬﾝ ブロックエディタ</title>
+    <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png" />
+    <title>ブロックエディタ | ｽﾀｯｸﾁｬﾝ</title>
+    <link rel="stylesheet" href="../global.css" />
     <link rel="stylesheet" href="./editor.css" />
     <script src="https://unpkg.com/blockly@11.2.2/blockly_compressed.js"></script>
     <script src="https://unpkg.com/blockly@11.2.2/blocks_compressed.js"></script>
     <script src="https://unpkg.com/blockly@11.2.2/javascript_compressed.js"></script>
     <script src="https://unpkg.com/blockly@11.2.2/msg/ja.js"></script>
+    <script src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"></script>
   </head>
   <body>
     <main class="editor-shell">
-      <header class="editor-header">
-        <h1>ｽﾀｯｸﾁｬﾝ ブロックエディタ</h1>
-        <p>
-          ブロックでMODを組み立てて、ブラウザ内のmcrun(WebAssembly)でビルドし、
-          <a href="../simulator/" target="_blank" rel="noopener">Webシミュレーター</a
-          >やWebSerial経由の実機にインストールできます。
-        </p>
+      <header class="topbar">
+        <a class="brand-link" href="../"
+          ><img src="../assets/stackchan-symbol.png" alt="" /><span
+            >ｽﾀｯｸﾁｬﾝ<span class="surface-name"> ブロックエディタ</span></span
+          ></a
+        >
+        <div class="workspace-actions" aria-label="ワークスペース操作">
+          <button
+            id="sample-button"
+            class="icon-button"
+            type="button"
+            title="サンプルを読み込む"
+            aria-label="サンプルを読み込む"
+          >
+            <i data-lucide="file-input"></i>
+          </button>
+          <button
+            id="clear-button"
+            class="icon-button danger-button"
+            type="button"
+            title="ワークスペースを消去"
+            aria-label="ワークスペースを消去"
+          >
+            <i data-lucide="trash-2"></i>
+          </button>
+        </div>
+        <nav class="tool-nav" aria-label="ツール">
+          <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
+          ><a href="../flash/" title="書き込み"><i data-lucide="cpu"></i></a
+          ><a href="../preference/" title="設定"><i data-lucide="sliders-horizontal"></i></a
+          ><a href="../simulator/" title="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" aria-current="page" title="エディタ"><i data-lucide="blocks"></i></a>
+        </nav>
       </header>
-
-      <section class="editor-layout">
-        <div id="blockly-workspace" class="workspace-card" aria-label="Blockly workspace"></div>
-
-        <aside class="side-panel">
-          <div class="panel-card">
-            <h2>ビルド</h2>
-            <div class="button-row">
-              <button id="build-button" type="button" class="primary">ビルド (mc.xsa)</button>
-              <button id="download-button" type="button" disabled>.xsaをダウンロード</button>
+      <div class="editor-layout">
+        <section id="blockly-workspace" class="workspace" aria-label="Blocklyワークスペース"></section>
+        <aside class="editor-inspector" aria-label="ビルドとインストール">
+          <section class="build-section">
+            <div class="section-heading">
+              <h1>MOD</h1>
+              <p id="build-status" class="status-line" role="status">未ビルド</p>
             </div>
-            <div class="button-row">
-              <button id="install-simulator-button" type="button" disabled>シミュレータにインストール</button>
-              <button id="install-device-button" type="button" disabled>実機に書き込み (WebSerial)</button>
+            <button id="build-button" type="button" class="primary-button">
+              <i data-lucide="hammer"></i><span>ビルド</span>
+            </button>
+            <div class="install-grid">
+              <button id="download-button" type="button" disabled title="XSAをダウンロード">
+                <i data-lucide="download"></i><span>ダウンロード</span>
+              </button>
+              <button id="install-simulator-button" type="button" disabled>
+                <i data-lucide="box"></i><span>シミュレーターへ</span>
+              </button>
+              <button id="install-device-button" type="button" disabled>
+                <i data-lucide="usb"></i><span>実機へ書き込み</span>
+              </button>
             </div>
-            <p class="hint">
-              実機書き込みは esptool-js でブートローダ経由。MODを xs パーティションに書き、再起動後に動きます。
-            </p>
-            <p id="build-status" class="status">未ビルド</p>
-            <progress id="install-progress" max="1" value="0" hidden></progress>
-          </div>
-
-          <div class="panel-card">
-            <h2>生成コード (mod.js)</h2>
-            <pre id="code-preview" aria-label="generated mod.js"></pre>
-          </div>
-
-          <div class="panel-card">
-            <h2>ワークスペース</h2>
-            <div class="button-row">
-              <button id="sample-button" type="button">サンプルを読み込む</button>
-              <button id="clear-button" type="button">全部消す</button>
+            <progress id="install-progress" max="1" value="0" hidden aria-label="書き込み進行状況"></progress>
+          </section>
+          <section class="output-section">
+            <div class="output-tabs" role="tablist" aria-label="出力表示">
+              <button
+                id="code-tab"
+                class="output-tab"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                aria-controls="code-panel"
+              >
+                生成コード
+              </button>
+              <button
+                id="log-tab"
+                class="output-tab"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="log-panel"
+              >
+                ログ
+              </button>
             </div>
-            <p class="hint">ワークスペースは自動的にブラウザへ保存されます。</p>
-          </div>
-
-          <div class="panel-card">
-            <h2>ログ</h2>
-            <pre id="log-output" aria-label="build and install log"></pre>
-          </div>
+            <div id="code-panel" class="output-panel" role="tabpanel" aria-labelledby="code-tab">
+              <pre id="code-preview" aria-label="生成されたmod.js"></pre>
+            </div>
+            <div id="log-panel" class="output-panel" role="tabpanel" aria-labelledby="log-tab" hidden>
+              <pre id="log-output" aria-label="ビルドとインストールのログ"></pre>
+            </div>
+          </section>
         </aside>
-      </section>
+      </div>
     </main>
-
     <script type="module" src="./editor.mjs"></script>
+    <script>
+      globalThis.lucide?.createIcons()
+    </script>
   </body>
 </html>

--- a/web/flash/flash.css
+++ b/web/flash/flash.css
@@ -1,17 +1,38 @@
-.app {
-  font-size: 1.8em;
-  justify-content:center;
-  max-width: 300px;
-  gap: .5em;
-  margin: auto;
+.flash-workspace {
+  display: grid;
+  min-height: calc(100dvh - var(--header-height));
+  place-items: center;
+  padding: 24px;
 }
-.select-target {
-  max-height: 2.5em;
-  width: 100%;
+.flash-panel {
+  width: min(100%, 460px);
 }
-.button-flash-container {
+.field {
+  display: grid;
+  gap: 7px;
+  margin-bottom: 14px;
+}
+.field label {
+  color: #cbd2d8;
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+.button-flash-container,
+.button-flash {
   width: 100%;
 }
 .button-flash {
-  width: 100%;
+  min-height: 48px;
+}
+.compatibility-message {
+  margin: 12px 0 0;
+  color: var(--danger);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+@media (max-width: 600px) {
+  .flash-workspace {
+    place-items: start center;
+    padding: 28px 14px;
+  }
 }

--- a/web/flash/index.html
+++ b/web/flash/index.html
@@ -1,45 +1,68 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png">
-  <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png">
-  <title>Flash firmware</title>
-  <link rel="stylesheet" href="../global.css">
-  <link rel="stylesheet" href="flash.css">
-  <script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const button = document.querySelector('esp-web-install-button')
-      const select = document.querySelector('.select-target')
-      select.addEventListener('change', (event) => {
-        const target = event.target.value
-        button.setAttribute("manifest", `manifest_${target}.json`)
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png" />
+    <link rel="stylesheet" href="../global.css" />
+    <link rel="stylesheet" href="flash.css" />
+    <title>ファームウェア書き込み | ｽﾀｯｸﾁｬﾝ</title>
+    <script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>
+    <script src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const button = document.querySelector('esp-web-install-button')
+        document.querySelector('.select-target').addEventListener('change', (event) => {
+          button.setAttribute('manifest', `manifest_${event.target.value}.json`)
+        })
+        globalThis.lucide?.createIcons()
       })
-    })
-  </script>
-</head>
-
-<body>
-  <div class="app">
-    <select class="select-target">
-      <option value="esp32_m5stack">M5Stack</option>
-      <option value="esp32_m5stack_core2">M5Stack Core2</option>
-      <option value="esp32_m5stack_fire">M5Stack Fire</option>
-      <option value="esp32_m5stack_cores3">M5Stack CoreS3</option>
-    </select>
-    <esp-web-install-button manifest="manifest_esp32_m5stack.json" class="button-flash-container">
-      <button slot="activate" class="button-flash">
-        Flash Stack-chan firmware [・＿・]
-      </button>
-      <span slot="unsupported">Ah snap, your browser doesn't work!</span>
-      <span slot="not-allowed">Ah snap, you are not allowed to use this on HTTP!</span>
-    </esp-web-install-button>
-  </div>
-
-</body>
-
+    </script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="topbar">
+        <a class="brand-link" href="../"
+          ><img src="../assets/stackchan-symbol.png" alt="" /><span
+            >ｽﾀｯｸﾁｬﾝ<span class="surface-name"> ファームウェア書き込み</span></span
+          ></a
+        >
+        <nav class="tool-nav" aria-label="ツール">
+          <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
+          ><a href="../flash/" aria-current="page" title="書き込み"
+            ><i data-lucide="cpu"></i><span class="nav-label">書き込み</span></a
+          ><a href="../preference/" title="設定"><i data-lucide="sliders-horizontal"></i></a
+          ><a href="../simulator/" title="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" title="エディタ"><i data-lucide="blocks"></i></a>
+        </nav>
+      </header>
+      <div class="flash-workspace">
+        <section class="flash-panel" aria-labelledby="flash-heading">
+          <div class="page-heading">
+            <h1 id="flash-heading">ファームウェア書き込み</h1>
+            <p>USBで接続するｽﾀｯｸﾁｬﾝのボードを選択してください。</p>
+          </div>
+          <div class="field">
+            <label for="target-board">ボード</label
+            ><select id="target-board" class="select-target">
+              <option value="esp32_m5stack">M5Stack</option>
+              <option value="esp32_m5stack_core2">M5Stack Core2</option>
+              <option value="esp32_m5stack_fire">M5Stack Fire</option>
+              <option value="esp32_m5stack_cores3">M5Stack CoreS3</option>
+            </select>
+          </div>
+          <esp-web-install-button manifest="manifest_esp32_m5stack.json" class="button-flash-container">
+            <button slot="activate" class="button-flash primary-button">
+              <i data-lucide="usb"></i><span>USBに接続して書き込む</span>
+            </button>
+            <p class="compatibility-message" slot="unsupported" role="alert">
+              このブラウザはWeb Serialに対応していません。
+            </p>
+            <p class="compatibility-message" slot="not-allowed" role="alert">書き込みにはHTTPS接続が必要です。</p>
+          </esp-web-install-button>
+        </section>
+      </div>
+    </main>
+  </body>
 </html>

--- a/web/flash/index.html
+++ b/web/flash/index.html
@@ -30,11 +30,11 @@
         >
         <nav class="tool-nav" aria-label="ツール">
           <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
-          ><a href="../flash/" aria-current="page" title="書き込み"
+          ><a href="../flash/" aria-current="page" title="書き込み" aria-label="書き込み"
             ><i data-lucide="cpu"></i><span class="nav-label">書き込み</span></a
-          ><a href="../preference/" title="設定"><i data-lucide="sliders-horizontal"></i></a
-          ><a href="../simulator/" title="シミュレーター"><i data-lucide="box"></i></a
-          ><a href="../editor/" title="エディタ"><i data-lucide="blocks"></i></a>
+          ><a href="../preference/" title="設定" aria-label="設定"><i data-lucide="sliders-horizontal"></i></a
+          ><a href="../simulator/" title="シミュレーター" aria-label="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" title="エディタ" aria-label="エディタ"><i data-lucide="blocks"></i></a>
         </nav>
       </header>
       <div class="flash-workspace">

--- a/web/global.css
+++ b/web/global.css
@@ -14,6 +14,7 @@
   --surface-hover: #2b3237;
   --line: #343a3f;
   --line-strong: #4b555c;
+  --line-hover: #697780;
   --text: #f4f6f7;
   --muted: #aeb7be;
   --accent: #42bde8;
@@ -79,7 +80,7 @@ button,
 button:hover,
 .button:hover,
 .icon-button:hover {
-  border-color: #697780;
+  border-color: var(--line-hover);
   background: var(--surface-hover);
 }
 
@@ -109,6 +110,11 @@ button:disabled,
 .primary-button:hover {
   border-color: var(--accent);
   background: var(--accent);
+}
+
+.danger-button {
+  border-color: var(--line-strong);
+  color: var(--danger);
 }
 
 .danger-button:hover {

--- a/web/global.css
+++ b/web/global.css
@@ -1,124 +1,335 @@
-html,body {
-  height: 100%;
+:root {
+  color-scheme: dark;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  --bg: #111315;
+  --surface: #191c1f;
+  --surface-raised: #22272b;
+  --surface-hover: #2b3237;
+  --line: #343a3f;
+  --line-strong: #4b555c;
+  --text: #f4f6f7;
+  --muted: #aeb7be;
+  --accent: #42bde8;
+  --accent-strong: #1599c6;
+  --success: #83d9aa;
+  --warning: #f2c66d;
+  --danger: #ff8e8e;
+  --header-height: 52px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-width: 320px;
+  min-height: 100%;
   margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+a,
+label {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button,
+.button,
+.icon-button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text);
+  font-weight: 650;
+  line-height: 1.2;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+button:hover,
+.button:hover,
+.icon-button:hover {
+  border-color: #697780;
+  background: var(--surface-hover);
+}
+
+button:focus-visible,
+.button:focus-visible,
+.icon-button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+a:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+
+button:disabled,
+.button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.primary-button {
+  border-color: var(--accent-strong);
+  background: var(--accent-strong);
+  color: #061318;
+}
+
+.primary-button:hover {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.danger-button:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.icon-button {
+  width: 42px;
+  min-width: 42px;
   padding: 0;
 }
-body {
-  font-family: 'Roboto', sans-serif;
-  color: #212121;
-  background-color: #f5f5f5;
+
+button svg,
+.button svg,
+.icon-button svg,
+.tool-link svg {
+  width: 19px;
+  height: 19px;
+  flex: 0 0 auto;
+  stroke-width: 2;
 }
 
-.app {
+input,
+select,
+textarea {
   width: 100%;
-  min-height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-around;
+  min-width: 0;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  background: #101214;
+  color: var(--text);
 }
 
-.dev-home {
-  box-sizing: border-box;
-  padding: 2rem;
+input,
+select {
+  min-height: 42px;
+  padding: 8px 10px;
+}
+
+textarea {
+  padding: 10px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  color: #7f898f;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+.app-shell {
+  min-height: 100dvh;
+}
+
+.topbar {
+  display: flex;
+  min-width: 0;
+  height: var(--header-height);
+  align-items: center;
+  gap: 16px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.brand-link {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  color: var(--text);
+  font-weight: 750;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.brand-link img {
+  width: 30px;
+  height: 30px;
+  border-radius: 5px;
+  object-fit: cover;
+}
+
+.surface-name {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.tool-nav {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 3px;
+  margin-left: auto;
+}
+
+.tool-nav a {
+  display: inline-flex;
+  min-width: 40px;
+  min-height: 40px;
+  align-items: center;
   justify-content: center;
-  gap: 1.5rem;
+  gap: 7px;
+  padding: 7px 9px;
+  border-radius: 5px;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-decoration: none;
 }
 
-.app-icon {
-  display: block;
-  width: min(240px, 70vw);
-  height: auto;
-  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.2));
+.tool-nav a:hover,
+.tool-nav a[aria-current='page'] {
+  background: var(--surface-hover);
+  color: var(--text);
 }
 
-.card {
-  position: relative;
-  background-color: white;
-  padding: 1.4em;
-  border-radius: 8px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
-  width: 100%;
-  max-width: 600px;
+.tool-nav svg {
+  width: 18px;
+  height: 18px;
 }
 
-button {
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
+.page-content {
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: 28px 20px 40px;
 }
 
-.card button {
-  box-shadow: none;
+.page-heading {
+  margin-bottom: 24px;
 }
 
-.card h1,h2,h3,h4,h5,h6 {
-  margin: 0.3em 0;
+.page-heading h1 {
+  margin-bottom: 5px;
+  font-size: 1.25rem;
+  letter-spacing: 0;
 }
 
-.form {
-  display: flex;
-  flex-direction: column;
+.page-heading p,
+.muted {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.5;
 }
 
-.form-group {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1em;
+.status-line {
+  min-height: 1.4em;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
-.form-group label {
-  flex: 1;
-  text-align: right;
-  margin-right: 1em;
+.status-line[data-state='success'] {
+  color: var(--success);
+}
+.status-line[data-state='warning'] {
+  color: var(--warning);
+}
+.status-line[data-state='error'] {
+  color: var(--danger);
 }
 
-.form-group input,select,textarea {
-  flex: 2;
-  padding: 0.5em;
+.section-block {
+  padding: 18px 0;
+  border-top: 1px solid var(--line);
 }
 
-.card input,select,textarea {
-  border: 1px solid #bdbdbd;
-  border-radius: 4px;
+.section-block:first-child {
+  padding-top: 0;
+  border-top: 0;
 }
 
-button {
-  background-color: #2196F3;
-  color: white;
-  padding: 0.7em 1em;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
+.section-block h2 {
+  margin-bottom: 14px;
+  color: #cbd2d8;
+  font-size: 0.84rem;
+  letter-spacing: 0;
 }
 
-button:hover {
-  background-color: #1976D2;
-}
-
-.toast {
-  position: absolute;
-  font-size: 1.2em;
-  padding: 0.4em;
-  top: 0;
-  right: 0;
-  max-width: 400px;
-  background-color: #388E3C;
-  color: white;
-  visibility: hidden;
-  transform: translateY(-100px);
-}
-
-.toast.visible {
-  visibility: visible;
-  animation: toast 3s ease 1 normal;
-}
-
-@keyframes toast {
-  33% {
-    transform: translateY(0);
+@media (max-width: 760px) {
+  :root {
+    --header-height: 48px;
   }
-  66% {
-    transform: translateY(0);
+  .topbar {
+    gap: 8px;
+    padding: 0 8px;
+  }
+  .brand-link {
+    gap: 7px;
+    font-size: 0.9rem;
+  }
+  .brand-link img {
+    width: 28px;
+    height: 28px;
+  }
+  .surface-name,
+  .nav-label {
+    display: none;
+  }
+  .tool-nav {
+    gap: 0;
+  }
+  .tool-nav a {
+    min-width: 36px;
+    min-height: 36px;
+    padding: 6px;
+  }
+  .page-content {
+    padding: 22px 14px 32px;
   }
 }

--- a/web/global.css
+++ b/web/global.css
@@ -29,6 +29,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 html,
 body {
   min-width: 320px;

--- a/web/index.html
+++ b/web/index.html
@@ -1,29 +1,154 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="assets/stackchan-favicon-32.png" type="image/png">
-  <link rel="apple-touch-icon" href="assets/stackchan-apple-touch-icon.png">
-  <link rel="stylesheet" href="global.css">
-  <title>Stack-chan dev server</title>
-</head>
-
-<body>
-  <main class="app dev-home">
-    <img class="app-icon" src="assets/stackchan-icon.png" alt="Stack-chan icon" width="240" height="160">
-    <section class="card">
-      <h2>Stack-chan development page</h2>
-      <ul>
-        <li><a href="flash/">Flash</a>: Flash Stack-chan firmware</li>
-        <li><a href="preference/">Preference</a>: Set Stack-chan's preferences via BLE</li>
-        <li><a href="simulator/">Simulator</a>: Run Stack-chan firmware as WebAssembly on a 3D model</li>
-        <li><a href="editor/">Block Editor</a>: Build Stack-chan MODs with Blockly and install them to the simulator or a device</li>
-      </ul>
-    </section>
-  </main>
-</body>
-
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="assets/stackchan-favicon-32.png" type="image/png" />
+    <link rel="apple-touch-icon" href="assets/stackchan-apple-touch-icon.png" />
+    <link rel="stylesheet" href="global.css" />
+    <title>ｽﾀｯｸﾁｬﾝ Webツール</title>
+    <script src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"></script>
+    <style>
+      .launcher {
+        display: grid;
+        min-height: calc(100dvh - var(--header-height));
+        place-items: center;
+        padding: 28px 20px;
+      }
+      .launcher-inner {
+        width: min(100%, 780px);
+      }
+      .brand-panel {
+        display: flex;
+        align-items: center;
+        gap: 22px;
+        margin-bottom: 30px;
+      }
+      .brand-panel img {
+        width: 150px;
+        height: 100px;
+        object-fit: contain;
+        filter: drop-shadow(0 10px 20px rgba(0, 0, 0, 0.32));
+      }
+      .brand-panel h1 {
+        margin: 0 0 6px;
+        font-size: 1.45rem;
+        letter-spacing: 0;
+      }
+      .brand-panel p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.88rem;
+      }
+      .tool-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        border-top: 1px solid var(--line);
+        border-left: 1px solid var(--line);
+      }
+      .tool-link {
+        display: grid;
+        grid-template-columns: 42px minmax(0, 1fr) 20px;
+        align-items: center;
+        gap: 13px;
+        min-height: 92px;
+        padding: 16px;
+        border-right: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+        color: var(--text);
+        text-decoration: none;
+      }
+      .tool-link:hover {
+        background: var(--surface);
+      }
+      .tool-icon {
+        display: grid;
+        width: 42px;
+        height: 42px;
+        place-items: center;
+        border: 1px solid var(--line-strong);
+        border-radius: 6px;
+        background: var(--surface-raised);
+        color: var(--accent);
+      }
+      .tool-link strong {
+        display: block;
+        margin-bottom: 3px;
+        font-size: 0.94rem;
+      }
+      .tool-link small {
+        display: block;
+        color: var(--muted);
+        font-size: 0.76rem;
+        line-height: 1.4;
+      }
+      .arrow {
+        color: #6f7b83;
+      }
+      @media (max-width: 600px) {
+        .launcher {
+          place-items: start center;
+        }
+        .brand-panel {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 10px;
+        }
+        .brand-panel img {
+          width: 120px;
+          height: 80px;
+        }
+        .tool-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="topbar">
+        <a class="brand-link" href="./" aria-current="page"
+          ><img src="assets/stackchan-symbol.png" alt="" /><span
+            >ｽﾀｯｸﾁｬﾝ<span class="surface-name"> Webツール</span></span
+          ></a
+        >
+      </header>
+      <section class="launcher" aria-labelledby="launcher-heading">
+        <div class="launcher-inner">
+          <div class="brand-panel">
+            <img src="assets/stackchan-icon.png" alt="ｽﾀｯｸﾁｬﾝ" width="240" height="160" />
+            <div>
+              <h1 id="launcher-heading">ｽﾀｯｸﾁｬﾝ Webツール</h1>
+              <p>セットアップ、設定、開発をブラウザから行えます。</p>
+            </div>
+          </div>
+          <nav class="tool-grid" aria-label="ツール一覧">
+            <a class="tool-link" href="flash/"
+              ><span class="tool-icon"><i data-lucide="cpu"></i></span
+              ><span><strong>ファームウェア書き込み</strong><small>対応ボードへUSB経由で書き込む</small></span
+              ><i class="arrow" data-lucide="chevron-right"></i
+            ></a>
+            <a class="tool-link" href="preference/"
+              ><span class="tool-icon"><i data-lucide="sliders-horizontal"></i></span
+              ><span><strong>設定</strong><small>BLEで本体の設定を変更する</small></span
+              ><i class="arrow" data-lucide="chevron-right"></i
+            ></a>
+            <a class="tool-link" href="simulator/"
+              ><span class="tool-icon"><i data-lucide="box"></i></span
+              ><span><strong>シミュレーター</strong><small>WASMと3Dモデルを実行する</small></span
+              ><i class="arrow" data-lucide="chevron-right"></i
+            ></a>
+            <a class="tool-link" href="editor/"
+              ><span class="tool-icon"><i data-lucide="blocks"></i></span
+              ><span><strong>ブロックエディタ</strong><small>MODを作成してインストールする</small></span
+              ><i class="arrow" data-lucide="chevron-right"></i
+            ></a>
+          </nav>
+        </div>
+      </section>
+    </main>
+    <script>
+      globalThis.lucide?.createIcons()
+    </script>
+  </body>
 </html>

--- a/web/package.json
+++ b/web/package.json
@@ -4,8 +4,8 @@
   "description": "Stack-chan development server",
   "scripts": {
     "dev": "live-server --verbose",
-    "test": "node --test simulator/*.test.mjs editor/*.test.mjs icon-assets.test.mjs",
-    "test:visual": "node simulator/visual-test.mjs"
+    "test": "node --test simulator/*.test.mjs editor/*.test.mjs *.test.mjs",
+    "test:visual": "node visual-pages-test.mjs && node simulator/visual-test.mjs"
   },
   "keywords": [],
   "author": "Shinya Ishikawa",

--- a/web/preference/ble-client.mjs
+++ b/web/preference/ble-client.mjs
@@ -81,9 +81,7 @@ class SimpleBLEClient {
 
     for (let i = 0; i < buf.length; i += chunkSize) {
       const chunk = buf.slice(i, i + chunkSize)
-      await this.#rx_characteristic?.writeValue(chunk).catch((reason) => {
-        console.warn(`write failed: ${reason}`)
-      })
+      await this.#rx_characteristic?.writeValue(chunk)
     }
   }
 }

--- a/web/preference/index.html
+++ b/web/preference/index.html
@@ -25,8 +25,7 @@
         const connectionStatus = document.getElementById('connection-status')
         const saveStatus = document.getElementById('save-status')
         const controls = [...form.querySelectorAll('input, select, textarea, button')]
-        let submitting = null
-        let pendingPreferences = new Set()
+        let submitting = false
         const currentValues = new Map()
 
         const setStatus = (element, text, state = '') => {
@@ -71,7 +70,7 @@
 
         form.addEventListener('submit', async (event) => {
           event.preventDefault()
-          if (!client.isConnected() || submitting != null) return
+          if (!client.isConnected() || submitting) return
           const props = [
             'wifi.ssid',
             'wifi.password',
@@ -101,20 +100,17 @@
           }
           submitButton.disabled = true
           setStatus(saveStatus, '保存中…')
-          pendingPreferences = new Set(Object.keys(payload))
+          submitting = true
           try {
             await client.send({ _batch: payload })
-            submitting = setTimeout(() => {
-              submitting = null
-              pendingPreferences.clear()
-              submitButton.disabled = false
-              setStatus(saveStatus, '応答がありません。接続を確認して再度保存してください。', 'error')
-            }, 3000)
+            for (const [prop, value] of Object.entries(payload)) currentValues.set(prop, value)
+            setStatus(saveStatus, '設定を送信しました。', 'success')
           } catch (error) {
             console.error(error)
-            pendingPreferences.clear()
-            submitButton.disabled = false
             setStatus(saveStatus, `保存できませんでした: ${error.message ?? error}`, 'error')
+          } finally {
+            submitting = false
+            submitButton.disabled = !client.isConnected()
           }
         })
 
@@ -122,21 +118,12 @@
           deviceName: 'STK',
           onCharacteristicValueChanged: ({ prop, value }) => {
             currentValues.set(prop, String(value))
-            pendingPreferences.delete(prop)
-            if (submitting != null && pendingPreferences.size === 0) {
-              clearTimeout(submitting)
-              submitting = null
-              submitButton.disabled = false
-              setStatus(saveStatus, '設定を保存しました。', 'success')
-            }
             const element = document.querySelector(`[name="${prop}"]`)
             if (element != null) element.value = value
           },
         })
         client.onDisconnected = () => {
-          if (submitting != null) clearTimeout(submitting)
-          submitting = null
-          pendingPreferences.clear()
+          submitting = false
           currentValues.clear()
           setStatus(saveStatus, '接続が切れました。保存されていない項目を確認してください。', 'warning')
           updateView()

--- a/web/preference/index.html
+++ b/web/preference/index.html
@@ -8,7 +8,12 @@
     <link rel="stylesheet" href="../global.css" />
     <link rel="stylesheet" href="preference.css" />
     <title>設定 | ｽﾀｯｸﾁｬﾝ</title>
-    <script src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"></script>
+    <script
+      src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"
+      integrity="sha384-mooE85Luwgx+AyykX7e90VcN8/QCFTSIwPuHLmvcsLVoA0en7lKYb9XlOzn5G2co"
+      crossorigin="anonymous"
+      defer
+    ></script>
     <script type="module">
       import SimpleBLEClient from './ble-client.mjs'
 
@@ -21,6 +26,8 @@
         const saveStatus = document.getElementById('save-status')
         const controls = [...form.querySelectorAll('input, select, textarea, button')]
         let submitting = null
+        let pendingPreferences = new Set()
+        const currentValues = new Map()
 
         const setStatus = (element, text, state = '') => {
           element.textContent = text
@@ -84,19 +91,28 @@
           const payload = {}
           for (const prop of props) {
             const value = document.getElementById(prop)?.value
-            if (value != null && value.trimEnd().length > 0) payload[prop] = value
+            if (value != null && value.trimEnd().length > 0 && currentValues.get(prop) !== value) {
+              payload[prop] = value
+            }
+          }
+          if (Object.keys(payload).length === 0) {
+            setStatus(saveStatus, '変更する項目がありません。')
+            return
           }
           submitButton.disabled = true
           setStatus(saveStatus, '保存中…')
+          pendingPreferences = new Set(Object.keys(payload))
           try {
             await client.send({ _batch: payload })
             submitting = setTimeout(() => {
               submitting = null
+              pendingPreferences.clear()
               submitButton.disabled = false
               setStatus(saveStatus, '応答がありません。接続を確認して再度保存してください。', 'error')
             }, 3000)
           } catch (error) {
             console.error(error)
+            pendingPreferences.clear()
             submitButton.disabled = false
             setStatus(saveStatus, `保存できませんでした: ${error.message ?? error}`, 'error')
           }
@@ -105,7 +121,9 @@
         const client = new SimpleBLEClient({
           deviceName: 'STK',
           onCharacteristicValueChanged: ({ prop, value }) => {
-            if (submitting != null) {
+            currentValues.set(prop, String(value))
+            pendingPreferences.delete(prop)
+            if (submitting != null && pendingPreferences.size === 0) {
               clearTimeout(submitting)
               submitting = null
               submitButton.disabled = false
@@ -118,6 +136,8 @@
         client.onDisconnected = () => {
           if (submitting != null) clearTimeout(submitting)
           submitting = null
+          pendingPreferences.clear()
+          currentValues.clear()
           setStatus(saveStatus, '接続が切れました。保存されていない項目を確認してください。', 'warning')
           updateView()
         }
@@ -137,11 +157,11 @@
         >
         <nav class="tool-nav" aria-label="ツール">
           <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
-          ><a href="../flash/" title="書き込み"><i data-lucide="cpu"></i></a
-          ><a href="../preference/" aria-current="page" title="設定"
+          ><a href="../flash/" title="書き込み" aria-label="書き込み"><i data-lucide="cpu"></i></a
+          ><a href="../preference/" aria-current="page" title="設定" aria-label="設定"
             ><i data-lucide="sliders-horizontal"></i><span class="nav-label">設定</span></a
-          ><a href="../simulator/" title="シミュレーター"><i data-lucide="box"></i></a
-          ><a href="../editor/" title="エディタ"><i data-lucide="blocks"></i></a>
+          ><a href="../simulator/" title="シミュレーター" aria-label="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" title="エディタ" aria-label="エディタ"><i data-lucide="blocks"></i></a>
         </nav>
       </header>
       <div class="preference-layout">

--- a/web/preference/index.html
+++ b/web/preference/index.html
@@ -1,220 +1,261 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png" />
+    <link rel="stylesheet" href="../global.css" />
+    <link rel="stylesheet" href="preference.css" />
+    <title>設定 | ｽﾀｯｸﾁｬﾝ</title>
+    <script src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"></script>
+    <script type="module">
+      import SimpleBLEClient from './ble-client.mjs'
 
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png">
-  <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png">
-  <link rel="stylesheet" href="../global.css">
-  <link rel="stylesheet" href="preference.css">
-  <script type="module">
-    import SimpleBLEClient from './ble-client.mjs'
+      document.addEventListener('DOMContentLoaded', () => {
+        const form = document.getElementById('form-preference')
+        const connectButton = document.getElementById('ble-connect-button')
+        const disconnectButton = document.getElementById('ble-disconnect-button')
+        const submitButton = document.getElementById('preference-submit-button')
+        const connectionStatus = document.getElementById('connection-status')
+        const saveStatus = document.getElementById('save-status')
+        const controls = [...form.querySelectorAll('input, select, textarea, button')]
+        let submitting = null
 
-    document.addEventListener('DOMContentLoaded', () => {
-      /**
-       * Views
-       */
-      const settingsForm = document.getElementById('settings-form')
-      const bleConnectButton = document.getElementById('ble-connect-button')
-      const updateView = () => {
-        if (client.isConnected()) {
-          bleConnectButton.classList.remove('active')
-          settingsForm.classList.add('active')
-        } else {
-          settingsForm.classList.remove('active')
-          bleConnectButton.classList.add('active')
+        const setStatus = (element, text, state = '') => {
+          element.textContent = text
+          element.dataset.state = state
         }
-      }
-
-      /**
-       * Event Handlers
-       */
-      const handleConnectButtonClick = async () => {
-        console.log("Connecting")
-        await client.connect()
-        updateView()
-      }
-      const handleDisconnectButtonClick = async () => {
-        console.log("Disconnecting")
-        await client.disconnect()
-        updateView()
-      }
-
-      const toast = document.getElementById('toast')
-      toast.addEventListener('animationend', () => {
-        toast.className = 'toast'
-      })
-      const showToast = () => {
-        toast.classList.add('visible')
-      }
-
-      let submitting = null
-      const handleWifiSubmit = async (event) => {
-        console.log('handlewifi')
-        event.preventDefault();
-        if (!client.isConnected()) {
-          console.warn('Not Connected')
-          return;
+        const updateView = () => {
+          const connected = client.isConnected()
+          connectButton.hidden = connected
+          disconnectButton.hidden = !connected
+          controls.forEach((control) => {
+            control.disabled = !connected
+          })
+          setStatus(connectionStatus, connected ? '接続済み' : '未接続', connected ? 'success' : '')
         }
-        const props = [
-          'wifi.ssid',
-          'wifi.password',
-          'driver.type',
-          'driver.offsetPan',
-          'driver.offsetTilt',
-          'ui.type',
-          'tts.type',
-          'tts.host',
-          'tts.port',
-          'tts.token',
-          'tts.voice',
-          'tts.volume',
-          'ai.token',
-          'ai.context',
-        ]
-        const payload = {}
-        for (const prop of props) {
-          const value = document.getElementById(prop)?.value
-          if (value != null && value.trimEnd().length > 0) {
-            payload[prop] = value
+
+        connectButton.addEventListener('click', async () => {
+          connectButton.disabled = true
+          setStatus(connectionStatus, '接続中…')
+          try {
+            await client.connect()
+          } catch (error) {
+            console.error(error)
+            setStatus(connectionStatus, `接続できませんでした: ${error.message ?? error}`, 'error')
+          } finally {
+            connectButton.disabled = false
+            if (client.isConnected()) updateView()
           }
-        }
-        await client.send({ _batch: payload })
-        console.log('Sent')
-        submitting = setTimeout(() => {
-          console.error('Timeout')
-        }, 3000)
-      }
-      const handleCharacteristicWritten = ({ prop, value }) => {
-        if (submitting != null) {
-          toast.innerText = 'Preference set [・＿・]'
-          showToast()
-          clearTimeout(submitting)
+        })
+        disconnectButton.addEventListener('click', async () => {
+          disconnectButton.disabled = true
+          try {
+            await client.disconnect()
+          } catch (error) {
+            console.error(error)
+            setStatus(connectionStatus, `切断できませんでした: ${error.message ?? error}`, 'error')
+          } finally {
+            disconnectButton.disabled = false
+            if (!client.isConnected()) updateView()
+          }
+        })
+
+        form.addEventListener('submit', async (event) => {
+          event.preventDefault()
+          if (!client.isConnected() || submitting != null) return
+          const props = [
+            'wifi.ssid',
+            'wifi.password',
+            'driver.type',
+            'driver.offsetPan',
+            'driver.offsetTilt',
+            'ui.type',
+            'tts.type',
+            'tts.host',
+            'tts.port',
+            'tts.token',
+            'tts.voice',
+            'tts.volume',
+            'ai.token',
+            'ai.context',
+          ]
+          const payload = {}
+          for (const prop of props) {
+            const value = document.getElementById(prop)?.value
+            if (value != null && value.trimEnd().length > 0) payload[prop] = value
+          }
+          submitButton.disabled = true
+          setStatus(saveStatus, '保存中…')
+          try {
+            await client.send({ _batch: payload })
+            submitting = setTimeout(() => {
+              submitting = null
+              submitButton.disabled = false
+              setStatus(saveStatus, '応答がありません。接続を確認して再度保存してください。', 'error')
+            }, 3000)
+          } catch (error) {
+            console.error(error)
+            submitButton.disabled = false
+            setStatus(saveStatus, `保存できませんでした: ${error.message ?? error}`, 'error')
+          }
+        })
+
+        const client = new SimpleBLEClient({
+          deviceName: 'STK',
+          onCharacteristicValueChanged: ({ prop, value }) => {
+            if (submitting != null) {
+              clearTimeout(submitting)
+              submitting = null
+              submitButton.disabled = false
+              setStatus(saveStatus, '設定を保存しました。', 'success')
+            }
+            const element = document.querySelector(`[name="${prop}"]`)
+            if (element != null) element.value = value
+          },
+        })
+        client.onDisconnected = () => {
+          if (submitting != null) clearTimeout(submitting)
           submitting = null
+          setStatus(saveStatus, '接続が切れました。保存されていない項目を確認してください。', 'warning')
+          updateView()
         }
-        const elem = document.querySelector(`[name="${prop}"]`)
-        if (elem != null) {
-          elem.value = value
-        }
-      }
 
-      /**
-       * BLE Client
-       */
-      const client = new SimpleBLEClient({
-        deviceName: "STK",
-        onCharacteristicValueChanged: handleCharacteristicWritten
-      })
-      client.onDisconnected = () => {
         updateView()
-      }
-
-      /**
-       * Bind
-       */
-      document.getElementById('ble-connect-button').addEventListener('click', handleConnectButtonClick)
-      document.getElementById('ble-disconnect-button').addEventListener('click', handleDisconnectButtonClick)
-      document.getElementById('form-preference').addEventListener('submit', handleWifiSubmit)
-    })
-
-  </script>
-  <title>Document</title>
-</head>
-
-<body>
-  <div class="app">
-    <div>
-      <button class="accordion active" id="ble-connect-button">
-        Connect Stack-chan with BLE[・＿・]
-      </button>
-    </div>
-    <div class="accordion card" id="settings-form">
-      <h2>Stack-chan preferences</h2>
-      <div class="ble-disconnect-button" id="ble-disconnect-button" title="Disconnect">×</div>
-      <form class="form" id="form-preference">
-        <h3>WiFi</h3>
-        <div class="form-group">
-          <label for="wifi.ssid">SSID: </label>
-          <input type="text" name="wifi.ssid" id="wifi.ssid" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <label for="wifi.password">Password: </label>
-          <input type="password" name="wifi.password" id="wifi.password" autocomplete="off">
-        </div>
-        <h3>Face</h3>
-        <div class="form-group">
-          <label for="ui.type">Type: </label>
-          <select name="ui.type" id="ui.type">
-            <option value="simple">Simple</option>
-            <option value="dog">Dog</option>
-          </select>
-        </div>
-        <h3>Servo</h3>
-        <div class="form-group">
-          <label for="driver.type">Type: </label>
-          <select name="driver.type" id="driver.type">
-            <option value="scservo">SCServo</option>
-            <option value="dynamixel">Dynamixel(Protocol version 2)</option>
-            <option value="rs30x">RS30X</option>
-            <option value="pwm">PWM(SG-90)</option>
-            <option value="none">None</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label for="driver.offsetPan">Offset Pan:</label>
-          <input type="number" name="driver.offsetPan" id="driver.offsetPan" value="0">
-        </div>
-        <div class="form-group">
-          <label for="driver.offsetTilt">Offset Tilt:</label>
-          <input type="number" name="driver.offsetTilt" id="driver.offsetTilt" value="0">
-        </div>
-        <h3>TTS</h3>
-        <div class="form-group">
-          <label for="tts.type">Type: </label>
-          <select name="tts.type" id="tts.type">
-            <option value="voicevox">VOICEVOX</option>
-            <option value="elevenlabs">ElevenLabs</option>
-            <option value="google-tts">Google TTS</option>
-            <option value="openai">OpenAI</option>
-            <option value="local">Local</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label for="tts.host">Host:</label>
-          <input type="text" name="tts.host" id="tts.host" placeholder="my-tts-host.local">
-        </div>
-        <div class="form-group">
-          <label for="tts.port">Port:</label>
-          <input type="number" name="tts.port" id="tts.port" placeholder="50021">
-        </div>
-        <div class="form-group">
-          <label for="tts.voice">Voice:</label>
-          <input type="text" name="tts.voice" id="tts.voice" placeholder="ally">
-        </div>
-        <div class="form-group">
-          <label for="tts.token">Token:</label>
-          <input type="text" name="tts.token" id="tts.token">
-        </div>
-        <div class="form-group">
-          <label for="tts.volume">Volume:</label>
-          <input type="number" name="tts.volume" id="tts.volume" step="0.1" min="0" max="1">
-        </div>
-        <h3>AI</h3>
-        <div class="form-group">
-          <label for="ai.token">Token:</label>
-          <input type="text" name="ai.token" id="ai.token">
-        </div>
-        <label for="ai.context">System Role:</label>
-        <textarea name="ai.context" id="ai.context" cols="30" rows="5"
-          placeholder="You are Stack-chan(スタックチャン), the palm sized super kawaii companion robot."></textarea>
-        <hr>
-        <button type="submit">Submit</button>
-      </form>
-    </div>
-  </div>
-  <div id="toast" class="toast"></div>
-</body>
-
+        globalThis.lucide?.createIcons()
+      })
+    </script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="topbar">
+        <a class="brand-link" href="../"
+          ><img src="../assets/stackchan-symbol.png" alt="" /><span
+            >ｽﾀｯｸﾁｬﾝ<span class="surface-name"> 設定</span></span
+          ></a
+        >
+        <nav class="tool-nav" aria-label="ツール">
+          <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
+          ><a href="../flash/" title="書き込み"><i data-lucide="cpu"></i></a
+          ><a href="../preference/" aria-current="page" title="設定"
+            ><i data-lucide="sliders-horizontal"></i><span class="nav-label">設定</span></a
+          ><a href="../simulator/" title="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" title="エディタ"><i data-lucide="blocks"></i></a>
+        </nav>
+      </header>
+      <div class="preference-layout">
+        <aside class="connection-pane">
+          <div class="page-heading">
+            <h1>本体設定</h1>
+            <p>BLEでｽﾀｯｸﾁｬﾝに接続します。</p>
+          </div>
+          <button id="ble-connect-button" class="primary-button" type="button">
+            <i data-lucide="bluetooth"></i><span>BLEで接続</span>
+          </button>
+          <button id="ble-disconnect-button" class="danger-button" type="button" hidden>
+            <i data-lucide="unplug"></i><span>切断</span>
+          </button>
+          <p id="connection-status" class="status-line" role="status">未接続</p>
+        </aside>
+        <section id="settings-form" class="settings-pane" aria-label="設定項目">
+          <form id="form-preference">
+            <section class="section-block">
+              <h2>Wi-Fi</h2>
+              <div class="form-grid">
+                <label class="form-field"
+                  ><span>SSID</span><input type="text" name="wifi.ssid" id="wifi.ssid" autocomplete="off" /></label
+                ><label class="form-field"
+                  ><span>パスワード</span
+                  ><input type="password" name="wifi.password" id="wifi.password" autocomplete="off"
+                /></label>
+              </div>
+            </section>
+            <section class="section-block">
+              <h2>外観</h2>
+              <div class="form-grid">
+                <label class="form-field"
+                  ><span>顔の種類</span
+                  ><select name="ui.type" id="ui.type">
+                    <option value="simple">シンプル</option>
+                    <option value="dog">いぬ</option>
+                  </select></label
+                >
+              </div>
+            </section>
+            <section class="section-block">
+              <h2>サーボ</h2>
+              <div class="form-grid">
+                <label class="form-field form-field-wide"
+                  ><span>ドライバー</span
+                  ><select name="driver.type" id="driver.type">
+                    <option value="scservo">SCServo</option>
+                    <option value="dynamixel">Dynamixel（Protocol 2）</option>
+                    <option value="rs30x">RS30X</option>
+                    <option value="pwm">PWM（SG-90）</option>
+                    <option value="none">なし</option>
+                  </select></label
+                ><label class="form-field"
+                  ><span>パン オフセット</span
+                  ><input type="number" name="driver.offsetPan" id="driver.offsetPan" value="0" /></label
+                ><label class="form-field"
+                  ><span>チルト オフセット</span
+                  ><input type="number" name="driver.offsetTilt" id="driver.offsetTilt" value="0"
+                /></label>
+              </div>
+            </section>
+            <section class="section-block">
+              <h2>音声合成</h2>
+              <div class="form-grid">
+                <label class="form-field"
+                  ><span>サービス</span
+                  ><select name="tts.type" id="tts.type">
+                    <option value="voicevox">VOICEVOX</option>
+                    <option value="elevenlabs">ElevenLabs</option>
+                    <option value="google-tts">Google TTS</option>
+                    <option value="openai">OpenAI</option>
+                    <option value="local">ローカル</option>
+                  </select></label
+                ><label class="form-field"
+                  ><span>ホスト</span
+                  ><input type="text" name="tts.host" id="tts.host" placeholder="my-tts-host.local" /></label
+                ><label class="form-field"
+                  ><span>ポート</span><input type="number" name="tts.port" id="tts.port" placeholder="50021" /></label
+                ><label class="form-field"
+                  ><span>音声</span><input type="text" name="tts.voice" id="tts.voice" placeholder="ally" /></label
+                ><label class="form-field"
+                  ><span>トークン</span><input type="password" name="tts.token" id="tts.token" /></label
+                ><label class="form-field"
+                  ><span>音量（0–1）</span
+                  ><input type="number" name="tts.volume" id="tts.volume" step="0.1" min="0" max="1"
+                /></label>
+              </div>
+            </section>
+            <section class="section-block">
+              <h2>AI</h2>
+              <div class="form-grid">
+                <label class="form-field"
+                  ><span>トークン</span><input type="password" name="ai.token" id="ai.token" /></label
+                ><label class="form-field form-field-full"
+                  ><span>システムロール</span
+                  ><textarea
+                    name="ai.context"
+                    id="ai.context"
+                    rows="5"
+                    placeholder="You are Stack-chan（スタックチャン）, the palm sized super kawaii companion robot."
+                  ></textarea>
+                </label>
+              </div>
+            </section>
+            <footer class="form-actions">
+              <p id="save-status" class="status-line" role="status"></p>
+              <button id="preference-submit-button" class="primary-button" type="submit">
+                <i data-lucide="save"></i><span>設定を保存</span>
+              </button>
+            </footer>
+          </form>
+        </section>
+      </div>
+    </main>
+  </body>
 </html>

--- a/web/preference/preference.css
+++ b/web/preference/preference.css
@@ -1,16 +1,81 @@
-.accordion {
-  display: none;
+.preference-layout {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 760px);
+  align-items: start;
+  gap: 32px;
+  width: min(100%, 1080px);
+  margin: 0 auto;
+  padding: 28px 20px 56px;
 }
-
-.accordion.active {
-  display: block;
+.connection-pane {
+  position: sticky;
+  top: 28px;
 }
-
-.ble-disconnect-button {
-  position: absolute;
-  right: 0.5em;
-  top: 0.5em;
-  font-size: 1.2em;
-  color: #bdbdbd;
-  cursor: pointer;
+.connection-pane button {
+  width: 100%;
+  margin-bottom: 9px;
+}
+.connection-pane .status-line {
+  padding: 2px 3px;
+}
+.settings-pane {
+  min-width: 0;
+}
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 16px;
+}
+.form-field {
+  display: grid;
+  align-content: start;
+  gap: 6px;
+  min-width: 0;
+}
+.form-field > span {
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+.form-field-wide,
+.form-field-full {
+  grid-column: 1 / -1;
+}
+.form-actions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  padding: 12px 0;
+  border-top: 1px solid var(--line);
+  background: var(--bg);
+}
+.form-actions .status-line {
+  flex: 1;
+}
+@media (max-width: 760px) {
+  .preference-layout {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 22px 14px 40px;
+  }
+  .connection-pane {
+    position: static;
+  }
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+  .form-field-wide,
+  .form-field-full {
+    grid-column: auto;
+  }
+  .form-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .form-actions button {
+    width: 100%;
+  }
 }

--- a/web/simulator/index.html
+++ b/web/simulator/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Stack-chan Web Simulator</title>
+    <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png" />
+    <title>Webシミュレーター | ｽﾀｯｸﾁｬﾝ</title>
+    <link rel="stylesheet" href="../global.css" />
     <link rel="stylesheet" href="./simulator.css" />
     <script type="importmap">
       {
@@ -21,8 +24,19 @@
   <body>
     <main class="app-shell">
       <header class="topbar">
-        <h1><span>ｽﾀｯｸﾁｬﾝ</span><span class="surface-name"> Web Simulator</span></h1>
+        <a class="brand-link" href="../"
+          ><img src="../assets/stackchan-symbol.png" alt="" /><span
+            >ｽﾀｯｸﾁｬﾝ<span class="surface-name"> Webシミュレーター</span></span
+          ></a
+        >
         <p id="simulator-info" role="status">WASMを読み込み中</p>
+        <nav class="tool-nav" aria-label="ツール">
+          <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
+          ><a href="../flash/" title="書き込み"><i data-lucide="cpu"></i></a
+          ><a href="../preference/" title="設定"><i data-lucide="sliders-horizontal"></i></a
+          ><a href="../simulator/" aria-current="page" title="シミュレーター"><i data-lucide="box"></i></a
+          ><a href="../editor/" title="エディタ"><i data-lucide="blocks"></i></a>
+        </nav>
       </header>
 
       <div class="simulator-layout">

--- a/web/simulator/index.html
+++ b/web/simulator/index.html
@@ -32,10 +32,11 @@
         <p id="simulator-info" role="status">WASMを読み込み中</p>
         <nav class="tool-nav" aria-label="ツール">
           <a href="../" title="ホーム" aria-label="ホーム"><i data-lucide="home"></i></a
-          ><a href="../flash/" title="書き込み"><i data-lucide="cpu"></i></a
-          ><a href="../preference/" title="設定"><i data-lucide="sliders-horizontal"></i></a
-          ><a href="../simulator/" aria-current="page" title="シミュレーター"><i data-lucide="box"></i></a
-          ><a href="../editor/" title="エディタ"><i data-lucide="blocks"></i></a>
+          ><a href="../flash/" title="書き込み" aria-label="書き込み"><i data-lucide="cpu"></i></a
+          ><a href="../preference/" title="設定" aria-label="設定"><i data-lucide="sliders-horizontal"></i></a
+          ><a href="../simulator/" aria-current="page" title="シミュレーター" aria-label="シミュレーター"
+            ><i data-lucide="box"></i></a
+          ><a href="../editor/" title="エディタ" aria-label="エディタ"><i data-lucide="blocks"></i></a>
         </nav>
       </header>
 

--- a/web/simulator/simulator.css
+++ b/web/simulator/simulator.css
@@ -139,7 +139,7 @@ h2 {
 
 .icon-button:hover,
 .command-button:hover {
-  border-color: #697780;
+  border-color: var(--line-hover);
   background: var(--surface-hover);
 }
 

--- a/web/simulator/simulator.css
+++ b/web/simulator/simulator.css
@@ -1,72 +1,19 @@
-:root {
-  color-scheme: dark;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
-  background: #111315;
-  color: #f4f6f7;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-  background: #111315;
-}
-
-button,
-input {
-  font: inherit;
-}
-
-button,
-a,
-label {
-  -webkit-tap-highlight-color: transparent;
+  overflow: hidden;
 }
 
 .app-shell {
   display: grid;
-  grid-template-rows: 52px minmax(0, 1fr);
+  grid-template-rows: var(--header-height) minmax(0, 1fr);
   width: 100%;
   height: 100dvh;
   min-height: 100vh;
   overflow: hidden;
 }
 
-.topbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  min-width: 0;
-  padding: 0 16px;
-  border-bottom: 1px solid #33383d;
-  background: #191c1f;
-}
-
-h1,
 h2,
 p {
   margin: 0;
-}
-
-h1 {
-  overflow: hidden;
-  font-size: 1rem;
-  line-height: 1.2;
-  letter-spacing: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 h2 {
@@ -77,12 +24,19 @@ h2 {
 }
 
 #simulator-info {
+  margin-left: auto;
   overflow: hidden;
   color: #83d9aa;
   font-size: 0.78rem;
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+#simulator-info + .tool-nav {
+  margin-left: 0;
+  padding-left: 8px;
+  border-left: 1px solid var(--line);
 }
 
 .simulator-layout {
@@ -128,8 +82,8 @@ h2 {
   flex-direction: column;
   gap: 0;
   overflow: hidden;
-  border-left: 1px solid #33383d;
-  background: #191c1f;
+  border-left: 1px solid var(--line);
+  background: var(--surface);
 }
 
 .tool-section,
@@ -137,7 +91,7 @@ h2 {
   display: grid;
   gap: 10px;
   padding: 16px;
-  border-bottom: 1px solid #33383d;
+  border-bottom: 1px solid var(--line);
 }
 
 .section-heading {
@@ -160,10 +114,10 @@ h2 {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border: 1px solid #454c52;
+  border: 1px solid var(--line-strong);
   border-radius: 6px;
-  background: #262b2f;
-  color: #f4f6f7;
+  background: var(--surface-raised);
+  color: var(--text);
   cursor: pointer;
   text-decoration: none;
   transition:
@@ -185,13 +139,13 @@ h2 {
 
 .icon-button:hover,
 .command-button:hover {
-  border-color: #6c7881;
-  background: #30373c;
+  border-color: #697780;
+  background: var(--surface-hover);
 }
 
 .icon-button:focus-visible,
 .command-button:focus-visible {
-  outline: 3px solid #42bde8;
+  outline: 3px solid var(--accent);
   outline-offset: 2px;
 }
 
@@ -243,7 +197,7 @@ button:disabled {
   margin: 0;
   padding: 10px;
   overflow: auto;
-  border: 1px solid #33383d;
+  border: 1px solid var(--line);
   border-radius: 6px;
   background: #101214;
   color: #cbd2d8;
@@ -255,19 +209,23 @@ button:disabled {
 }
 
 @media (max-width: 760px) {
+  body {
+    overflow: auto;
+  }
+
   .app-shell {
-    grid-template-rows: 48px auto;
+    grid-template-rows: var(--header-height) auto;
     height: auto;
     min-height: 100dvh;
     overflow: visible;
   }
 
-  .topbar {
-    padding: 0 10px;
+  #simulator-info {
+    max-width: 92px;
   }
-
-  .surface-name {
-    display: none;
+  #simulator-info + .tool-nav {
+    padding-left: 0;
+    border-left: 0;
   }
 
   .simulator-layout {
@@ -283,7 +241,7 @@ button:disabled {
 
   .inspector {
     overflow: visible;
-    border-top: 1px solid #33383d;
+    border-top: 1px solid var(--line);
     border-left: 0;
   }
 

--- a/web/visual-pages-test.mjs
+++ b/web/visual-pages-test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { chromium } from 'playwright-core'
+
+const port = Number(process.env.STACKCHAN_PAGES_TEST_PORT ?? 8097)
+const baseUrl = process.env.STACKCHAN_PAGES_TEST_URL ?? `http://127.0.0.1:${port}`
+const executablePath = [
+  process.env.CHROMIUM_PATH,
+  '/snap/bin/chromium',
+  '/usr/bin/chromium',
+  '/usr/bin/google-chrome',
+].find((candidate) => candidate && existsSync(candidate))
+if (!executablePath) throw new Error('Chromium executable not found; set CHROMIUM_PATH')
+
+let server
+if (!process.env.STACKCHAN_PAGES_TEST_URL) {
+  server = spawn(
+    process.execPath,
+    [
+      resolve('node_modules/live-server/live-server.js'),
+      `--port=${port}`,
+      '--host=127.0.0.1',
+      '--no-browser',
+      '--quiet',
+    ],
+    {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+    }
+  )
+}
+
+async function waitForServer() {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      if ((await fetch(baseUrl)).ok) return
+    } catch {}
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100))
+  }
+  throw new Error(`visual test server did not start at ${baseUrl}`)
+}
+
+const pages = [
+  ['home', '/'],
+  ['flash', '/flash/'],
+  ['preference', '/preference/'],
+  ['editor', '/editor/'],
+]
+const viewports = [
+  ['desktop', 1280, 800],
+  ['mobile', 390, 844],
+]
+
+let browser
+try {
+  await waitForServer()
+  browser = await chromium.launch({ executablePath, headless: true, args: ['--no-sandbox'] })
+  const page = await browser.newPage()
+  for (const [viewportName, width, height] of viewports) {
+    await page.setViewportSize({ width, height })
+    for (const [pageName, pathname] of pages) {
+      await page.goto(`${baseUrl}${pathname}`, { waitUntil: 'domcontentloaded' })
+      await page.waitForSelector('.topbar')
+      const layout = await page.evaluate(() => {
+        const topbar = document.querySelector('.topbar').getBoundingClientRect()
+        const interactive = [...document.querySelectorAll('button, a, input, select, textarea')]
+        return {
+          bodyWidth: document.body.scrollWidth,
+          topbar: { left: topbar.left, right: topbar.right, height: topbar.height },
+          clippedText: interactive.filter((element) => element.scrollWidth > element.clientWidth + 1).length,
+        }
+      })
+      assert.equal(layout.bodyWidth <= width, true, `${pageName}/${viewportName}: page must not overflow horizontally`)
+      assert.equal(
+        layout.topbar.left >= 0 && layout.topbar.right <= width,
+        true,
+        `${pageName}/${viewportName}: header must fit viewport`
+      )
+      assert.equal(
+        layout.topbar.height >= 48 && layout.topbar.height <= 52,
+        true,
+        `${pageName}/${viewportName}: header height must remain stable`
+      )
+      assert.equal(layout.clippedText, 0, `${pageName}/${viewportName}: interactive text must not be clipped`)
+      await page.screenshot({ path: `/tmp/stackchan-${pageName}-${viewportName}.png`, fullPage: true })
+    }
+  }
+  console.log('page visual checks passed: /tmp/stackchan-{home,flash,preference,editor}-{desktop,mobile}.png')
+} finally {
+  await browser?.close()
+  server?.kill('SIGTERM')
+}

--- a/web/visual-pages-test.mjs
+++ b/web/visual-pages-test.mjs
@@ -70,6 +70,9 @@ try {
           bodyWidth: document.body.scrollWidth,
           topbar: { left: topbar.left, right: topbar.right, height: topbar.height },
           clippedText: interactive.filter((element) => element.scrollWidth > element.clientWidth + 1).length,
+          visibleHiddenElements: [...document.querySelectorAll('[hidden]')].filter(
+            (element) => getComputedStyle(element).display !== 'none'
+          ).length,
         }
       })
       assert.equal(layout.bodyWidth <= width, true, `${pageName}/${viewportName}: page must not overflow horizontally`)
@@ -84,6 +87,7 @@ try {
         `${pageName}/${viewportName}: header height must remain stable`
       )
       assert.equal(layout.clippedText, 0, `${pageName}/${viewportName}: interactive text must not be clipped`)
+      assert.equal(layout.visibleHiddenElements, 0, `${pageName}/${viewportName}: hidden controls must not be rendered`)
       await page.screenshot({ path: `/tmp/stackchan-${pageName}-${viewportName}.png`, fullPage: true })
     }
   }

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const pages = ['index.html', 'flash/index.html', 'preference/index.html', 'editor/index.html', 'simulator/index.html']
+
+test('all web tools use the shared Japanese application shell', () => {
+  for (const page of pages) {
+    const html = readFileSync(page, 'utf8')
+    assert.match(html, /<html lang="ja">/, `${page} should declare Japanese UI text`)
+    assert.match(html, /class="topbar"/, `${page} should expose the shared top bar`)
+    assert.match(html, /stackchan-symbol\.png/, `${page} should expose the Stack-chan brand`)
+    assert.match(html, /apple-touch-icon/, `${page} should expose an Apple touch icon`)
+    assert.match(html, /data-lucide=/, `${page} should use Lucide controls`)
+  }
+})
+
+test('tool pages expose consistent navigation without changing integration ids', () => {
+  for (const page of pages.slice(1)) {
+    const html = readFileSync(page, 'utf8')
+    assert.match(html, /class="tool-nav"/, `${page} should expose tool navigation`)
+    assert.match(html, /aria-current="page"/, `${page} should identify the current tool`)
+  }
+
+  const preference = readFileSync('preference/index.html', 'utf8')
+  for (const id of ['ble-connect-button', 'ble-disconnect-button', 'form-preference', 'settings-form']) {
+    assert.match(preference, new RegExp(`id="${id}"`))
+  }
+  assert.match(preference, /role="alert"|data-state.*error|setStatus\([^)]*'error'/s)
+
+  const editor = readFileSync('editor/index.html', 'utf8')
+  for (const id of [
+    'blockly-workspace',
+    'build-button',
+    'download-button',
+    'install-simulator-button',
+    'install-device-button',
+  ]) {
+    assert.match(editor, new RegExp(`id="${id}"`))
+  }
+  assert.match(editor, /role="tablist"/)
+})

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -27,6 +27,9 @@ test('tool pages expose consistent navigation without changing integration ids',
     assert.match(preference, new RegExp(`id="${id}"`))
   }
   assert.match(preference, /role="alert"|data-state.*error|setStatus\([^)]*'error'/s)
+  assert.match(preference, /currentValues\.get\(prop\) !== value/)
+  assert.match(preference, /pendingPreferences\.delete\(prop\)/)
+  assert.match(preference, /変更する項目がありません/)
 
   const editor = readFileSync('editor/index.html', 'utf8')
   for (const id of [
@@ -39,4 +42,20 @@ test('tool pages expose consistent navigation without changing integration ids',
     assert.match(editor, new RegExp(`id="${id}"`))
   }
   assert.match(editor, /role="tablist"/)
+  const editorScript = readFileSync('editor/editor.mjs', 'utf8')
+  assert.match(editorScript, /\.output-tabs \[role="tab"\]/)
+  assert.match(editorScript, /ArrowRight/)
+  assert.match(editorScript, /candidate\.tabIndex = selected \? 0 : -1/)
+})
+
+test('third-party scripts that handle editable data use subresource integrity', () => {
+  for (const page of ['preference/index.html', 'editor/index.html']) {
+    const html = readFileSync(page, 'utf8')
+    const externalScripts = [...html.matchAll(/<script[^>]+src="https:\/\/unpkg\.com\/[^>]+>/g)]
+    assert.notEqual(externalScripts.length, 0)
+    for (const [script] of externalScripts) {
+      assert.match(script, /integrity="sha384-/, `${page} external script should have SRI`)
+      assert.match(script, /crossorigin="anonymous"/, `${page} external script should use anonymous CORS`)
+    }
+  }
 })

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -28,7 +28,8 @@ test('tool pages expose consistent navigation without changing integration ids',
   }
   assert.match(preference, /role="alert"|data-state.*error|setStatus\([^)]*'error'/s)
   assert.match(preference, /currentValues\.get\(prop\) !== value/)
-  assert.match(preference, /pendingPreferences\.delete\(prop\)/)
+  assert.doesNotMatch(preference, /pendingPreferences|setTimeout/)
+  assert.match(preference, /設定を送信しました/)
   assert.match(preference, /変更する項目がありません/)
 
   const editor = readFileSync('editor/index.html', 'utf8')
@@ -46,6 +47,11 @@ test('tool pages expose consistent navigation without changing integration ids',
   assert.match(editorScript, /\.output-tabs \[role="tab"\]/)
   assert.match(editorScript, /ArrowRight/)
   assert.match(editorScript, /candidate\.tabIndex = selected \? 0 : -1/)
+})
+
+test('shared controls preserve the native hidden state', () => {
+  const css = readFileSync('global.css', 'utf8')
+  assert.match(css, /\[hidden\]\s*{[^}]*display:\s*none\s*!important/s)
 })
 
 test('third-party scripts that handle editable data use subresource integrity', () => {


### PR DESCRIPTION
## What changed

- unify the home, firmware flash, preference, block editor, and simulator surfaces with a shared dark tool UI
- add consistent Japanese labels, Stack-chan branding, Lucide controls, navigation, responsive sizing, and accessible status states
- reorganize Preference connection/save feedback and the block editor inspector without changing existing integration IDs or data formats
- add shared UI contract tests and desktop/mobile Playwright visual checks

## Why

The web tools had evolved independently: the simulator already used a tool-first workspace, while the remaining pages used different palettes, navigation patterns, languages, and control styles. This made moving between setup and development workflows feel inconsistent and left several connection and save failures unclear.

## Impact

Users get a consistent Japanese interface across all web tools, clearer BLE and firmware-writing states, and responsive layouts from mobile through desktop. Existing manifests, Preference keys, MOD formats, and simulator/editor integration IDs remain unchanged.

## Validation

- `cd web && npm test` — 87 tests passed
- `cd web && npm run test:visual` — desktop/mobile checks passed for all five surfaces, including the simulator WebGL and Piu transition checks
- `git diff --check -- web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Japanese Web Tools launcher with navigable firmware, preferences, simulator, and block editor pages.
  * Introduced accessible, keyboard-friendly output tabs in the editor (code/log) with ARIA-compliant behavior.
  * Refreshed preference and flash experiences with updated UI layout, localized text, and improved status messaging.

* **Bug Fixes**
  * Improved editor, simulator, and preference layouts for more reliable scrolling and responsive behavior.
  * Enhanced Bluetooth write reliability by simplifying error handling during chunked sends.

* **Tests**
  * Expanded automated web UI checks (including accessibility/hidden-state expectations and integrity attributes) and added Playwright visual smoke coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->