### PR TITLE
fix(web): sync website sources to GitHub Pages

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -5,18 +5,18 @@ on:
     branches:
       - develop
     paths:
-      - 'firmware/**'
-      - 'web/simulator/**'
-      - '.github/actions/setup/action.yml'
-      - '.github/workflows/bundle.yml'
+      - "firmware/**"
+      - "web/**"
+      - ".github/actions/setup/action.yml"
+      - ".github/workflows/bundle.yml"
   pull_request:
     branches:
       - develop
     paths:
-      - 'firmware/**'
-      - 'web/simulator/**'
-      - '.github/actions/setup/action.yml'
-      - '.github/workflows/bundle.yml'
+      - "firmware/**"
+      - "web/**"
+      - ".github/actions/setup/action.yml"
+      - ".github/workflows/bundle.yml"
 
 permissions:
   contents: read
@@ -65,6 +65,11 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: gh-pages
+      - name: Checkout website source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: website-source
       - name: Download firmware bundle
         uses: actions/download-artifact@v8
         with:
@@ -85,6 +90,10 @@ jobs:
             echo "WASM simulator artifact is empty"
             exit 1
           fi
+          rsync -a --delete \
+            --exclude '/schematics/' \
+            --exclude '/flash/tech.moddable.stackchan/' \
+            ./website-source/web/ ./web/
           rm -rf ./web/flash/tech.moddable.stackchan ./web/simulator
           mkdir -p ./web/flash/tech.moddable.stackchan ./web/simulator
           cp -R ./firmware-bundle/. ./web/flash/tech.moddable.stackchan/
@@ -93,10 +102,10 @@ jobs:
         run: |
           git config user.name 'GitHub Action'
           git config user.email 'action@github.com'
-          git add ./web/flash/tech.moddable.stackchan ./web/simulator
+          git add --all ./web
           if git diff --cached --quiet; then
             echo "No bundle changes to deploy"
             exit 0
           fi
-          git commit -m "Deploy firmware bundle from ${{ github.sha }}"
+          git commit -m "Deploy website and firmware bundle from ${{ github.sha }}"
           git push origin HEAD:gh-pages

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           path: website-source
+          persist-credentials: false
       - name: Download firmware bundle
         uses: actions/download-artifact@v8
         with:
@@ -93,6 +94,7 @@ jobs:
           rsync -a --delete \
             --exclude '/schematics/' \
             --exclude '/flash/tech.moddable.stackchan/' \
+            --exclude '/simulator/' \
             ./website-source/web/ ./web/
           rm -rf ./web/flash/tech.moddable.stackchan ./web/simulator
           mkdir -p ./web/flash/tech.moddable.stackchan ./web/simulator


### PR DESCRIPTION
## Summary

- sync the website source from the triggering `develop` commit into `gh-pages`
- deploy generated firmware and WASM simulator artifacts on top of the synced source
- trigger the workflow for changes anywhere under `web/`
- preserve generated schematics and firmware bundle directories during synchronization

## Root cause

The deploy job checked out `gh-pages` and only replaced `web/simulator/` and the firmware bundle. Shared files such as `web/global.css` therefore remained stale, causing the newly deployed simulator markup and CSS to be combined with the old global stylesheet.

## Impact

Website source changes, including shared styles and assets, are now published together with generated artifacts. This fixes the inconsistent GitHub Pages appearance after #542 and prevents the same mismatch for other web tools.

## Validation

- `prettier --check .github/workflows/bundle.yml`
- `git diff --check`
- simulated the `rsync` operation using the current `gh-pages` tree and verified:
  - `web/global.css` is updated
  - `web/schematics/` is preserved
  - `web/flash/tech.moddable.stackchan/` is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated deployments now include website updates together with firmware bundle updates.
  * Deployment detection and bundling now react to changes across the entire web directory.

* **Bug Fixes**
  * Improved website mirroring during deployment to better synchronize web assets, including safer cleanup of removed files while preserving excluded simulator/flash and schematics content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->