### PR TITLE
fix(web): improve Blockly tab contrast

### DIFF
--- a/web/editor/editor.css
+++ b/web/editor/editor.css
@@ -30,6 +30,9 @@ body {
   overflow: hidden;
   background: #e7ebed;
 }
+.blocklyTreeLabel {
+  color: #202428;
+}
 .editor-inspector {
   display: flex;
   min-width: 0;

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -47,6 +47,9 @@ test('tool pages expose consistent navigation without changing integration ids',
   assert.match(editorScript, /\.output-tabs \[role="tab"\]/)
   assert.match(editorScript, /ArrowRight/)
   assert.match(editorScript, /candidate\.tabIndex = selected \? 0 : -1/)
+
+  const editorStyles = readFileSync('editor/editor.css', 'utf8')
+  assert.match(editorStyles, /\.blocklyTreeLabel\s*{[^}]*color:\s*#202428/s)
 })
 
 test('shared controls preserve the native hidden state', () => {


### PR DESCRIPTION
## What changed

- change Blockly category tab labels from white to dark charcoal
- add a UI contract test that preserves the readable label color

## Why

PR #542 introduced a light gray Blockly toolbox while Blockly's default white category labels remained in place. The resulting low contrast made the category names difficult to read.

## Impact

Block categories are easier to scan without darkening the toolbox or changing the category color markers.

## Validation

- `cd web && npm test` — 10 test files passed
- editor desktop/mobile visual checks passed
- visually inspected `/tmp/stackchan-editor-desktop.png`

The full visual command reaches the simulator checks after the editor checks pass, then fails on the existing `settings action must leave the splash screen` simulator transition assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the readability of editor tree labels with a darker, consistent text color.

* **Tests**
  * Added coverage to verify the editor tree label styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->