### PR TITLE
fix(web): preserve Face data across editor round trips

### DIFF
--- a/web/editor/editor.css
+++ b/web/editor/editor.css
@@ -324,6 +324,16 @@ body {
 .face-selection-control {
   position: relative;
 }
+.edit-face-button {
+  width: 100%;
+  min-height: 36px;
+  justify-content: flex-start;
+  font-size: 0.72rem;
+}
+.edit-face-button > svg {
+  width: 16px;
+  height: 16px;
+}
 .face-selection-button {
   width: 100%;
   min-height: 40px;

--- a/web/editor/editor.mjs
+++ b/web/editor/editor.mjs
@@ -29,6 +29,12 @@ import {
 } from './project-library.mjs'
 import { createProjectStorage } from './project-storage.mjs'
 import { VISUAL_SAMPLES, sampleById } from './samples.mjs'
+import {
+  clearFaceEditContext,
+  clearStagedFaceTransfer,
+  loadStagedFaceTransfer,
+  saveFaceEditContext,
+} from '../face-editor/face-editor-storage.mjs'
 import createTools from './vendor/tools.js'
 
 const WORKSPACE_STORAGE_KEY = 'stackchan-blockly-workspace'
@@ -70,6 +76,8 @@ const faceSelectionButton = document.getElementById('face-selection-button')
 const faceSelectionLabel = document.getElementById('face-selection-label')
 const faceSelectionMenu = document.getElementById('face-selection-menu')
 const faceSelectionList = document.getElementById('face-selection-list')
+const editFaceButton = document.getElementById('edit-face-button')
+const faceEditorNavigationLink = document.querySelector('.tool-drawer-link[data-tool-id="face-editor"]')
 const embedAssetsInput = document.getElementById('embed-assets')
 const simulatorDialog = document.getElementById('simulator-dialog')
 const simulatorFrame = document.getElementById('simulator-frame')
@@ -282,16 +290,20 @@ function workspaceState() {
   return Blockly.serialization.workspaces.save(workspace)
 }
 
-let projectSave = Promise.resolve()
+let projectSave = Promise.resolve(true)
 function queueProjectSave() {
   const snapshot = structuredClone({ currentProject, projects: projectLibrary })
-  projectSave = projectSave
-    .catch(() => {})
-    .then(() => projectStorage.saveState(snapshot))
-    .catch((error) => {
+  projectSave = projectSave.then(async () => {
+    try {
+      await projectStorage.saveState(snapshot)
+      return true
+    } catch (error) {
       log(`プロジェクトを自動保存できませんでした: ${error.message}`)
       setStatus('自動保存に失敗しました。プロジェクトを書き出してください。')
-    })
+      return false
+    }
+  })
+  return projectSave
 }
 
 function persistProject(project = currentProject) {
@@ -548,6 +560,8 @@ function renderFaceSelection() {
   const selected = entries.find(({ asset }) => asset.path === selectedPath)
   faceSelectionLabel.textContent = selected?.name ?? '標準Face'
   faceSelectionButton.title = selected ? `使用中のFace: ${selected.name}` : '使用中のFace: 標準Face'
+  editFaceButton.disabled = !selected
+  editFaceButton.title = selected ? `「${selected.name}」を顔エディタで編集` : '標準Faceは編集できません'
   faceSelectionList.replaceChildren()
 
   const options = [
@@ -589,6 +603,39 @@ faceSelectionButton.addEventListener('click', (event) => {
   event.stopPropagation()
   setFaceSelectionMenuOpen(faceSelectionMenu.hidden, { focusItem: faceSelectionMenu.hidden })
 })
+
+async function openSelectedFaceEditor() {
+  const assetPath = currentProject.settings.faceAsset
+  const entry = currentProject.assets.find(
+    (asset) => asset.path === assetPath && asset.mediaType === FACE_ASSET_MEDIA_TYPE
+  )
+  if (!entry) {
+    setStatus('編集するカスタムFaceを選択してください')
+    return
+  }
+  editFaceButton.disabled = true
+  try {
+    const asset = parseFaceAsset(new TextDecoder().decode(assetBytes(entry)))
+    persistProject()
+    if (!(await projectSave)) throw new Error('MODプロジェクトを保存できませんでした')
+    saveFaceEditContext(asset, { projectId: currentProject.id, assetPath: entry.path })
+    location.href = '../face-editor/?face-edit=project'
+  } catch (error) {
+    log(`顔エディタを開けませんでした: ${error.message}`)
+    setStatus(`顔エディタを開けませんでした: ${error.message}`)
+    renderFaceSelection()
+  }
+}
+
+editFaceButton.addEventListener('click', openSelectedFaceEditor)
+faceEditorNavigationLink?.addEventListener('click', (event) => {
+  const selectedFace = faceAssetEntries().some(({ asset }) => asset.path === currentProject.settings.faceAsset)
+  if (!selectedFace) return
+  event.preventDefault()
+  document.getElementById('tool-drawer')?.close()
+  void openSelectedFaceEditor()
+})
+window.addEventListener('pageshow', renderFaceSelection)
 faceSelectionMenu.addEventListener('keydown', (event) => {
   const items = visibleFaceSelectionItems()
   const index = items.indexOf(document.activeElement)
@@ -644,21 +691,29 @@ function renderAssets() {
   }
 }
 
-function addFaceAsset(asset) {
-  return addFaceAssetToProject(currentProject, asset)
+function addFaceAsset(asset, options) {
+  return addFaceAssetToProject(currentProject, asset, options)
 }
 
 try {
-  const stagedFaceAsset = localStorage.getItem('stackchan-face-asset-staging')
-  if (stagedFaceAsset && new URLSearchParams(location.search).get('face-asset') === 'staging') {
-    const stagedProject = addFaceAsset(parseFaceAsset(stagedFaceAsset))
+  if (new URLSearchParams(location.search).get('face-asset') === 'staging') {
+    const stagedTransfer = loadStagedFaceTransfer()
+    if (!stagedTransfer) throw new Error('顔エディタからの受け渡しデータがありません')
+    const edit = stagedTransfer.edit
+    if (edit && edit.projectId !== currentProject.id) {
+      throw new Error('編集元と現在のMODプロジェクトが一致しません')
+    }
+    const stagedProject = addFaceAsset(stagedTransfer.asset, edit ? { replacePath: edit.assetPath } : undefined)
     persistProject(stagedProject)
-    localStorage.removeItem('stackchan-face-asset-staging')
+    if (!(await projectSave)) throw new Error('顔アセットを含むMODプロジェクトを保存できませんでした')
+    clearStagedFaceTransfer()
+    clearFaceEditContext()
     history.replaceState(null, '', location.pathname)
-    setStatus('顔エディタのアセットを追加しました')
+    setStatus(edit ? '顔エディタの変更を反映しました' : '顔エディタのアセットを追加しました')
   }
 } catch (error) {
   log(`顔アセットを読み込めませんでした: ${error.message}`)
+  setStatus(`顔アセットを読み込めませんでした: ${error.message}`)
 }
 
 function recordMetric(event, detail = {}) {

--- a/web/editor/face-assets.mjs
+++ b/web/editor/face-assets.mjs
@@ -253,9 +253,16 @@ export function parseFaceAsset(text) {
   return createFaceAsset(value)
 }
 
-export function addFaceAssetToProject(project, asset) {
+export function addFaceAssetToProject(project, asset, { replacePath = null } = {}) {
   const normalized = parseFaceAsset(JSON.stringify(asset))
-  const path = `assets/${normalized.name.replace(/[^\p{L}\p{N}._-]/gu, '_')}.stackchan-face.json`
+  const generatedPath = `assets/${normalized.name.replace(/[^\p{L}\p{N}._-]/gu, '_')}.stackchan-face.json`
+  const path = replacePath == null ? generatedPath : String(replacePath)
+  if (replacePath != null) {
+    const replaced = project.assets.find((item) => item.path === path)
+    if (!replaced || replaced.mediaType !== FACE_ASSET_MEDIA_TYPE) {
+      throw new TypeError('更新対象の顔アセットがプロジェクトにありません')
+    }
+  }
   const entry = {
     path,
     mediaType: FACE_ASSET_MEDIA_TYPE,

--- a/web/editor/face-assets.test.mjs
+++ b/web/editor/face-assets.test.mjs
@@ -231,3 +231,28 @@ test('staging a Shape face leaves the current project unchanged until persistenc
   assert.equal(next.settings.faceAsset, 'assets/追加の顔.stackchan-face.json')
   assert.equal(JSON.parse(next.assets[0].data).kind, 'shape')
 })
+
+test('editing a staged Shape face replaces its stable asset path even when its name changes', () => {
+  const original = addFaceAssetToProject(
+    { assets: [], settings: { educationalProfile: true, embedAssets: true, faceAsset: null } },
+    createFaceAsset({ name: '元の顔', emotion: 'NEUTRAL' })
+  )
+  const originalPath = original.settings.faceAsset
+
+  const edited = addFaceAssetToProject(original, createFaceAsset({ name: '変更後の顔', emotion: 'HOT' }), {
+    replacePath: originalPath,
+  })
+
+  assert.equal(edited.assets.length, 1)
+  assert.equal(edited.assets[0].path, originalPath)
+  assert.equal(edited.settings.faceAsset, originalPath)
+  assert.equal(JSON.parse(edited.assets[0].data).name, '変更後の顔')
+  assert.equal(JSON.parse(edited.assets[0].data).emotion, 'HOT')
+  assert.throws(
+    () =>
+      addFaceAssetToProject(original, createFaceAsset({ name: '不明な顔' }), {
+        replacePath: 'assets/missing.stackchan-face.json',
+      }),
+    /更新対象/
+  )
+})

--- a/web/editor/index.html
+++ b/web/editor/index.html
@@ -188,6 +188,9 @@
                   <div id="face-selection-list" class="face-selection-list"></div>
                 </div>
               </div>
+              <button id="edit-face-button" class="edit-face-button" type="button" disabled>
+                <i data-lucide="pencil"></i><span>使用中のFaceを編集</span>
+              </button>
             </div>
             <div id="asset-summary" class="asset-summary" aria-live="polite"></div>
             <label class="asset-mode">

--- a/web/face-editor/face-editor-storage.mjs
+++ b/web/face-editor/face-editor-storage.mjs
@@ -1,0 +1,92 @@
+import { parseFaceAsset } from '../editor/face-assets.mjs'
+
+export const FACE_EDITOR_DRAFT_STORAGE_KEY = 'stackchan-face-editor-draft-v1'
+export const FACE_EDITOR_CONTEXT_STORAGE_KEY = 'stackchan-face-editor-edit-context-v1'
+export const FACE_EDITOR_STAGING_STORAGE_KEY = 'stackchan-face-asset-staging'
+
+const FACE_EDITOR_TRANSFER_FORMAT = 'tech.stackchan.face-editor-transfer'
+const FACE_EDITOR_TRANSFER_VERSION = 1
+
+function parseJson(text, description) {
+  try {
+    return JSON.parse(String(text))
+  } catch (error) {
+    throw new TypeError(`${description}のJSONを解析できません: ${error.message}`)
+  }
+}
+
+function normalizeEditContext(edit) {
+  if (edit == null) return null
+  const projectId = String(edit.projectId ?? '').trim()
+  const assetPath = String(edit.assetPath ?? '')
+  if (!/^[A-Za-z0-9._-]{8,128}$/.test(projectId)) {
+    throw new TypeError('顔編集元のプロジェクトIDが不正です')
+  }
+  if (!assetPath.startsWith('assets/') || assetPath.includes('..') || assetPath.includes('\\')) {
+    throw new TypeError('顔編集元のアセットパスが不正です')
+  }
+  return { projectId, assetPath }
+}
+
+export function createFaceEditorTransfer(asset, edit = null) {
+  return {
+    format: FACE_EDITOR_TRANSFER_FORMAT,
+    version: FACE_EDITOR_TRANSFER_VERSION,
+    asset: parseFaceAsset(JSON.stringify(asset)),
+    edit: normalizeEditContext(edit),
+  }
+}
+
+export function parseFaceEditorTransfer(text) {
+  const value = parseJson(text, '顔エディタ受け渡しデータ')
+
+  // Version 1 of the face editor stored a raw Face asset in the staging key.
+  if (value?.format !== FACE_EDITOR_TRANSFER_FORMAT) {
+    return createFaceEditorTransfer(parseFaceAsset(JSON.stringify(value)))
+  }
+  if (value.version !== FACE_EDITOR_TRANSFER_VERSION || value.asset == null) {
+    throw new TypeError('未対応の顔エディタ受け渡し形式です')
+  }
+  return createFaceEditorTransfer(value.asset, value.edit)
+}
+
+export function loadFaceDraft(storage = globalThis.localStorage) {
+  const stored = storage.getItem(FACE_EDITOR_DRAFT_STORAGE_KEY)
+  return stored == null ? null : parseFaceAsset(stored)
+}
+
+export function saveFaceDraft(asset, storage = globalThis.localStorage) {
+  const normalized = parseFaceAsset(JSON.stringify(asset))
+  storage.setItem(FACE_EDITOR_DRAFT_STORAGE_KEY, JSON.stringify(normalized))
+  return normalized
+}
+
+export function loadFaceEditContext(storage = globalThis.localStorage) {
+  const stored = storage.getItem(FACE_EDITOR_CONTEXT_STORAGE_KEY)
+  return stored == null ? null : parseFaceEditorTransfer(stored)
+}
+
+export function saveFaceEditContext(asset, edit, storage = globalThis.localStorage) {
+  const transfer = createFaceEditorTransfer(asset, edit)
+  storage.setItem(FACE_EDITOR_CONTEXT_STORAGE_KEY, JSON.stringify(transfer))
+  return transfer
+}
+
+export function clearFaceEditContext(storage = globalThis.localStorage) {
+  storage.removeItem(FACE_EDITOR_CONTEXT_STORAGE_KEY)
+}
+
+export function loadStagedFaceTransfer(storage = globalThis.localStorage) {
+  const stored = storage.getItem(FACE_EDITOR_STAGING_STORAGE_KEY)
+  return stored == null ? null : parseFaceEditorTransfer(stored)
+}
+
+export function stageFaceTransfer(asset, edit = null, storage = globalThis.localStorage) {
+  const transfer = createFaceEditorTransfer(asset, edit)
+  storage.setItem(FACE_EDITOR_STAGING_STORAGE_KEY, JSON.stringify(transfer))
+  return transfer
+}
+
+export function clearStagedFaceTransfer(storage = globalThis.localStorage) {
+  storage.removeItem(FACE_EDITOR_STAGING_STORAGE_KEY)
+}

--- a/web/face-editor/face-editor-storage.test.mjs
+++ b/web/face-editor/face-editor-storage.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createFaceAsset } from '../editor/face-assets.mjs'
+import {
+  FACE_EDITOR_CONTEXT_STORAGE_KEY,
+  FACE_EDITOR_DRAFT_STORAGE_KEY,
+  FACE_EDITOR_STAGING_STORAGE_KEY,
+  clearFaceEditContext,
+  clearStagedFaceTransfer,
+  loadFaceDraft,
+  loadFaceEditContext,
+  loadStagedFaceTransfer,
+  saveFaceDraft,
+  saveFaceEditContext,
+  stageFaceTransfer,
+} from './face-editor-storage.mjs'
+
+function memoryStorage() {
+  const values = new Map()
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+  }
+}
+
+test('face editor draft storage round-trips the latest normalized Face asset', () => {
+  const storage = memoryStorage()
+  const asset = createFaceAsset({ name: '下書きFace', emotion: 'HAPPY' })
+
+  saveFaceDraft(asset, storage)
+
+  assert.equal(loadFaceDraft(storage).name, '下書きFace')
+  assert.equal(loadFaceDraft(storage).emotion, 'HAPPY')
+  assert.ok(storage.getItem(FACE_EDITOR_DRAFT_STORAGE_KEY))
+
+  storage.setItem(FACE_EDITOR_DRAFT_STORAGE_KEY, '{broken')
+  assert.throws(() => loadFaceDraft(storage), /JSON|解析/)
+})
+
+test('project edit context and staging retain the originating project and stable asset path', () => {
+  const storage = memoryStorage()
+  const original = createFaceAsset({ name: '元の顔' })
+  const edited = createFaceAsset({ name: '変更後の名前', emotion: 'HOT' })
+  const edit = { projectId: 'project-1234', assetPath: 'assets/original.stackchan-face.json' }
+
+  saveFaceEditContext(original, edit, storage)
+  assert.deepEqual(loadFaceEditContext(storage).edit, edit)
+  assert.equal(loadFaceEditContext(storage).asset.name, '元の顔')
+
+  stageFaceTransfer(edited, loadFaceEditContext(storage).edit, storage)
+  assert.deepEqual(loadStagedFaceTransfer(storage).edit, edit)
+  assert.equal(loadStagedFaceTransfer(storage).asset.name, '変更後の名前')
+
+  clearFaceEditContext(storage)
+  clearStagedFaceTransfer(storage)
+  assert.equal(storage.getItem(FACE_EDITOR_CONTEXT_STORAGE_KEY), null)
+  assert.equal(storage.getItem(FACE_EDITOR_STAGING_STORAGE_KEY), null)
+})
+
+test('staging accepts a legacy raw Face asset and rejects malformed edit identities', () => {
+  const storage = memoryStorage()
+  const asset = createFaceAsset({ name: '旧受け渡し' })
+  storage.setItem(FACE_EDITOR_STAGING_STORAGE_KEY, JSON.stringify(asset))
+
+  assert.equal(loadStagedFaceTransfer(storage).asset.name, '旧受け渡し')
+  assert.equal(loadStagedFaceTransfer(storage).edit, null)
+  assert.throws(
+    () => saveFaceEditContext(asset, { projectId: 'bad', assetPath: '../outside.json' }, storage),
+    /プロジェクトID|アセットパス/
+  )
+})

--- a/web/face-editor/face-editor.css
+++ b/web/face-editor/face-editor.css
@@ -326,7 +326,7 @@ body {
 }
 
 @media (max-width: 620px) {
-  .face-header-actions button:not(.icon-button) span {
+  #download-face span {
     display: none;
   }
 

--- a/web/face-editor/face-editor.mjs
+++ b/web/face-editor/face-editor.mjs
@@ -1,4 +1,13 @@
 import { FACE_ASSET_MEDIA_TYPE, createFaceAsset, parseFaceAsset, shapeFaceDefinition } from '../editor/face-assets.mjs'
+import {
+  clearFaceEditContext,
+  loadFaceDraft,
+  loadFaceEditContext,
+  saveFaceDraft,
+  stageFaceTransfer,
+} from './face-editor-storage.mjs'
+
+let activeEditContext = null
 
 const element = (id) => document.getElementById(id)
 const elements = {
@@ -24,6 +33,8 @@ const elements = {
   status: element('face-status'),
   codePreview: element('shape-code-preview'),
   fileInput: element('face-file-input'),
+  sendToEditor: element('send-to-editor'),
+  sendToEditorLabel: document.querySelector('#send-to-editor span'),
 }
 
 const controls = {
@@ -195,7 +206,7 @@ function applyAsset(asset) {
   setEyeValues(controls.rightEye, normalized.shape.eyes.right)
   setValues(controls.mouth, normalized.shape.mouth)
   syncMouthControls()
-  render()
+  return render()
 }
 
 function setIris(rectangle, eye) {
@@ -281,14 +292,24 @@ function setStatus(message, state = '') {
   elements.status.dataset.state = state
 }
 
+function persistDraft(asset) {
+  try {
+    saveFaceDraft(asset)
+    return true
+  } catch (error) {
+    setStatus(`下書きを保存できませんでした: ${error.message}`, 'error')
+    return false
+  }
+}
+
 elements.form.addEventListener('input', () => {
   for (const eyeControls of [controls.leftEye, controls.rightEye]) syncEyeControls(eyeControls)
   syncMouthControls()
-  render()
-  setStatus('Shape型Faceを編集中です。')
+  const asset = render()
+  if (persistDraft(asset)) setStatus('Shape型Faceを編集中です。')
 })
 
-elements.form.addEventListener('change', () => applyAsset(currentAsset()))
+elements.form.addEventListener('change', () => persistDraft(applyAsset(currentAsset())))
 
 function pointInCanvas(event) {
   const bounds = elements.canvas.getBoundingClientRect()
@@ -338,7 +359,7 @@ elements.canvas.addEventListener('pointermove', (event) => {
 const endDrag = (event) => {
   if (drag?.pointerId === event.pointerId) {
     drag = null
-    applyAsset(currentAsset())
+    persistDraft(applyAsset(currentAsset()))
   }
 }
 elements.canvas.addEventListener('pointerup', endDrag)
@@ -358,7 +379,7 @@ for (const part of elements.canvas.querySelectorAll('[data-part]')) {
     const step = event.shiftKey ? 5 : 1
     group.x.value = String(Number(group.x.value) + movement[0] * step)
     group.y.value = String(Number(group.y.value) + movement[1] * step)
-    applyAsset(currentAsset())
+    persistDraft(applyAsset(currentAsset()))
   })
 }
 
@@ -368,8 +389,8 @@ elements.fileInput.addEventListener('change', async () => {
   if (!file) return
   try {
     const asset = parseFaceAsset(await file.text())
-    applyAsset(asset)
-    setStatus(`「${asset.name}」を読み込みました。`, 'success')
+    const rendered = applyAsset(asset)
+    if (persistDraft(rendered)) setStatus(`「${asset.name}」を読み込みました。`, 'success')
   } catch (error) {
     setStatus(`Shape顔を読み込めませんでした: ${error.message}`, 'error')
   } finally {
@@ -378,8 +399,8 @@ elements.fileInput.addEventListener('change', async () => {
 })
 
 element('reset-face').addEventListener('click', () => {
-  applyAsset(createFaceAsset())
-  setStatus('標準のShape配置へ戻しました。', 'success')
+  const asset = applyAsset(createFaceAsset())
+  if (persistDraft(asset)) setStatus('標準のShape配置へ戻しました。', 'success')
 })
 
 element('download-face').addEventListener('click', () => {
@@ -396,11 +417,73 @@ element('download-face').addEventListener('click', () => {
   setStatus('Shape顔プロジェクトを保存しました。', 'success')
 })
 
-element('send-to-editor').addEventListener('click', () => {
+elements.sendToEditor.addEventListener('click', () => {
   const asset = render()
-  localStorage.setItem('stackchan-face-asset-staging', JSON.stringify(asset))
-  setStatus('Shape型Faceを保存しました。ブロックエディタを開きます。', 'success')
-  location.href = '../editor/?face-asset=staging'
+  try {
+    saveFaceDraft(asset)
+    stageFaceTransfer(asset, activeEditContext)
+    setStatus('Shape型Faceを保存しました。ブロックエディタを開きます。', 'success')
+    location.href = '../editor/?face-asset=staging'
+  } catch (error) {
+    setStatus(`ブロックエディタへ顔を渡せませんでした: ${error.message}`, 'error')
+  }
 })
 
-applyAsset(createFaceAsset())
+function loadInitialFace() {
+  const fromProject = new URLSearchParams(location.search).get('face-edit') === 'project'
+  if (fromProject) {
+    try {
+      const transfer = loadFaceEditContext()
+      if (!transfer?.edit) throw new TypeError('編集元の情報がありません')
+      activeEditContext = transfer.edit
+      return {
+        asset: transfer.asset,
+        message: `「${transfer.asset.name}」をMODプロジェクトから読み込みました。`,
+        state: 'success',
+      }
+    } catch (error) {
+      try {
+        const draft = loadFaceDraft()
+        if (draft) {
+          return {
+            asset: draft,
+            message: `MODの顔データを読み込めなかったため、下書きを復元しました: ${error.message}`,
+            state: 'error',
+          }
+        }
+      } catch {
+        // The original edit-context error is more useful than a secondary draft error.
+      }
+      return {
+        asset: createFaceAsset(),
+        message: `MODの顔データを読み込めなかったため、標準Faceを開きました: ${error.message}`,
+        state: 'error',
+      }
+    }
+  }
+
+  try {
+    clearFaceEditContext()
+  } catch {
+    // A stale context is ignored unless this page was explicitly opened for project editing.
+  }
+  try {
+    const draft = loadFaceDraft()
+    if (draft) return { asset: draft, message: '前回の下書きを復元しました。', state: 'success' }
+  } catch (error) {
+    return {
+      asset: createFaceAsset(),
+      message: `保存された下書きを読み込めなかったため、標準Faceを開きました: ${error.message}`,
+      state: 'error',
+    }
+  }
+  return { asset: createFaceAsset(), message: 'Shape型Faceを編集中です。', state: '' }
+}
+
+const initialFace = loadInitialFace()
+if (activeEditContext) {
+  elements.sendToEditorLabel.textContent = '変更を反映'
+  elements.sendToEditor.title = '変更をMODへ反映して戻る'
+}
+const initialAsset = applyAsset(initialFace.asset)
+if (persistDraft(initialAsset)) setStatus(initialFace.message, initialFace.state)

--- a/web/face-editor/face-editor.test.mjs
+++ b/web/face-editor/face-editor.test.mjs
@@ -4,9 +4,10 @@ import test from 'node:test'
 
 import { FACE_ASSET_EMOTIONS } from '../editor/face-assets.mjs'
 
-const [html, source, styles] = await Promise.all([
+const [html, source, storageSource, styles] = await Promise.all([
   readFile(new URL('./index.html', import.meta.url), 'utf8'),
   readFile(new URL('./face-editor.mjs', import.meta.url), 'utf8'),
+  readFile(new URL('./face-editor-storage.mjs', import.meta.url), 'utf8'),
   readFile(new URL('./face-editor.css', import.meta.url), 'utf8'),
 ])
 
@@ -54,7 +55,14 @@ test('Shape face editor exposes geometry, preview, persistence, and editor hando
   ]) {
     assert.match(html, new RegExp(`id="${id}"`))
   }
-  assert.match(source, /stackchan-face-asset-staging/)
+  assert.match(storageSource, /stackchan-face-asset-staging/)
+  assert.match(storageSource, /stackchan-face-editor-draft-v1/)
+  assert.match(source, /loadFaceEditContext/)
+  assert.match(source, /loadFaceDraft/)
+  assert.match(source, /saveFaceDraft/)
+  assert.match(source, /stageFaceTransfer\(asset, activeEditContext\)/)
+  assert.match(html, /id="send-to-editor"[\s\S]*?<span>MODで使う<\/span>/)
+  assert.match(source, /elements\.sendToEditorLabel\.textContent = '変更を反映'/)
   assert.match(source, /shapeFaceDefinition/)
   assert.match(source, /pointerdown/)
   assert.match(source, /ArrowLeft/)
@@ -81,6 +89,8 @@ test('Shape face editor exposes geometry, preview, persistence, and editor hando
   assert.match(styles, /aspect-ratio: 4 \/ 3/)
   assert.match(styles, /input\[readonly\]/)
   assert.match(styles, /\.toggle-control/)
+  assert.match(styles, /#download-face span\s*{\s*display: none;/)
+  assert.doesNotMatch(styles, /button:not\(\.icon-button\) span/)
   const emotionOptions = [...html.matchAll(/<option value="([A-Z]+)">/g)].map((match) => match[1])
   assert.deepEqual(emotionOptions, FACE_ASSET_EMOTIONS)
 })

--- a/web/face-editor/index.html
+++ b/web/face-editor/index.html
@@ -37,8 +37,8 @@
             <i data-lucide="rotate-ccw"></i>
           </button>
           <button id="download-face" type="button"><i data-lucide="download"></i><span>JSONを保存</span></button>
-          <button id="send-to-editor" class="primary-button" type="button">
-            <i data-lucide="blocks"></i><span>ブロックエディタで使う</span>
+          <button id="send-to-editor" class="primary-button" type="button" title="MODで使う">
+            <i data-lucide="blocks"></i><span>MODで使う</span>
           </button>
         </div>
       </header>

--- a/web/tool-navigation.mjs
+++ b/web/tool-navigation.mjs
@@ -61,6 +61,7 @@ export function navigationItemForPath(pathname) {
 function navigationLink(item, rootUrl, currentId) {
   const anchor = document.createElement('a')
   anchor.className = 'tool-drawer-link'
+  anchor.dataset.toolId = item.id
   anchor.href = new URL(item.href, rootUrl).href
   if (item.id === currentId) anchor.setAttribute('aria-current', 'page')
 

--- a/web/visual-pages-test.mjs
+++ b/web/visual-pages-test.mjs
@@ -282,6 +282,10 @@ try {
         await page.keyboard.press('Escape')
         await page.locator('#tool-drawer').waitFor({ state: 'hidden' })
       }
+      if (pageName === 'face-editor' && viewportName === 'mobile') {
+        assert.equal(await page.locator('#send-to-editor span').isVisible(), true)
+        assert.equal(await page.locator('#send-to-editor span').innerText(), 'MODで使う')
+      }
       if (pageName === 'face-editor' && viewportName === 'desktop') {
         assert.equal(await page.locator('#mouth-open').inputValue(), '0')
         assert.equal(await page.locator('#mouth-open-output').innerText(), '0.00')
@@ -394,6 +398,11 @@ try {
         const draggedLeftY = Number(await page.locator('#left-eye-y').inputValue())
         assert.equal(Math.abs(draggedLeftX - 70) <= 1, true)
         assert.equal(Math.abs(draggedLeftY - 45) <= 1, true)
+        await page.reload({ waitUntil: 'domcontentloaded' })
+        assert.equal(await page.locator('#face-name').inputValue(), 'あつい顔')
+        assert.equal(Number(await page.locator('#left-eye-x').inputValue()), draggedLeftX)
+        assert.equal(Number(await page.locator('#left-eye-y').inputValue()), draggedLeftY)
+        assert.match(await page.locator('#face-status').innerText(), /下書きを復元しました/)
         await page.screenshot({
           path: '/tmp/stackchan-face-editor-hot.png',
           fullPage: true,
@@ -421,11 +430,51 @@ try {
         assert.equal(await faceOptions.filter({ hasText: 'あつい顔' }).getAttribute('aria-checked'), 'true')
         await page.locator('.face-selection-option[data-face-asset=""]').click()
         assert.equal(await page.locator('#face-selection-label').innerText(), '標準Face')
+        assert.equal(await page.locator('#edit-face-button').isDisabled(), true)
         assert.doesNotMatch(await page.locator('#code-preview').innerText(), /_StackchanVisualShapeFace/)
         await page.locator('#face-selection-button').click()
         await faceOptions.filter({ hasText: 'あつい顔' }).click()
         assert.equal(await page.locator('#face-selection-label').innerText(), 'あつい顔')
+        assert.equal(await page.locator('#edit-face-button').isEnabled(), true)
         assert.match(await page.locator('#code-preview').innerText(), /_StackchanVisualShapeFace/)
+
+        await page.locator('#edit-face-button').click()
+        await page.waitForURL(/\/face-editor\/?\?face-edit=project/)
+        await page.goBack({ waitUntil: 'domcontentloaded' })
+        await page.waitForURL(/\/editor\/?$/)
+        assert.equal(await page.locator('#edit-face-button').isEnabled(), true)
+
+        await page.locator('.tool-menu-button').click()
+        await page.locator('#tool-drawer[open]').waitFor({ state: 'visible' })
+        await page.locator('.tool-drawer-link[data-tool-id="face-editor"]').click()
+        await page.waitForURL(/\/face-editor\/?\?face-edit=project/)
+        assert.equal(await page.locator('#face-name').inputValue(), 'あつい顔')
+        assert.equal(Number(await page.locator('#left-eye-x').inputValue()), draggedLeftX)
+        assert.equal(Number(await page.locator('#left-eye-y').inputValue()), draggedLeftY)
+        assert.match(await page.locator('#face-status').innerText(), /MODプロジェクトから読み込みました/)
+        assert.equal(await page.locator('#send-to-editor span').innerText(), '変更を反映')
+        await page.locator('#face-name').fill('編集後のあつい顔')
+        await page.locator('#face-emotion').selectOption('SAD')
+        await page.locator('#left-eye-x').fill('76')
+        await page.locator('#send-to-editor').click()
+        await page.waitForURL(/\/editor\/?\?face-asset=staging/)
+        await page.locator('#face-selection-label').filter({ hasText: '編集後のあつい顔' }).waitFor()
+        assert.equal(await page.locator('.asset-chip').count(), 1)
+        assert.match(await page.locator('#asset-summary').innerText(), /あつい顔\.stackchan-face\.json/)
+        assert.doesNotMatch(await page.locator('#asset-summary').innerText(), /編集後のあつい顔\.stackchan-face\.json/)
+        assert.match(await page.locator('#build-status').innerText(), /顔エディタの変更を反映しました/)
+        assert.match(await page.locator('#code-preview').innerText(), /new Eye\(\{ cx: 76/)
+        assert.match(await page.locator('#code-preview').innerText(), /setEmotion\(Emotion\.SAD\)/)
+        await page.locator('#face-selection-button').click()
+        assert.equal(await page.locator('.face-selection-option').count(), 2)
+        assert.equal(
+          await page
+            .locator('.face-selection-option')
+            .filter({ hasText: '編集後のあつい顔' })
+            .getAttribute('aria-checked'),
+          'true'
+        )
+        await page.keyboard.press('Escape')
         await page.screenshot({ path: '/tmp/stackchan-editor-face-selection.png', fullPage: true })
         await page.locator('#build-button').click()
         await page.waitForFunction(() => document.querySelector('#build-status')?.textContent.includes('ビルド成功'))

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -34,6 +34,7 @@ test('tool pages load the shared left drawer without changing integration ids', 
     assert.match(navigation, new RegExp(`id: '${id}'`), `drawer should expose ${id}`)
   }
   assert.match(navigation, /topbar\.prepend\(button\)/)
+  assert.match(navigation, /anchor\.dataset\.toolId = item\.id/)
   assert.match(navigation, /dialog\.showModal\(\)/)
   assert.match(navigation, /aria-current/)
 
@@ -65,6 +66,7 @@ test('tool pages load the shared left drawer without changing integration ids', 
     'face-selection-label',
     'face-selection-menu',
     'face-selection-list',
+    'edit-face-button',
   ]) {
     assert.match(editor, new RegExp(`id="${id}"`))
   }
@@ -92,6 +94,9 @@ test('tool pages load the shared left drawer without changing integration ids', 
   assert.match(editorScript, /setProjectMenuOpen/)
   assert.match(editorScript, /setRecentProjectsSubmenuOpen/)
   assert.match(editorScript, /renderFaceSelection/)
+  assert.match(editorScript, /saveFaceEditContext/)
+  assert.match(editorScript, /faceEditorNavigationLink\?\.addEventListener/)
+  assert.match(editorScript, /window\.addEventListener\('pageshow', renderFaceSelection\)/)
   assert.match(editorScript, /role', 'menuitemradio'/)
   assert.match(editorScript, /startProjectNameEdit/)
   assert.doesNotMatch(editorScript, /use\.textContent = selected \? '使用中' : '使う'/)


### PR DESCRIPTION
## Summary

- Preserve Shape Face drafts and explicit MOD project edit context across navigation.
- Add an edit action for the selected Face and make the MOD editor drawer open that same Face.
- Replace the original Face asset in place when applying edits, even if its display name changes.
- Restore the edit action after browser back navigation and keep the primary return label visible on mobile.

## Why

After creating a Face and sending it to the MOD editor, users had no reliable route back to edit that Face. Opening the Face editor from the side menu used the standalone route, so the active MOD Face was not carried over and could appear cleared or be replaced by an unrelated draft.

## Root cause

The original handoff stored only a one-way staged Face asset. It did not retain the source project ID or stable asset path, the shared drawer always used a static URL, and the edit button's disabled state could survive a back-forward cache restore.

## User impact

Users can now move from the Face editor to the MOD editor, reopen the selected Face from either the explicit edit button or the side menu, and apply changes back to the same asset without losing Face data.

## Validation

- `npm test`
- `npm run check:editor-artifacts`
- Prettier check and `git diff --check`
- Focused Chromium round-trip: create Face → use in MOD → edit → browser back → reopen from drawer → apply changes
- 390 px viewport check for the visible `MODで使う` / `変更を反映` action labels

## Known unrelated test issue

`npm run test:visual` still times out while waiting for the simulator iframe's `準備完了` state in `visual-pages-test.mjs`. The same failure was reproduced on the untouched `develop` worktree; the focused Face editor round-trip passes independently.