### PR TITLE
refactor(firmware): unify settings view factories

### DIFF
--- a/firmware/host/app/setup-mode.ts
+++ b/firmware/host/app/setup-mode.ts
@@ -171,7 +171,7 @@ export function startSetupMode(application: SettingsApplication): Promise<SetupM
 
     preferenceServer = new PreferenceServer({
       onPreferenceChanged: (key, value) => {
-        trace(`preference changed! ${key}: ${value}\n`)
+        trace(`preference changed! ${key}\n`)
         status[key] = value
         updateCurrentView()
       },

--- a/firmware/host/app/setup-mode.ts
+++ b/firmware/host/app/setup-mode.ts
@@ -6,18 +6,17 @@ import { PreferenceServer } from 'preference-server'
 import { createSettingsNetworkEntries, type RawWiFiScanResult, type SettingsNetworkEntry } from 'settings-network-list'
 import { createInitialSettingsStatus } from 'settings-status'
 import {
-  buildSettingsPasswordView,
-  buildSettingsView,
-  type SettingsStatusLabels,
+  type SettingsApplication,
   SettingsStatusValue,
-  updateSettingsNetworkLabels,
-  updateSettingsStatusLabels,
+  type SettingsViewContext,
+  SettingsViewId,
+  type SettingsViewInstance,
+  settingsViews,
 } from 'settings-view'
 import { connectStoredWiFi, stopStoredWiFiConnection } from 'stored-wifi'
 import { scanWiFiNetworks } from 'wifi-scan'
 import type { WiFiScanSession } from 'wifi-scan-types'
 
-type SetupApplication = Parameters<typeof buildSettingsView>[0]
 export type SetupModeResult = 'back' | 'boot'
 
 function settingsWifiStatusFromNetworkState(state: NetworkState): SettingsStatusValue {
@@ -41,44 +40,72 @@ function settingsWifiStatusFromNetworkState(state: NetworkState): SettingsStatus
   return SettingsStatusValue.NOT_CONNECTED
 }
 
-export function startSetupMode(application: SetupApplication): Promise<SetupModeResult> {
+export function startSetupMode(application: SettingsApplication): Promise<SetupModeResult> {
   return new Promise((resolve) => {
     const status = createInitialSettingsStatus(loadPreferenceConfig())
-    let labels: SettingsStatusLabels
+    const viewState = {
+      status,
+      networks: [] as SettingsNetworkEntry[],
+      selectedSSID: '',
+    }
+    let currentView: SettingsViewInstance | undefined
     let scanSession: WiFiScanSession | undefined
     let scanResults: RawWiFiScanResult[] = []
     let preferenceServer: PreferenceServer | undefined
     let finished = false
 
-    const finish = (result: SetupModeResult) => {
+    const viewContext: SettingsViewContext = {
+      state: viewState,
+      actions: {
+        exit: () => finish('back'),
+        boot: () => finish('boot'),
+        navigate: showView,
+        scanWifi: scanNetworks,
+        cancelWifiScan,
+        selectWifiNetwork: selectNetwork,
+        submitWifiPassword,
+      },
+    }
+
+    function finish(result: SetupModeResult) {
       if (finished) return
       finished = true
-      scanSession?.close()
-      scanSession = undefined
+      currentView?.dispose?.()
+      currentView = undefined
       preferenceServer?.close?.()
       if (result === 'back') stopStoredWiFiConnection()
       resolve(result)
     }
 
-    const showSettingsView = () => {
-      labels = buildSettingsView(application, status, {
-        onBack: () => finish('back'),
-        onBoot: () => finish('boot'),
-        onScan: scanNetworks,
-        onSelectNetwork: selectNetwork,
-      })
-      updateNetworkList()
+    function showView(id: SettingsViewId) {
+      currentView?.dispose?.()
+      const nextView = settingsViews[id].create(viewContext)
+      application.empty()
+      application.add(nextView.content)
+      currentView = nextView
+      currentView.update?.()
     }
 
-    const updateNetworkList = () => {
-      updateSettingsNetworkLabels(labels, createSettingsNetworkEntries(scanResults))
+    function updateCurrentView() {
+      currentView?.update?.()
     }
 
-    const scanNetworks = () => {
+    function updateNetworkList() {
+      viewState.networks = createSettingsNetworkEntries(scanResults)
+      updateCurrentView()
+    }
+
+    function cancelWifiScan() {
       scanSession?.close()
+      scanSession = undefined
+      if (status.wifi === SettingsStatusValue.SCANNING) status.wifi = SettingsStatusValue.NOT_CONNECTED
+    }
+
+    function scanNetworks() {
+      cancelWifiScan()
       scanResults = []
       status.wifi = SettingsStatusValue.SCANNING
-      updateSettingsStatusLabels(labels, status)
+      updateCurrentView()
       updateNetworkList()
       let scanFinished = false
       const nextScanSession = scanWiFiNetworks({
@@ -90,7 +117,7 @@ export function startSetupMode(application: SetupApplication): Promise<SetupMode
           scanFinished = true
           scanSession = undefined
           if (status.wifi === SettingsStatusValue.SCANNING) status.wifi = SettingsStatusValue.NOT_CONNECTED
-          updateSettingsStatusLabels(labels, status)
+          updateCurrentView()
           updateNetworkList()
         },
         onError: (message?: string) => {
@@ -98,27 +125,27 @@ export function startSetupMode(application: SetupApplication): Promise<SetupMode
           scanSession = undefined
           trace(`Wi-Fi scan failed${message ? `: ${message}` : ''}\n`)
           status.wifi = SettingsStatusValue.FAILED
-          updateSettingsStatusLabels(labels, status)
+          updateCurrentView()
         },
       })
       scanSession = scanFinished ? undefined : nextScanSession
     }
 
-    const selectNetwork = (network: SettingsNetworkEntry) => {
+    function selectNetwork(network: SettingsNetworkEntry) {
       status['wifi.ssid'] = network.ssid
+      viewState.selectedSSID = network.ssid
       Preference.set(DOMAIN.wifi, 'ssid', network.ssid)
-      buildSettingsPasswordView(application, network.ssid, {
-        onBack: showSettingsView,
-        onPassword: (password) => {
-          status['wifi.password'] = password
-          Preference.set(DOMAIN.wifi, 'password', password)
-          showSettingsView()
-          testConnection()
-        },
-      })
+      showView(SettingsViewId.PASSWORD)
     }
 
-    const testConnection = () => {
+    function submitWifiPassword(password: string) {
+      status['wifi.password'] = password
+      Preference.set(DOMAIN.wifi, 'password', password)
+      showView(SettingsViewId.WIFI)
+      testConnection()
+    }
+
+    function testConnection() {
       if (status['wifi.ssid'].length === 0 || status['wifi.password'].length === 0) return
       stopStoredWiFiConnection()
       connectStoredWiFi({
@@ -126,35 +153,35 @@ export function startSetupMode(application: SetupApplication): Promise<SetupMode
         password: status['wifi.password'],
         onStateChanged: (state: NetworkState) => {
           status.wifi = settingsWifiStatusFromNetworkState(state)
-          updateSettingsStatusLabels(labels, status)
+          updateCurrentView()
         },
         onConnected: () => {
           trace('connection complete\n')
           status.wifi = SettingsStatusValue.CONNECTED
-          updateSettingsStatusLabels(labels, status)
+          updateCurrentView()
         },
         onError: () => {
           trace('connection failed\n')
           status.wifi = SettingsStatusValue.FAILED
-          updateSettingsStatusLabels(labels, status)
+          updateCurrentView()
         },
       })
     }
-    showSettingsView()
+    showView(SettingsViewId.MENU)
 
     preferenceServer = new PreferenceServer({
       onPreferenceChanged: (key, value) => {
         trace(`preference changed! ${key}: ${value}\n`)
         status[key] = value
-        updateSettingsStatusLabels(labels, status)
+        updateCurrentView()
       },
       onConnected: () => {
         status.ble = SettingsStatusValue.CONNECTED
-        updateSettingsStatusLabels(labels, status)
+        updateCurrentView()
       },
       onDisconnected: () => {
         status.ble = SettingsStatusValue.NOT_CONNECTED
-        updateSettingsStatusLabels(labels, status)
+        updateCurrentView()
       },
       keys: PREF_KEYS,
     })

--- a/firmware/host/modules/ui/views/settings/__tests__/settings-view/settings-view.test.ts
+++ b/firmware/host/modules/ui/views/settings/__tests__/settings-view/settings-view.test.ts
@@ -1,101 +1,134 @@
+import type { Container as PiuContainer, Content as PiuContent } from 'piu/MC'
 import { Application } from 'piu/MC'
 import {
-  buildSettingsPasswordView,
-  buildSettingsView,
+  type SettingsStatus,
   SettingsStatusValue,
-  updateSettingsNetworkLabels,
-  updateSettingsStatusLabels,
+  type SettingsViewContext,
+  SettingsViewId,
+  type SettingsViewInstance,
+  settingsViews,
 } from 'settings-view'
 import { equal } from 'testing/assert'
 
 trace('=== settings-view test ===\n')
 
-let scanCount = 0
-let bootCount = 0
-let selectedSSID = ''
+type Touchable = PiuContent & {
+  active?: boolean
+  behavior: {
+    onTouchBegan: (content: unknown, id: number, x: number, y: number) => void
+    onTouchEnded: (content: unknown) => void
+  }
+}
+
+function press(content: Touchable) {
+  content.behavior.onTouchBegan(content, 0, 0, 0)
+  content.behavior.onTouchEnded(content)
+}
+
 const application = new Application(null, {
   displayListLength: 4096,
   contents: [],
 })
+const status: SettingsStatus = {
+  ble: SettingsStatusValue.READY,
+  wifi: SettingsStatusValue.NOT_CONNECTED,
+  'wifi.ssid': 'stackchan-ap',
+  'wifi.password': 'secret',
+}
+const state = {
+  status,
+  networks: [] as Array<{ ssid: string; signal: number; label: string }>,
+  selectedSSID: 'stackchan-ap',
+}
+let navigatedView = -1
+let exitCount = 0
+let scanCount = 0
+let cancelScanCount = 0
+let bootCount = 0
+let selectedSSID = ''
+let password = ''
 
-const labels = buildSettingsView(
-  application,
-  {
-    ble: SettingsStatusValue.READY,
-    wifi: SettingsStatusValue.NOT_CONNECTED,
-    'wifi.ssid': 'stackchan-ap',
-    'wifi.password': 'secret',
-  },
-  {
-    onBoot() {
+const context: SettingsViewContext = {
+  state,
+  actions: {
+    exit() {
+      exitCount += 1
+    },
+    boot() {
       bootCount += 1
     },
-    onScan() {
+    navigate(view) {
+      navigatedView = view
+    },
+    scanWifi() {
       scanCount += 1
     },
-    onSelectNetwork(network) {
+    cancelWifiScan() {
+      cancelScanCount += 1
+    },
+    selectWifiNetwork(network) {
       selectedSSID = network.ssid
     },
+    submitWifiPassword(value) {
+      password = value
+    },
   },
-)
-
-equal(application.length, 1, 'settings view should replace application contents')
-equal(labels.wifi.string, 'Wi-Fi: 未接続', 'Wi-Fi label should reflect status')
-const scanButton = labels.scan as unknown as {
-  behavior: {
-    onTouchBegan: (container: unknown, id: number, x: number, y: number) => void
-    onTouchEnded: (container: unknown) => void
-  }
 }
-scanButton.behavior.onTouchBegan(scanButton, 0, 0, 0)
-scanButton.behavior.onTouchEnded(scanButton)
+
+function mount(instance: SettingsViewInstance) {
+  application.empty()
+  application.add(instance.content)
+  instance.update?.()
+}
+
+equal(settingsViews.length, 3, 'settings registry should contain menu, Wi-Fi, and password views')
+
+const menuView = settingsViews[SettingsViewId.MENU].create(context)
+equal(application.length, 0, 'creating a settings view should not mount it')
+mount(menuView)
+const menuScroller = menuView.content.last as PiuContainer
+const menuItems = menuScroller.first as PiuContainer
+const wifiMenuItem = menuItems.first as Touchable
+press(wifiMenuItem)
+equal(navigatedView, SettingsViewId.WIFI, 'Wi-Fi menu item should navigate through the shared action')
+
+const menuHeader = menuView.content.first as PiuContainer
+press(menuHeader.first as Touchable)
+equal(exitCount, 1, 'settings menu back button should exit setup mode')
+
+const wifiView = settingsViews[SettingsViewId.WIFI].create(context)
+mount(wifiView)
+const wifiHeader = wifiView.content.first as PiuContent
+const wifiLabel = wifiHeader.next as PiuContent & { string?: string }
+equal(wifiLabel.string, 'Wi-Fi: 未接続', 'Wi-Fi label should reflect status')
+const scanButton = wifiLabel.next as Touchable
+press(scanButton)
 equal(scanCount, 1, 'pressing the visible scan action should request Wi-Fi scan')
 
-updateSettingsNetworkLabels(labels, [
+state.networks = [
   { ssid: 'stackchan-ap', signal: -42, label: 'stackchan-ap (-42 dBm)' },
   { ssid: 'guest-ap', signal: -76, label: 'guest-ap (-76 dBm)' },
-])
-equal(labels.networkState.networks.length, 2, 'network list should retain every scanned SSID for scroller rows')
-
-const list = labels.list as unknown as {
-  first: {
-    behavior: {
-      onTouchBegan: (port: unknown, id: number, x: number, y: number) => void
-      onTouchEnded: (port: unknown) => void
-    }
-  }
-}
-list.first.behavior.onTouchBegan(list.first, 0, 0, 0)
-list.first.behavior.onTouchEnded(list.first)
+]
+wifiView.update?.()
+const networkScroller = wifiView.content.last as PiuContainer
+const list = networkScroller.first as PiuContainer
+equal(list.length, 2, 'network list should retain every scanned SSID for scroller rows')
+press(list.first as Touchable)
 equal(selectedSSID, 'stackchan-ap', 'network row should select its SSID')
 
-updateSettingsStatusLabels(labels, {
-  ble: SettingsStatusValue.OFF,
-  wifi: SettingsStatusValue.CONNECTED,
-})
-
-equal(labels.wifi.string, 'Wi-Fi: 接続済み', 'Wi-Fi label should update')
-const bootButton = labels.boot as unknown as {
-  active: boolean
-  behavior: {
-    onTouchBegan: (container: unknown, id: number, x: number, y: number) => void
-    onTouchEnded: (container: unknown) => void
-  }
-}
+status.wifi = SettingsStatusValue.CONNECTED
+wifiView.update?.()
+equal(wifiLabel.string, 'Wi-Fi: 接続済み', 'Wi-Fi label should update')
+const bootButton = scanButton.next as Touchable
 equal(bootButton.active, true, 'connected settings should enable the boot action')
-bootButton.behavior.onTouchBegan(bootButton, 0, 0, 0)
-bootButton.behavior.onTouchEnded(bootButton)
+press(bootButton)
 equal(bootCount, 1, 'connected settings should continue to the main application')
+wifiView.dispose?.()
+equal(cancelScanCount, 1, 'leaving the Wi-Fi view should cancel an active scan through the shared action')
 
-let password = ''
-buildSettingsPasswordView(application, 'stackchan-ap', {
-  onPassword(value) {
-    password = value
-  },
-})
-
-equal(application.length, 1, 'password view should replace application contents')
-const passwordRoot = application.first as unknown as {
+const passwordView = settingsViews[SettingsViewId.PASSWORD].create(context)
+mount(passwordView)
+const passwordRoot = passwordView.content as unknown as {
   behavior: {
     onKeyboardOK: (container: unknown, value: string) => void
     onKeyboardTransitionFinished: (container: unknown, out: boolean) => void

--- a/firmware/host/modules/ui/views/settings/__tests__/settings-view/settings-view.test.ts
+++ b/firmware/host/modules/ui/views/settings/__tests__/settings-view/settings-view.test.ts
@@ -116,9 +116,11 @@ equal(list.length, 2, 'network list should retain every scanned SSID for scrolle
 press(list.first as Touchable)
 equal(selectedSSID, 'stackchan-ap', 'network row should select its SSID')
 
+const firstNetworkRow = list.first
 status.wifi = SettingsStatusValue.CONNECTED
 wifiView.update?.()
 equal(wifiLabel.string, 'Wi-Fi: 接続済み', 'Wi-Fi label should update')
+equal(list.first, firstNetworkRow, 'status-only updates should preserve existing network rows')
 const bootButton = scanButton.next as Touchable
 equal(bootButton.active, true, 'connected settings should enable the boot action')
 press(bootButton)

--- a/firmware/host/modules/ui/views/settings/settings-view.architecture.ts
+++ b/firmware/host/modules/ui/views/settings/settings-view.architecture.ts
@@ -12,12 +12,18 @@ test('default launch behavior reaches the settings screen only through setup-mod
   assert.doesNotMatch(launchSource, /from 'settings-view'/)
   assert.match(launchSource, /from 'setup-mode'/)
   assert.match(setupModeSource, /from 'settings-view'/)
+  assert.match(setupModeSource, /settingsViews\[id\]\.create\(viewContext\)/)
+  assert.doesNotMatch(setupModeSource, /buildSettings(?:Menu|Password|Wifi)?View/)
+  assert.doesNotMatch(setupModeSource, /SettingsStatusLabels/)
+  assert.doesNotMatch(setupModeSource, /updateSettings(?:Network|Status)/)
 
   // Piu view construction belongs to the view layer; on-launch orchestrates.
-  assert.doesNotMatch(launchSource, /new Container/)
-  assert.doesNotMatch(launchSource, /new Column/)
-  assert.doesNotMatch(launchSource, /new Label/)
-  assert.doesNotMatch(launchSource, /new Skin/)
-  assert.doesNotMatch(launchSource, /new Style/)
+  for (const source of [launchSource, setupModeSource]) {
+    assert.doesNotMatch(source, /new Container/)
+    assert.doesNotMatch(source, /new Column/)
+    assert.doesNotMatch(source, /new Label/)
+    assert.doesNotMatch(source, /new Skin/)
+    assert.doesNotMatch(source, /new Style/)
+  }
   assert.doesNotMatch(launchSource, /globalThis\.button/)
 })

--- a/firmware/host/modules/ui/views/settings/settings-view.ts
+++ b/firmware/host/modules/ui/views/settings/settings-view.ts
@@ -73,7 +73,7 @@ type SettingsWifiViewHandles = {
   boot: PiuContainer
   list: PiuColumn
   networkState: {
-    networks: SettingsNetworkEntry[]
+    networks: readonly SettingsNetworkEntry[]
   }
   context: SettingsViewContext
 }
@@ -310,6 +310,7 @@ function updateSettingsStatus(handles: SettingsWifiViewHandles, status: Settings
 }
 
 function updateSettingsNetworks(handles: SettingsWifiViewHandles, networks: readonly SettingsNetworkEntry[]) {
+  if (handles.networkState.networks === networks) return
   const styles = uiStyles()
   handles.list.empty()
   if (networks.length === 0) {
@@ -375,7 +376,7 @@ function updateSettingsNetworks(handles: SettingsWifiViewHandles, networks: read
       )
     }
   }
-  handles.networkState.networks = [...networks]
+  handles.networkState.networks = networks
 }
 
 const SettingsPasswordView = {

--- a/firmware/host/modules/ui/views/settings/settings-view.ts
+++ b/firmware/host/modules/ui/views/settings/settings-view.ts
@@ -27,7 +27,47 @@ export const settingsStatusToLabel = settingsStatusToLabelImpl
 export type SettingsStatusValue = SettingsStatusValueModel
 export type { SettingsStatus }
 
-export type SettingsStatusLabels = {
+export const SettingsViewId = Object.freeze({
+  MENU: 0,
+  WIFI: 1,
+  PASSWORD: 2,
+} as const)
+
+export type SettingsViewId = (typeof SettingsViewId)[keyof typeof SettingsViewId]
+export type SettingsApplication = PiuApplication
+
+export type SettingsViewState = Readonly<{
+  status: SettingsStatus
+  networks: readonly SettingsNetworkEntry[]
+  selectedSSID: string
+}>
+
+export type SettingsViewActions = Readonly<{
+  exit(): void
+  boot(): void
+  navigate(view: SettingsViewId): void
+  scanWifi(): void
+  cancelWifiScan(): void
+  selectWifiNetwork(network: SettingsNetworkEntry): void
+  submitWifiPassword(password: string): void
+}>
+
+export type SettingsViewContext = Readonly<{
+  state: SettingsViewState
+  actions: SettingsViewActions
+}>
+
+export type SettingsViewInstance = Readonly<{
+  content: PiuContainer
+  update?(): void
+  dispose?(): void
+}>
+
+export type SettingsViewDefinition = Readonly<{
+  create(context: SettingsViewContext): SettingsViewInstance
+}>
+
+type SettingsWifiViewHandles = {
   wifi: PiuContent & { string?: string }
   scan: PiuContainer
   boot: PiuContainer
@@ -35,19 +75,7 @@ export type SettingsStatusLabels = {
   networkState: {
     networks: SettingsNetworkEntry[]
   }
-  options: SettingsViewOptions
-}
-
-export type SettingsViewOptions = {
-  onBack?: () => void
-  onBoot?: () => void
-  onScan?: () => void
-  onSelectNetwork?: (network: SettingsNetworkEntry) => void
-}
-
-export type SettingsPasswordViewOptions = {
-  onBack?: () => void
-  onPassword?: (password: string) => void
+  context: SettingsViewContext
 }
 
 const STATUS_TOP = UI.headerHeight + 4
@@ -149,53 +177,101 @@ class VerticalScrollerBehavior extends Behavior {
 
 type NetworkRowData = {
   network: SettingsNetworkEntry
-  options: SettingsViewOptions
+  context: SettingsViewContext
   moved?: boolean
   startY?: number
 }
 
-export const buildSettingsView = (
-  application: PiuApplication,
-  status: SettingsStatus,
-  options: SettingsViewOptions = {},
-): SettingsStatusLabels => {
-  const styles = uiStyles()
-  const networkState = { networks: [] as SettingsNetworkEntry[] }
-  const scan = new ActionButton(
-    { icon: 'scan', label: 'スキャン', onTap: options.onScan },
-    { left: 8, top: ACTION_TOP, width: 148 },
-  )
-  const boot = new ActionButton(
-    { icon: 'play', label: '起動', onTap: options.onBoot, enabled: false, tone: 'success' },
-    { left: 164, top: ACTION_TOP, width: 148 },
-  )
-  const labels: SettingsStatusLabels = {
-    wifi: new Label(null, {
-      left: 12,
-      right: 12,
-      top: STATUS_TOP,
-      height: STATUS_HEIGHT,
-      style: styles.bodyMuted,
-    }),
-    scan,
-    boot,
-    list: new Column(null, { left: 0, width: UI.screenWidth, top: 0 }),
-    networkState,
-    options,
-  }
-
-  application.empty()
-  application.skin = styles.screen
-  application.add(
-    new Container(null, {
+const SettingsMenuView = {
+  create(context: SettingsViewContext): SettingsViewInstance {
+    const styles = uiStyles()
+    const content = new Container(null, {
       left: 0,
       right: 0,
       top: 0,
       bottom: 0,
       skin: styles.screen,
       contents: [
-        new ScreenHeader({ title: 'Wi-Fi設定', leading: 'back', onLeading: options.onBack }),
-        labels.wifi,
+        new ScreenHeader({ title: '設定', leading: 'back', onLeading: context.actions.exit }),
+        new Scroller(null, {
+          left: 0,
+          right: 0,
+          top: UI.headerHeight,
+          bottom: 0,
+          active: true,
+          backgroundTouch: true,
+          clip: true,
+          Behavior: VerticalScrollerBehavior,
+          contents: [
+            new Column(null, {
+              left: 0,
+              right: 0,
+              top: 0,
+              contents: [
+                new ActionButton(
+                  {
+                    icon: 'wifi',
+                    label: 'Wi-Fi設定',
+                    onTap: () => context.actions.navigate(SettingsViewId.WIFI),
+                  },
+                  { left: 8, right: 8 },
+                ),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+    return { content }
+  },
+} satisfies SettingsViewDefinition
+
+const SettingsWifiView = {
+  create(context: SettingsViewContext): SettingsViewInstance {
+    const styles = uiStyles()
+    const networkState = { networks: [] as SettingsNetworkEntry[] }
+    const scan = new ActionButton(
+      { icon: 'scan', label: 'スキャン', onTap: context.actions.scanWifi },
+      { left: 8, top: ACTION_TOP, width: 148 },
+    )
+    const boot = new ActionButton(
+      {
+        icon: 'play',
+        label: '起動',
+        onTap: context.actions.boot,
+        enabled: false,
+        tone: 'success',
+      },
+      { left: 164, top: ACTION_TOP, width: 148 },
+    )
+    const handles: SettingsWifiViewHandles = {
+      wifi: new Label(null, {
+        left: 12,
+        right: 12,
+        top: STATUS_TOP,
+        height: STATUS_HEIGHT,
+        style: styles.bodyMuted,
+      }),
+      scan,
+      boot,
+      list: new Column(null, { left: 0, width: UI.screenWidth, top: 0 }),
+      networkState,
+      context,
+    }
+
+    const content = new Container(null, {
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      skin: styles.screen,
+      contents: [
+        new ScreenHeader({
+          title: 'Wi-Fi設定',
+          leading: 'back',
+          onLeading: () => context.actions.navigate(SettingsViewId.MENU),
+        }),
+        handles.wifi,
         scan,
         boot,
         new Scroller(null, {
@@ -207,32 +283,37 @@ export const buildSettingsView = (
           backgroundTouch: true,
           clip: true,
           Behavior: VerticalScrollerBehavior,
-          contents: [labels.list],
+          contents: [handles.list],
         }),
       ],
-    }),
-  )
-  updateSettingsStatusLabels(labels, status)
-  updateSettingsNetworkLabels(labels, [])
-  return labels
-}
+    })
 
-export const updateSettingsStatusLabels = (labels: SettingsStatusLabels, status: SettingsStatus): void => {
-  labels.wifi.string = `Wi-Fi: ${settingsStatusToLabel(status.wifi)}`
+    return {
+      content,
+      update() {
+        updateSettingsStatus(handles, context.state.status)
+        updateSettingsNetworks(handles, context.state.networks)
+      },
+      dispose() {
+        context.actions.cancelWifiScan()
+      },
+    }
+  },
+} satisfies SettingsViewDefinition
+
+function updateSettingsStatus(handles: SettingsWifiViewHandles, status: SettingsStatus): void {
+  handles.wifi.string = `Wi-Fi: ${settingsStatusToLabel(status.wifi)}`
   const scanning = status.wifi === SettingsStatusValue.SCANNING
-  setActionButtonLabel(labels.scan, scanning ? 'スキャン中' : 'スキャン')
-  setActionButtonEnabled(labels.scan, !scanning)
-  setActionButtonEnabled(labels.boot, status.wifi === SettingsStatusValue.CONNECTED)
+  setActionButtonLabel(handles.scan, scanning ? 'スキャン中' : 'スキャン')
+  setActionButtonEnabled(handles.scan, !scanning)
+  setActionButtonEnabled(handles.boot, status.wifi === SettingsStatusValue.CONNECTED)
 }
 
-export const updateSettingsNetworkLabels = (
-  labels: SettingsStatusLabels,
-  networks: readonly SettingsNetworkEntry[],
-): void => {
+function updateSettingsNetworks(handles: SettingsWifiViewHandles, networks: readonly SettingsNetworkEntry[]) {
   const styles = uiStyles()
-  labels.list.empty()
+  handles.list.empty()
   if (networks.length === 0) {
-    labels.list.add(
+    handles.list.add(
       new Label(null, {
         left: 12,
         right: 12,
@@ -243,8 +324,8 @@ export const updateSettingsNetworkLabels = (
     )
   } else {
     for (const network of networks) {
-      const data: NetworkRowData = { network, options: labels.options }
-      labels.list.add(
+      const data: NetworkRowData = { network, context: handles.context }
+      handles.list.add(
         new Port(data, {
           left: 0,
           width: UI.screenWidth,
@@ -279,7 +360,7 @@ export const updateSettingsNetworkLabels = (
             onTouchEnded(port: PiuPort) {
               port.skin = null
               if (!this.data || this.data.moved) return
-              this.data.options.onSelectNetwork?.(this.data.network)
+              this.data.context.actions.selectWifiNetwork(this.data.network)
             }
 
             onDraw(port: PiuPort) {
@@ -294,26 +375,20 @@ export const updateSettingsNetworkLabels = (
       )
     }
   }
-  labels.networkState.networks = [...networks]
+  handles.networkState.networks = [...networks]
 }
 
-export const buildSettingsPasswordView = (
-  application: PiuApplication,
-  ssid: string,
-  options: SettingsPasswordViewOptions = {},
-): void => {
-  const styles = uiStyles()
-  const data: {
-    options: SettingsPasswordViewOptions
-    password?: string
-    FIELD?: { visible?: boolean }
-    KEYBOARD?: { add: (content: unknown) => void; length: number; first?: unknown }
-  } = { options }
+const SettingsPasswordView = {
+  create(context: SettingsViewContext): SettingsViewInstance {
+    const styles = uiStyles()
+    const data: {
+      context: SettingsViewContext
+      password?: string
+      FIELD?: { visible?: boolean }
+      KEYBOARD?: { add: (content: unknown) => void; length: number; first?: unknown }
+    } = { context }
 
-  application.empty()
-  application.skin = styles.screen
-  application.add(
-    new Container(data, {
+    const content = new Container(data, {
       left: 0,
       right: 0,
       top: 0,
@@ -327,13 +402,17 @@ export const buildSettingsPasswordView = (
           top: 0,
           height: PASSWORD_FIELD_TOP,
           contents: [
-            new ScreenHeader({ title: 'Wi-Fiパスワード', leading: 'back', onLeading: options.onBack }),
+            new ScreenHeader({
+              title: 'Wi-Fiパスワード',
+              leading: 'back',
+              onLeading: () => context.actions.navigate(SettingsViewId.WIFI),
+            }),
             new Label(null, {
               left: 12,
               right: 12,
               top: UI.headerHeight,
               height: PASSWORD_SSID_HEIGHT,
-              string: fitSSID(ssid),
+              string: fitSSID(context.state.selectedSSID),
               style: styles.bodyMuted,
             }),
           ],
@@ -389,13 +468,21 @@ export const buildSettingsPasswordView = (
 
         onKeyboardTransitionFinished(_container: PiuContainer, out: boolean) {
           if (!this.data) return
-          if (out) this.data.options.onPassword?.(this.data.password ?? '')
+          if (out) this.data.context.actions.submitWifiPassword(this.data.password ?? '')
           else if (this.data.FIELD) this.data.FIELD.visible = true
         }
       },
-    }),
-  )
-}
+    })
+
+    return { content }
+  },
+} satisfies SettingsViewDefinition
+
+export const settingsViews: readonly SettingsViewDefinition[] = [
+  SettingsMenuView,
+  SettingsWifiView,
+  SettingsPasswordView,
+]
 
 type SkinTemplate = PiuSkinConstructor & { new (): PiuSkin }
 type StyleTemplate = PiuStyleConstructor & { new (): PiuStyle }

--- a/web/simulator/visual-test.mjs
+++ b/web/simulator/visual-test.mjs
@@ -271,11 +271,22 @@ async function inspectViewport(page, name, width, height) {
       true,
       `keyboard bottom row must remain visible: ${JSON.stringify(passwordLayout)}`
     )
+    const passwordReadySignature = await screenSignature()
     await touchPiu(22, 20)
+    const wifiBackSignature = await waitForScreenChange(passwordReadySignature, 5_000)
+    assert.notEqual(wifiBackSignature, passwordReadySignature, 'password back action must open Wi-Fi settings')
     await touchPiu(22, 20)
+    const settingsMenuSignature = await waitForScreenChange(wifiBackSignature, 5_000)
+    assert.notEqual(settingsMenuSignature, wifiBackSignature, 'Wi-Fi back action must open the settings menu')
     await touchPiu(22, 20)
-    const mainSignature = await waitForScreenChange(splashSignature, 20000)
-    assert.notEqual(mainSignature, splashSignature, 'auto boot must open the main face')
+    const returnedSplashSignature = await waitForScreenChange(settingsMenuSignature, 5_000)
+    assert.notEqual(
+      returnedSplashSignature,
+      settingsMenuSignature,
+      'settings back action must return to the splash screen'
+    )
+    const mainSignature = await waitForScreenChange(returnedSplashSignature, 20_000)
+    assert.notEqual(mainSignature, returnedSplashSignature, 'auto boot must open the main face')
     const menuHiddenSignature = await waitForScreenChange(mainSignature, 6000)
     assert.notEqual(menuHiddenSignature, mainSignature, 'main menu must hide after auto boot')
     await page.screenshot({ path: '/tmp/stackchan-main.png', fullPage: true })

--- a/web/simulator/visual-test.mjs
+++ b/web/simulator/visual-test.mjs
@@ -220,9 +220,13 @@ async function inspectViewport(page, name, width, height) {
     assert.notEqual(settingsSignature, splashSignature, 'settings action must leave the splash screen')
     await page.screenshot({ path: '/tmp/stackchan-settings.png', fullPage: true })
     await savePiuScreen('settings')
+    await touchPiu(160, 66)
+    const wifiSettingsSignature = await waitForScreenChange(settingsSignature, 5_000)
+    assert.notEqual(wifiSettingsSignature, settingsSignature, 'Wi-Fi menu item must open network settings')
+    await savePiuScreen('wifi-settings')
     await touchPiu(82, 98)
-    const networkListSignature = await waitForScreenChange(settingsSignature, 10_000)
-    assert.notEqual(networkListSignature, settingsSignature, 'network settings must open the scanned network list')
+    const networkListSignature = await waitForScreenChange(wifiSettingsSignature, 10_000)
+    assert.notEqual(networkListSignature, wifiSettingsSignature, 'network settings must open the scanned network list')
     await savePiuScreen('network-list')
     await touchPiu(160, 146)
     const passwordSignature = await waitForScreenChange(networkListSignature, 5_000)
@@ -267,6 +271,7 @@ async function inspectViewport(page, name, width, height) {
       true,
       `keyboard bottom row must remain visible: ${JSON.stringify(passwordLayout)}`
     )
+    await touchPiu(22, 20)
     await touchPiu(22, 20)
     await touchPiu(22, 20)
     const mainSignature = await waitForScreenChange(splashSignature, 20000)
@@ -388,7 +393,7 @@ try {
   await inspectViewport(page, 'desktop', 1280, 800)
   await inspectViewport(page, 'mobile', 390, 844)
   console.log(
-    'visual checks passed: /tmp/stackchan-{desktop,mobile,settings,password,main,drawer,face-menu,dog-face,camera,camera-closed,sample-mod}.png and /tmp/stackchan-screen-{settings,network-list,password,main-menu-hidden,drawer,face-menu,dog-face,camera,camera-closed,sample-mod}.png'
+    'visual checks passed: /tmp/stackchan-{desktop,mobile,settings,password,main,drawer,face-menu,dog-face,camera,camera-closed,sample-mod}.png and /tmp/stackchan-screen-{settings,wifi-settings,network-list,password,main-menu-hidden,drawer,face-menu,dog-face,camera,camera-closed,sample-mod}.png'
   )
 } finally {
   await browser?.close()


### PR DESCRIPTION
## Summary

- expose a static settings view registry with a create(context) lifecycle aligned with the mini-app factory boundary
- add a top-level VerticalScroller settings menu and route Menu → Wi-Fi → Password through shared view actions
- keep Piu construction, view updates, and scan cleanup inside the settings view layer

## Motivation and scope

This prepares a consistent view factory boundary before the i18n work. The first menu contains only Wi-Fi settings; language selection, i18n resources, and a QR-code item remain out of scope for this PR.

## Validation

- npm test — 168 subtests / 176 tests passed
- npm run check:architecture — 59 tests passed
- STACKCHAN_MODULE_TEST_FILTER=settings-view STACKCHAN_MODULE_TEST_JOBS=1 npm run test:moddable — passed
- npx biome ci . --error-on-warnings — passed
- npm run check:legacy-names — passed
- npm run check:manifest — 6 targets passed
- STACKCHAN_LIN_XSBUG_PORT=5503 npm run smoke:lin — passed
- M5Stack debug build comparison — both this branch and unmodified develop reach the final link, then fail the existing factory-partition size check; develop overflows by 0x21dd0 and this branch by 0x225d0 (+0x800 / 2 KiB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Wi‑Fi setup flow with dedicated settings menu, network list (with live scanning), and password entry views.
  - Connection status updates are more consistent, including BLE connectivity where applicable.

- **Bug Fixes**
  - Leaving the Wi‑Fi view now properly cancels any active scan.
  - Setup mode exits/advances cleanly after booting, backing out, or finishing configuration.
  - Wi‑Fi SSID/password submission now reliably persists selections, tests the connection, and updates the UI accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->