### PR TITLE
fix: preserve Moddable version in firmware bundles

### DIFF
--- a/firmware/host/modules/audio/__tests__/web-radio-device/manifest.json
+++ b/firmware/host/modules/audio/__tests__/web-radio-device/manifest.json
@@ -20,7 +20,7 @@
   "platforms": {
     "esp32/m5stackchan_cores3": {
       "build": {
-        "SDKCONFIGPATH": "../../platforms/m5stackchan-cores3/sdkconfig"
+        "SDKCONFIGPATH ?=": "../../platforms/m5stackchan-cores3/sdkconfig"
       },
       "dependency": [
         {

--- a/firmware/host/modules/audio/__tests__/web-radio-player.test.ts
+++ b/firmware/host/modules/audio/__tests__/web-radio-player.test.ts
@@ -155,7 +155,7 @@ test('CoreS3 WebRadio receives into a shared ring and decodes MP3 on a Core 1 wo
   assert.match(manifest, /"buffered-mp3streamer": "\.\/platforms\/m5stackchan-cores3\/worker-mp3streamer"/)
   assert.match(manifest, /"buffered-mp3streamer-core": "\.\/platforms\/m5stackchan-cores3\/buffered-mp3streamer"/)
   assert.match(manifest, /"esp32-mp3-decoder": "\.\/platforms\/m5stackchan-cores3\/esp32-mp3-decoder"/)
-  assert.match(manifest, /"SDKCONFIGPATH": "\.\/platforms\/m5stackchan-cores3\/sdkconfig"/)
+  assert.match(manifest, /"SDKCONFIGPATH \?=": "\.\/platforms\/m5stackchan-cores3\/sdkconfig"/)
   assert.match(manifest, /"name": "esp_audio_codec"/)
   assert.match(manifest, /"version": "\^2\.6\.0"/)
   assert.doesNotMatch(manifest, /libmad-optimized|mp3-half-sample-rate/)

--- a/firmware/host/modules/audio/manifest.json
+++ b/firmware/host/modules/audio/manifest.json
@@ -124,7 +124,7 @@
         "../../../vendor/stackchan-voice/manifest.json"
       ],
       "build": {
-        "SDKCONFIGPATH": "./platforms/m5stackchan-cores3/sdkconfig"
+        "SDKCONFIGPATH ?=": "./platforms/m5stackchan-cores3/sdkconfig"
       },
       "modules": {
         "~": "./tts-stackchan-voice",

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/sdkconfig/sdkconfig.defaults
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/sdkconfig/sdkconfig.defaults
@@ -3,6 +3,12 @@ CONFIG_ESP_CONSOLE_UART=y
 CONFIG_ESP_CONSOLE_UART_NUM=0
 CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
 
+# The web editor reads this value from esp_app_desc before installing a MOD.
+# Pin it to the Moddable SDK used to build the host instead of letting ESP-IDF
+# infer a Git revision from the repository containing the output directory.
+CONFIG_APP_PROJECT_VER_FROM_CONFIG=y
+CONFIG_APP_PROJECT_VER="8.3.1"
+
 CONFIG_ESP_SYSTEM_PANIC_GDBSTUB=n
 CONFIG_ESP_COREDUMP_ENABLE_TO_UART=n
 CONFIG_ESP_COREDUMP_ENABLE=n

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/sdkconfig/sdkconfig.defaults
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/sdkconfig/sdkconfig.defaults
@@ -3,12 +3,8 @@ CONFIG_ESP_CONSOLE_UART=y
 CONFIG_ESP_CONSOLE_UART_NUM=0
 CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
 
-# The web editor reads this value from esp_app_desc before installing a MOD.
-# Host bundles require Moddable SDK 8.3.1; bundle.mjs checks that requirement
-# before building. Pin the same version here instead of letting ESP-IDF infer a
-# Git revision from the repository containing the output directory.
-CONFIG_APP_PROJECT_VER_FROM_CONFIG=y
-CONFIG_APP_PROJECT_VER="8.3.1"
+# The build wrappers append the actual $MODDABLE/tools/VERSION to a generated
+# copy of this file so the web editor can read it from esp_app_desc.
 
 CONFIG_ESP_SYSTEM_PANIC_GDBSTUB=n
 CONFIG_ESP_COREDUMP_ENABLE_TO_UART=n

--- a/firmware/host/modules/audio/platforms/m5stackchan-cores3/sdkconfig/sdkconfig.defaults
+++ b/firmware/host/modules/audio/platforms/m5stackchan-cores3/sdkconfig/sdkconfig.defaults
@@ -4,8 +4,9 @@ CONFIG_ESP_CONSOLE_UART_NUM=0
 CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
 
 # The web editor reads this value from esp_app_desc before installing a MOD.
-# Pin it to the Moddable SDK used to build the host instead of letting ESP-IDF
-# infer a Git revision from the repository containing the output directory.
+# Host bundles require Moddable SDK 8.3.1; bundle.mjs checks that requirement
+# before building. Pin the same version here instead of letting ESP-IDF infer a
+# Git revision from the repository containing the output directory.
 CONFIG_APP_PROJECT_VER_FROM_CONFIG=y
 CONFIG_APP_PROJECT_VER="8.3.1"
 

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -18,7 +18,7 @@
     "generate-speech-google": "cross-env GOOGLE_APPLICATION_CREDENTIALS=scripts/key.json node scripts/generate-speech-google.js",
     "generate-apidoc": "typedoc --entryPointStrategy expand --plugin typedoc-plugin-markdown --out docs/api ./host",
     "test": "npm run test:unit",
-    "test:unit": "rm -rf dist-tests && tsc --project tsconfig.test.json && node --test \"dist-tests/host/**/*.test.js\" scripts/lib/build-output.test.mjs scripts/lib/idf-dependencies.test.mjs",
+    "test:unit": "rm -rf dist-tests && tsc --project tsconfig.test.json && node --test \"dist-tests/host/**/*.test.js\" scripts/lib/build-output.test.mjs scripts/lib/idf-dependencies.test.mjs scripts/lib/moddable-version.test.mjs",
     "test:moddable": "node scripts/run-module-tests.js",
     "test:web-radio-device:build": "node scripts/run-mcconfig.mjs -d -m -p esp32:./host/platforms/m5stackchan_cores3 -t build \"$PWD/host/modules/audio/__tests__/web-radio-device/manifest.json\"",
     "test:web-radio-device:flash": "node scripts/run-mcconfig.mjs -d -m -p esp32:./host/platforms/m5stackchan_cores3 \"$PWD/host/modules/audio/__tests__/web-radio-device/manifest.json\"",

--- a/firmware/scripts/bundle.mjs
+++ b/firmware/scripts/bundle.mjs
@@ -26,12 +26,19 @@ const buildMode = 'release'
 const signature = 'stackchan.moddable.tech'
 const binaries = ['bootloader.bin', 'partition-table.bin', 'xs_esp32.bin']
 const bundleTargets = ['com.m5stack', 'com.m5stack.core2', 'com.m5stack.cores3', targetName]
+const requiredModdableVersion = '8.3.1'
 
 if (!process.env.MODDABLE) {
   console.error('[stack-chan] MODDABLE environment variable is required')
   process.exit(1)
 }
 const moddableVersion = readFileSync(path.join(process.env.MODDABLE, 'tools', 'VERSION'), 'utf8').trim()
+if (moddableVersion !== requiredModdableVersion) {
+  console.error(
+    `[stack-chan] Moddable SDK ${requiredModdableVersion} is required (found ${moddableVersion || 'missing'})`,
+  )
+  process.exit(1)
+}
 
 // mcbundle does not forward its -o option to the mcconfig processes it
 // generates, so its standard device builds intentionally remain under the

--- a/firmware/scripts/bundle.mjs
+++ b/firmware/scripts/bundle.mjs
@@ -11,6 +11,7 @@ import {
   moddableOutputArguments,
 } from './lib/build-output.mjs'
 import { prepareCoreS3IdfDependencies } from './lib/idf-dependencies.mjs'
+import { prepareCoreS3VersionSdkconfig } from './lib/moddable-version.mjs'
 
 const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url))
 const firmwareDirectory = path.resolve(scriptsDirectory, '..')
@@ -26,19 +27,19 @@ const buildMode = 'release'
 const signature = 'stackchan.moddable.tech'
 const binaries = ['bootloader.bin', 'partition-table.bin', 'xs_esp32.bin']
 const bundleTargets = ['com.m5stack', 'com.m5stack.core2', 'com.m5stack.cores3', targetName]
-const requiredModdableVersion = '8.3.1'
 
 if (!process.env.MODDABLE) {
   console.error('[stack-chan] MODDABLE environment variable is required')
   process.exit(1)
 }
-const moddableVersion = readFileSync(path.join(process.env.MODDABLE, 'tools', 'VERSION'), 'utf8').trim()
-if (moddableVersion !== requiredModdableVersion) {
-  console.error(
-    `[stack-chan] Moddable SDK ${requiredModdableVersion} is required (found ${moddableVersion || 'missing'})`,
-  )
+let versionSdkconfig
+try {
+  versionSdkconfig = prepareCoreS3VersionSdkconfig()
+} catch (error) {
+  console.error(`[stack-chan] CoreS3 firmware version could not be prepared: ${error.message}`)
   process.exit(1)
 }
+const moddableVersion = versionSdkconfig.version
 
 // mcbundle does not forward its -o option to the mcconfig processes it
 // generates, so its standard device builds intentionally remain under the
@@ -71,6 +72,7 @@ run(
     m5stackchanManifestPath,
   ],
   firmwareDirectory,
+  { ...process.env, SDKCONFIGPATH: versionSdkconfig.directory },
 )
 
 const buildDirectory = path.join(buildOutputDirectory, 'bin', 'esp32', targetName, buildMode, hostApplicationName)
@@ -187,9 +189,10 @@ function assertFirmwareVersion(directory, expectedVersion) {
  * @param {string} command - Executable name.
  * @param {string[]} args - Command-line arguments.
  * @param {string} cwd - Working directory for the subprocess.
+ * @param {NodeJS.ProcessEnv} env - Environment for the subprocess.
  */
-function run(command, args, cwd) {
-  const result = spawnSync(command, args, { cwd, stdio: 'inherit' })
+function run(command, args, cwd, env = process.env) {
+  const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' })
   if (result.error) {
     console.error(`[stack-chan] failed to run ${command}: ${result.error.message}`)
     process.exit(1)

--- a/firmware/scripts/bundle.mjs
+++ b/firmware/scripts/bundle.mjs
@@ -31,6 +31,7 @@ if (!process.env.MODDABLE) {
   console.error('[stack-chan] MODDABLE environment variable is required')
   process.exit(1)
 }
+const moddableVersion = readFileSync(path.join(process.env.MODDABLE, 'tools', 'VERSION'), 'utf8').trim()
 
 // mcbundle does not forward its -o option to the mcconfig processes it
 // generates, so its standard device builds intentionally remain under the
@@ -80,6 +81,7 @@ for (const bundleTarget of bundleTargets) {
   const directory = path.join(bundleDirectory, bundleTarget)
   for (const binary of binaries) assertNonEmpty(path.join(directory, binary))
   assertFitsFactoryPartition(directory)
+  assertFirmwareVersion(directory, moddableVersion)
 }
 
 rmSync(bundleZipPath, { force: true })
@@ -142,6 +144,35 @@ function assertFitsFactoryPartition(directory) {
   console.log(
     `[stack-chan] bundle target fits factory partition: ${path.basename(directory)} (${firmwareSize}/${factorySize} bytes)`,
   )
+}
+
+/**
+ * Ensures the ESP app descriptor exposes the Moddable SDK version used by the
+ * editor's MOD compatibility preflight. ESP-IDF otherwise falls back to the
+ * nearest repository's Git revision when builds use a repository-local output.
+ * @param {string} directory - Directory containing xs_esp32.bin.
+ * @param {string} expectedVersion - Moddable SDK version used for the build.
+ */
+function assertFirmwareVersion(directory, expectedVersion) {
+  const firmwarePath = path.join(directory, 'xs_esp32.bin')
+  const firmware = readFileSync(firmwarePath)
+  const descriptorMagic = 0xabcd5432
+  if (firmware.length < 0x70 || firmware.readUInt32LE(0x20) !== descriptorMagic) {
+    console.error(`[stack-chan] firmware app descriptor is missing: ${firmwarePath}`)
+    process.exit(1)
+  }
+
+  const nul = firmware.indexOf(0, 0x30)
+  const versionEnd = nul >= 0 && nul < 0x50 ? nul : 0x50
+  const actualVersion = firmware.toString('utf8', 0x30, versionEnd).trim()
+  if (actualVersion !== expectedVersion) {
+    console.error(
+      `[stack-chan] firmware version mismatch: ${firmwarePath} (${actualVersion || 'missing'} != ${expectedVersion})`,
+    )
+    process.exit(1)
+  }
+
+  console.log(`[stack-chan] bundle target firmware version: ${path.basename(directory)} (${actualVersion})`)
 }
 
 /**

--- a/firmware/scripts/firmware.mjs
+++ b/firmware/scripts/firmware.mjs
@@ -12,6 +12,7 @@ import {
 } from './lib/build-output.mjs'
 import { aliases, devices, resolveDevice } from './lib/devices.mjs'
 import { prepareCoreS3IdfDependencies } from './lib/idf-dependencies.mjs'
+import { prepareCoreS3VersionSdkconfig } from './lib/moddable-version.mjs'
 
 const command = process.argv[2]
 const rawArgs = process.argv.slice(3)
@@ -55,6 +56,7 @@ const manifest = readOption(rawArgs, 'manifest') ?? process.env.STACKCHAN_MANIFE
 const dryRun = process.env.STACKCHAN_DRY_RUN === '1'
 const { mode: buildMode, args: buildModeArgs } = readBuildConfiguration(rawArgs)
 const outputArgs = moddableOutputArguments()
+let subprocessEnvironment = process.env
 
 if (!dryRun && deviceName === 'm5stackchan_cores3' && command !== 'mod') {
   try {
@@ -66,6 +68,13 @@ if (!dryRun && deviceName === 'm5stackchan_cores3' && command !== 'mod') {
     })
   } catch (error) {
     console.error(`[stack-chan] IDF dependencies could not be prepared: ${error.message}`)
+    process.exit(1)
+  }
+  try {
+    const versionSdkconfig = prepareCoreS3VersionSdkconfig()
+    subprocessEnvironment = { ...process.env, SDKCONFIGPATH: versionSdkconfig.directory }
+  } catch (error) {
+    console.error(`[stack-chan] CoreS3 firmware version could not be prepared: ${error.message}`)
     process.exit(1)
   }
 }
@@ -143,7 +152,7 @@ function run(bin, binArgs, cwd = process.cwd()) {
   }
 
   ensureBuildOutputDirectory()
-  const result = spawnSync(bin, binArgs, { cwd, stdio: 'inherit' })
+  const result = spawnSync(bin, binArgs, { cwd, env: subprocessEnvironment, stdio: 'inherit' })
   if (result.error) {
     console.error(`[stack-chan] ${bin}を実行できませんでした: ${result.error.message}`)
     console.error('[stack-chan] npm run setup と npm run doctor を確認してください。')

--- a/firmware/scripts/lib/moddable-version.mjs
+++ b/firmware/scripts/lib/moddable-version.mjs
@@ -1,0 +1,88 @@
+import { Buffer } from 'node:buffer'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { buildOutputDirectory } from './build-output.mjs'
+
+const libraryDirectory = path.dirname(fileURLToPath(import.meta.url))
+export const coreS3SdkconfigSourceDirectory = path.resolve(
+  libraryDirectory,
+  '../../host/modules/audio/platforms/m5stackchan-cores3/sdkconfig',
+)
+
+/**
+ * Reads the Moddable SDK version that must be exposed through esp_app_desc.
+ * @param {string|undefined} moddableDirectory - Moddable SDK root.
+ * @returns {string} Validated SDK version.
+ */
+export function readModdableVersion(moddableDirectory = process.env.MODDABLE) {
+  if (!moddableDirectory) throw new Error('MODDABLE environment variable is required')
+  const versionPath = path.join(moddableDirectory, 'tools', 'VERSION')
+  let version
+  try {
+    version = readFileSync(versionPath, 'utf8').trim()
+  } catch (error) {
+    throw new Error(`Moddable SDK version could not be read: ${versionPath} (${error.message})`)
+  }
+  assertDescriptorVersion(version)
+  return version
+}
+
+/**
+ * Produces the CoreS3 sdkconfig overlay with the actual Moddable SDK version.
+ * @param {string} source - Base sdkconfig.defaults contents.
+ * @param {string} version - Moddable SDK version for esp_app_desc.
+ * @returns {string} Generated sdkconfig.defaults contents.
+ */
+export function renderCoreS3VersionSdkconfig(source, version) {
+  assertDescriptorVersion(version)
+  const base = source
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .filter((line) => !/^CONFIG_APP_PROJECT_VER(?:_FROM_CONFIG)?=/.test(line))
+    .join('\n')
+    .trimEnd()
+
+  return `${base}
+
+# Generated from $MODDABLE/tools/VERSION by scripts/lib/moddable-version.mjs.
+CONFIG_APP_PROJECT_VER_FROM_CONFIG=y
+CONFIG_APP_PROJECT_VER="${version}"
+`
+}
+
+/**
+ * Writes a generated CoreS3 sdkconfig directory for Moddable's SDKCONFIGPATH.
+ * @param {{moddableDirectory?: string, outputDirectory?: string, sourceDirectory?: string}} options - Generation inputs.
+ * @returns {{directory: string, filePath: string, version: string}} Generated configuration details.
+ */
+export function prepareCoreS3VersionSdkconfig({
+  moddableDirectory = process.env.MODDABLE,
+  outputDirectory = buildOutputDirectory,
+  sourceDirectory = coreS3SdkconfigSourceDirectory,
+} = {}) {
+  const version = readModdableVersion(moddableDirectory)
+  const sourcePath = path.join(sourceDirectory, 'sdkconfig.defaults')
+  const source = readFileSync(sourcePath, 'utf8')
+  const sdkconfig = renderCoreS3VersionSdkconfig(source, version)
+  const directory = path.join(outputDirectory, 'generated', 'sdkconfig', 'm5stackchan_cores3')
+  const filePath = path.join(directory, 'sdkconfig.defaults')
+
+  mkdirSync(directory, { recursive: true })
+  const previous = existsSync(filePath) ? readFileSync(filePath, 'utf8') : null
+  if (previous !== sdkconfig) writeFileSync(filePath, sdkconfig)
+
+  console.log(`[stack-chan] prepared CoreS3 firmware version ${version}: ${filePath}`)
+  return { directory, filePath, version }
+}
+
+/**
+ * Validates a version before embedding it in a quoted Kconfig value and the
+ * 32-byte esp_app_desc version field.
+ * @param {string} version - Candidate version.
+ */
+function assertDescriptorVersion(version) {
+  if (!/^[0-9A-Za-z][0-9A-Za-z.+-]*$/.test(version) || Buffer.byteLength(version, 'utf8') > 31) {
+    throw new Error(`Invalid Moddable SDK version for esp_app_desc: ${version || 'missing'}`)
+  }
+}

--- a/firmware/scripts/lib/moddable-version.test.mjs
+++ b/firmware/scripts/lib/moddable-version.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { test } from 'node:test'
+import {
+  prepareCoreS3VersionSdkconfig,
+  readModdableVersion,
+  renderCoreS3VersionSdkconfig,
+} from './moddable-version.mjs'
+
+test('renders the actual Moddable version without retaining a pinned value', () => {
+  const source = `CONFIG_ESP_CONSOLE_UART=y
+CONFIG_APP_PROJECT_VER_FROM_CONFIG=y
+CONFIG_APP_PROJECT_VER="8.3.1"
+CONFIG_SPIRAM=y
+`
+  const rendered = renderCoreS3VersionSdkconfig(source, '9.0.0')
+
+  assert.match(rendered, /CONFIG_ESP_CONSOLE_UART=y/)
+  assert.match(rendered, /CONFIG_SPIRAM=y/)
+  assert.equal(count(rendered, 'CONFIG_APP_PROJECT_VER_FROM_CONFIG=y'), 1)
+  assert.equal(count(rendered, 'CONFIG_APP_PROJECT_VER="9.0.0"'), 1)
+  assert.doesNotMatch(rendered, /CONFIG_APP_PROJECT_VER="8\.3\.1"/)
+})
+
+test('prepares an SDKCONFIGPATH directory from MODDABLE tools VERSION', () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), 'stackchan-moddable-version-'))
+  const moddableDirectory = path.join(fixture, 'moddable')
+  const sourceDirectory = path.join(fixture, 'source')
+  const outputDirectory = path.join(fixture, 'output')
+
+  try {
+    mkdirSync(path.join(moddableDirectory, 'tools'), { recursive: true })
+    mkdirSync(sourceDirectory, { recursive: true })
+    writeFileSync(path.join(moddableDirectory, 'tools', 'VERSION'), '9.0.0\n')
+    writeFileSync(path.join(sourceDirectory, 'sdkconfig.defaults'), 'CONFIG_SPIRAM=y\n')
+
+    const result = prepareCoreS3VersionSdkconfig({ moddableDirectory, outputDirectory, sourceDirectory })
+
+    assert.equal(result.version, '9.0.0')
+    assert.equal(result.directory, path.join(outputDirectory, 'generated', 'sdkconfig', 'm5stackchan_cores3'))
+    assert.match(readFileSync(result.filePath, 'utf8'), /CONFIG_APP_PROJECT_VER="9\.0\.0"/)
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('rejects missing and unsafe Moddable versions', () => {
+  assert.throws(() => readModdableVersion(''), /MODDABLE environment variable is required/)
+  assert.throws(() => renderCoreS3VersionSdkconfig('', '9.0.0"\nCONFIG_FOO=y'), /Invalid Moddable SDK version/)
+  assert.throws(() => renderCoreS3VersionSdkconfig('', 'v'.repeat(32)), /Invalid Moddable SDK version/)
+})
+
+function count(source, value) {
+  return source.split(value).length - 1
+}

--- a/firmware/scripts/run-mcconfig.mjs
+++ b/firmware/scripts/run-mcconfig.mjs
@@ -2,6 +2,7 @@
 
 import { spawnSync } from 'node:child_process'
 import { assertNoCustomBuildOutput, ensureBuildOutputDirectory, moddableOutputArguments } from './lib/build-output.mjs'
+import { prepareCoreS3VersionSdkconfig } from './lib/moddable-version.mjs'
 
 const args = process.argv.slice(2)
 
@@ -13,7 +14,20 @@ try {
 }
 
 ensureBuildOutputDirectory()
-const result = spawnSync('mcconfig', [...moddableOutputArguments(), ...args], { stdio: 'inherit' })
+let subprocessEnvironment = process.env
+if (targetsM5StackChanCoreS3(args)) {
+  try {
+    const versionSdkconfig = prepareCoreS3VersionSdkconfig()
+    subprocessEnvironment = { ...process.env, SDKCONFIGPATH: versionSdkconfig.directory }
+  } catch (error) {
+    console.error(`[stack-chan] CoreS3 firmware version could not be prepared: ${error.message}`)
+    process.exit(1)
+  }
+}
+const result = spawnSync('mcconfig', [...moddableOutputArguments(), ...args], {
+  env: subprocessEnvironment,
+  stdio: 'inherit',
+})
 
 if (result.error) {
   console.error(`[stack-chan] mcconfigを実行できませんでした: ${result.error.message}`)
@@ -21,3 +35,8 @@ if (result.error) {
 }
 
 process.exit(result.status ?? 1)
+
+function targetsM5StackChanCoreS3(values) {
+  const platformIndex = values.indexOf('-p')
+  return platformIndex >= 0 && values[platformIndex + 1]?.toLowerCase().includes('m5stackchan_cores3')
+}


### PR DESCRIPTION
## Summary

- derive the M5StackChan CoreS3 ESP app descriptor version from `$MODDABLE/tools/VERSION`
- generate a repository-local `sdkconfig.defaults` overlay and pass it through the supported CoreS3 build, flash, deploy, debug, device-test, and bundle wrappers
- validate every bundled firmware image against the actual Moddable SDK version

## Root cause

After build artifacts moved under `firmware/dist`, ESP-IDF inferred `PROJECT_VER` from the enclosing stack-chan Git repository. The web editor therefore read a stack-chan commit such as `2ea659b` instead of the Moddable SDK version and rejected MOD installation during its compatibility preflight.

## Impact

CoreS3 host firmware now exposes the SDK version it was actually built with. Firmware installed from the web Flash page can therefore be compared accurately with the editor's MOD toolchain, while bundle generation still fails if embedded metadata drifts from `$MODDABLE/tools/VERSION`.

## Validation

- firmware unit tests, including generation with a synthetic Moddable `9.0.0` VERSION
- `npm run build:m5stackchan_cores3 -- --mode=release`
- parsed the generated `xs_esp32.bin` app descriptor: `{ version: '8.3.1', projectName: 'xs_esp32' }`
- confirmed generated and effective sdkconfig values use `CONFIG_APP_PROJECT_VER="8.3.1"`
- Biome and `git diff --check`
