### PR TITLE
fix: enforce platform-specific servo driver settings

### DIFF
--- a/firmware/docs/flashing-firmware.md
+++ b/firmware/docs/flashing-firmware.md
@@ -28,7 +28,7 @@ StackChan can change settings such as motor types and pin assignments from the m
 
 | Key               | Description                                                                | Available values                     |
 | ----------------- | -------------------------------------------------------------------------- | ------------------------------------ |
-| driver.type       | Type of motor driver                                                       | "scservo", "rs30x", "pwm", "none", "dynamixel"    |
+| driver.type       | Type of motor driver                                                       | "m5stackchan", "scservo", "rs30x", "pwm", "none", "dynamixel"    |
 | driver.panId      | ID of the serial servo used for pan axis (horizontal rotation of the neck) | 1~254                                |
 | driver.tiltId     | ID of the serial servo used for tilt axis (vertical rotation of the neck)  | 1~254                                |
 | driver.offsetPan  | Offset of the pan axis                                                     | -90~90                               |
@@ -134,6 +134,8 @@ The board-specific driver type and servo bus pins live in each subplatform manif
 - M5StackChan CoreS3: [`host/platforms/m5stackchan_cores3/manifest.json`](../host/platforms/m5stackchan_cores3/manifest.json) — `m5stackchan` driver, serial TX6 / RX7.
 - Stack-chan RT: [`host/platforms/stackchan_rt/manifest.json`](../host/platforms/stackchan_rt/manifest.json) — `dynamixel` driver, serial TX7 / RX6.
 - Takao Core2 + SG90: [`host/platforms/takao_core2_sg90/manifest.json`](../host/platforms/takao_core2_sg90/manifest.json) — `pwm` driver, pan PWM19 / tilt PWM27.
+
+The `m5stackchan` driver adds M5StackChan-specific zero positions, motion limits, and PY32 servo-power control on top of the SCServo protocol. For safety, M5StackChan CoreS3 firmware locks the driver type to `m5stackchan`, while Stack-chan RT firmware locks it to `dynamixel`. Both ignore a different stored `driver.type`.
 
 Put per-device settings such as Wi-Fi credentials and API keys in the board's app manifest under `"config"`. Keep secrets out of commits and add them locally only. On boot, the log line `[dynamixel] serial port=1 tx=7 rx=6 baud=1000000` shows the RT serial pins actually in use.
 

--- a/firmware/docs/flashing-firmware_ja.md
+++ b/firmware/docs/flashing-firmware_ja.md
@@ -34,7 +34,7 @@ MOD がインストールされている場合、製品既定動作は実行さ�
 
 | キー              | 説明                                            | 使用可能な値                                |
 | ----------------- | ----------------------------------------------- | ------------------------------------------- |
-| driver.type       | モータドライバの種類                            | "scservo", "rs30x", "pwm", "none", "dynamixel"           |
+| driver.type       | モータドライバの種類                            | "m5stackchan", "scservo", "rs30x", "pwm", "none", "dynamixel"           |
 | driver.panId      | パン軸（首の横回転）に使うシリアルサーボの ID   | 1~254                                       |
 | driver.tiltId     | チルト軸（首の縦回転）に使うシリアルサーボの ID | 1~254                                       |
 | driver.offsetPan  | パン軸のオフセット                              | -90~90                                      |
@@ -141,6 +141,8 @@ Stack-chan の各ハードウェア構成は、サーボの driver 種別とバ�
 - M5StackChan CoreS3: [`host/platforms/m5stackchan_cores3/manifest.json`](../host/platforms/m5stackchan_cores3/manifest.json) — `m5stackchan` driver、シリアル TX6 / RX7。
 - Stack-chan RT: [`host/platforms/stackchan_rt/manifest.json`](../host/platforms/stackchan_rt/manifest.json) — `dynamixel` driver、シリアル TX7 / RX6。
 - タカオ版 Core2 + SG90: [`host/platforms/takao_core2_sg90/manifest.json`](../host/platforms/takao_core2_sg90/manifest.json) — `pwm` driver、pan PWM19 / tilt PWM27。
+
+`m5stackchan` driver は SCServo プロトコルに加えて、M5StackChan 専用のゼロ位置、可動域、PY32 サーボ電源制御を提供します。安全のため、M5StackChan CoreS3 用ファームウェアは driver 種別を `m5stackchan` に、Stack-chan RT 用ファームウェアは `dynamixel` に固定します。どちらも保存済みの異なる `driver.type` は無視します。
 
 Wi-Fi 認証情報や API キーなどのデバイス固有の設定は、各ボードのアプリ manifest の `"config"` 配下に書いてください。秘密情報はコミットせず、ローカルにのみ追加してください。起動時のログ `[dynamixel] serial port=1 tx=7 rx=6 baud=1000000` で RT が実際に使うシリアルピンを確認できます。
 

--- a/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
+++ b/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
@@ -180,15 +180,18 @@ touchPanel.onEvent?.({ gesture: 'backwardSwipe', position: 0.75, intensity: 3, t
 equal(emotions[emotions.length - 1], Emotion.HAPPY, 'petting swipe pair should set HAPPY emotion')
 assert(effects.length > 0, 'petting should add a visible emotion effect')
 
-const drawerCloseCountBeforeSpeech = drawerCloseCount
-Promise.resolve(speakButton?.callback?.(robot)).then(
-  async () => {
-    equal(speechRequests.length, 1, 'speakStackchan should request one utterance')
-    equal(speechRequests[0], 'こんにちわ。すたっくちゃんです。', 'speakStackchan should request its greeting')
-    equal(drawerCloseCount - drawerCloseCountBeforeSpeech, 1, 'speakStackchan should close the drawer before speaking')
+async function testSpeakStackchan() {
+  const drawerCloseCountBeforeSpeech = drawerCloseCount
+  await speakButton?.callback?.(robot)
+  equal(speechRequests.length, 1, 'speakStackchan should request one utterance')
+  equal(speechRequests[0], 'こんにちわ。すたっくちゃんです。', 'speakStackchan should request its greeting')
+  equal(drawerCloseCount - drawerCloseCountBeforeSpeech, 1, 'speakStackchan should close the drawer before speaking')
+}
 
-    const servoButton = buttons.find((button) => button.key === 'servoTest')
-    assert(servoButton, 'servoTest button should be registered')
+async function testServoRecovery() {
+  const servoButton = buttons.find((button) => button.key === 'servoTest')
+  assert(servoButton, 'servoTest button should be registered')
+  try {
     servoFailure = new Error('servo unavailable')
     await servoButton.callback?.(robot)
     assert(balloonMessages.includes('servo error'), 'servo failures should be visible instead of aborting the runtime')
@@ -196,11 +199,18 @@ Promise.resolve(speakButton?.callback?.(robot)).then(
 
     await servoButton.callback?.(robot)
     assert(torqueRequests.length > requestsAfterFirstFailure, 'servo failure should release the moving guard for retry')
+  } finally {
     servoFailure = undefined
-    trace('ok\n')
-  },
-  (error) => {
-    trace(`speakStackchan callback error: ${String(error)}\n`)
-    throw error
-  },
-)
+  }
+}
+
+async function runAsyncTests() {
+  await testSpeakStackchan()
+  await testServoRecovery()
+  trace('ok\n')
+}
+
+runAsyncTests().catch((error) => {
+  trace(`default behavior async test error: ${String(error)}\n`)
+  throw error
+})

--- a/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
+++ b/firmware/host/app/default-behavior/__tests__/face-init/face-init.test.ts
@@ -23,6 +23,9 @@ const faces: unknown[] = []
 const selectedHandAnimations: string[] = []
 const colors: [string, number, number, number][] = []
 const speechRequests: string[] = []
+const balloonMessages: string[] = []
+const torqueRequests: boolean[] = []
+let servoFailure: Error | undefined
 let drawerCloseCount = 0
 const touchPanel: {
   onEvent?: (event: {
@@ -86,9 +89,14 @@ const robot = {
   },
   lookAway: () => {},
   lookAt: () => {},
-  setPose: () => Promise.resolve(),
-  setTorque: () => Promise.resolve(),
-  showBalloon: () => {},
+  setPose: () => (servoFailure ? Promise.reject(servoFailure) : Promise.resolve()),
+  setTorque: (enabled: boolean) => {
+    torqueRequests.push(enabled)
+    return servoFailure ? Promise.reject(servoFailure) : Promise.resolve()
+  },
+  showBalloon: (message: string) => {
+    balloonMessages.push(message)
+  },
   hideBalloon: () => {},
   setEmotion: (emotion: unknown) => {
     emotions.push(emotion)
@@ -174,10 +182,21 @@ assert(effects.length > 0, 'petting should add a visible emotion effect')
 
 const drawerCloseCountBeforeSpeech = drawerCloseCount
 Promise.resolve(speakButton?.callback?.(robot)).then(
-  () => {
+  async () => {
     equal(speechRequests.length, 1, 'speakStackchan should request one utterance')
     equal(speechRequests[0], 'こんにちわ。すたっくちゃんです。', 'speakStackchan should request its greeting')
     equal(drawerCloseCount - drawerCloseCountBeforeSpeech, 1, 'speakStackchan should close the drawer before speaking')
+
+    const servoButton = buttons.find((button) => button.key === 'servoTest')
+    assert(servoButton, 'servoTest button should be registered')
+    servoFailure = new Error('servo unavailable')
+    await servoButton.callback?.(robot)
+    assert(balloonMessages.includes('servo error'), 'servo failures should be visible instead of aborting the runtime')
+    const requestsAfterFirstFailure = torqueRequests.length
+
+    await servoButton.callback?.(robot)
+    assert(torqueRequests.length > requestsAfterFirstFailure, 'servo failure should release the moving guard for retry')
+    servoFailure = undefined
     trace('ok\n')
   },
   (error) => {

--- a/firmware/host/app/default-behavior/on-context-created.ts
+++ b/firmware/host/app/default-behavior/on-context-created.ts
@@ -396,42 +396,52 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
   /**
    * Servo test (Drawer action)
    */
-  const testMotion = (onComplete: () => void) => {
-    robot.showBalloon('moving...')
-    void robot.setTorque(true)
-
-    const rotations = [LEFT, RIGHT, DOWN, UP, FORWARD]
-    let index = 0
-    const step = () => {
-      const rot = rotations[index]
-      if (!rot) {
-        void robot.setTorque(false)
-        robot.hideBalloon()
-        onComplete()
-        return
-      }
-      void robot.setPose(poseForRotation(rot))
-      index += 1
-      Timer.set(step, 1000)
-    }
-    step()
-  }
   let isMoving = false
-  const runServoTest = () => {
+  const runServoTest = async () => {
     if (isMoving) return
-    isFollowing = false
-    robot.lookAway()
-    robot.drawer.setDrawerButtonState('toggleLookAround', false)
     isMoving = true
-    testMotion(() => {
+    let failed = false
+    const rotations = [LEFT, RIGHT, DOWN, UP, FORWARD]
+    try {
+      isFollowing = false
+      robot.lookAway()
+      robot.drawer.setDrawerButtonState('toggleLookAround', false)
+      robot.showBalloon('moving...')
+      await robot.setTorque(true)
+      for (const rotation of rotations) {
+        await robot.setPose(poseForRotation(rotation))
+        await wait(1000)
+      }
+    } catch (error) {
+      failed = true
+      trace(`[ServoTest] motion error ${errorMessage(error)}\n`)
+      robot.showBalloon('servo error')
+    } finally {
+      try {
+        await robot.setTorque(false)
+      } catch (error) {
+        failed = true
+        trace(`[ServoTest] torque release error ${errorMessage(error)}\n`)
+        robot.showBalloon('servo error')
+      }
       isMoving = false
-    })
+      if (failed) {
+        Timer.set(() => robot.hideBalloon(), 1200)
+      } else {
+        robot.hideBalloon()
+      }
+    }
   }
+  const startServoTest = () =>
+    runServoTest().catch((error) => {
+      isMoving = false
+      trace(`[ServoTest] unexpected error ${errorMessage(error)}\n`)
+    })
   robot.drawer.addDrawerButton({
     key: 'servoTest',
     label: 'サーボ',
     icon: 'play',
-    callback: runServoTest,
+    callback: startServoTest,
   })
 
   /**
@@ -601,7 +611,7 @@ export const onContextCreated: NonNullable<StackchanAppBehavior['onContextCreate
         if (!event.pressed) {
           return
         }
-        void runServoTest()
+        void startServoTest()
       }
     }
     if (robot.button.c != null) {

--- a/firmware/host/app/setup-mode.ts
+++ b/firmware/host/app/setup-mode.ts
@@ -42,7 +42,14 @@ function settingsWifiStatusFromNetworkState(state: NetworkState): SettingsStatus
 
 export function startSetupMode(application: SettingsApplication): Promise<SetupModeResult> {
   return new Promise((resolve) => {
-    const status = createInitialSettingsStatus(loadPreferenceConfig())
+    const preferences = loadPreferenceConfig()
+    const status = createInitialSettingsStatus(preferences)
+    const effectiveValues = Object.fromEntries(
+      PREF_KEYS.flatMap(([domain, key]) => {
+        const value = preferences[domain]?.[key]
+        return value == null ? [] : [[`${domain}.${key}`, value]]
+      }),
+    )
     const viewState = {
       status,
       networks: [] as SettingsNetworkEntry[],
@@ -194,6 +201,8 @@ export function startSetupMode(application: SettingsApplication): Promise<SetupM
         updateCurrentView()
       },
       keys: PREF_KEYS,
+      effectiveValues,
+      readOnlyKeys: preferences.driver.typeLocked === true ? ['driver.type'] : [],
     })
   })
 }

--- a/firmware/host/modules/connectivity/__tests__/fakes/uartserver.ts
+++ b/firmware/host/modules/connectivity/__tests__/fakes/uartserver.ts
@@ -1,0 +1,14 @@
+export const SERVICE_UUID = 'test-service'
+
+export class UARTServer {
+  deviceName = ''
+  notifications: { characteristic: unknown; value: ArrayBuffer }[] = []
+
+  onConnected(): void {}
+
+  startAdvertising(_options: unknown): void {}
+
+  notifyValue(characteristic: unknown, value: ArrayBuffer): void {
+    this.notifications.push({ characteristic, value })
+  }
+}

--- a/firmware/host/modules/connectivity/__tests__/preference-server.test.ts
+++ b/firmware/host/modules/connectivity/__tests__/preference-server.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { writeAliasPackage } from '../../testing/node-alias-package.js'
+import { DOMAIN, PREF_KEYS } from '../../preferences/consts.js'
+
+type FakePreference = {
+  resetPreference(values?: Record<string, unknown>): void
+  default: {
+    get(domain: string, name: string): unknown
+  }
+}
+
+type TestPreferenceServer = {
+  notifications: { value: ArrayBuffer }[]
+  onCharacteristicNotifyEnabled(characteristic: { name: string }): void
+  receiveAndSetPreference(domain: string, key: string, value: string): void
+}
+
+function installBareSpecifierPackages(): void {
+  const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+  writeAliasPackage(modulesRoot, 'consts', resolve(modulesRoot, 'preferences/consts.js'))
+  writeAliasPackage(modulesRoot, 'preference', resolve(modulesRoot, 'testing/fakes/preference.js'), {
+    hasDefaultExport: true,
+  })
+  writeAliasPackage(modulesRoot, 'timer', resolve(modulesRoot, 'testing/fakes/timer.js'), {
+    hasDefaultExport: true,
+  })
+  writeAliasPackage(modulesRoot, 'uartserver', resolve(modulesRoot, 'connectivity/__tests__/fakes/uartserver.js'))
+}
+
+async function setup() {
+  installBareSpecifierPackages()
+  const arrayBufferConstructor = ArrayBuffer as typeof ArrayBuffer & {
+    fromString(value: string): ArrayBuffer
+  }
+  arrayBufferConstructor.fromString = (value) => new TextEncoder().encode(value).buffer as ArrayBuffer
+  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = () => {}
+
+  const [preference, preferenceServer] = await Promise.all([
+    import('../../testing/fakes/preference.js') as Promise<FakePreference>,
+    import('../preference-server.js'),
+  ])
+  preference.resetPreference()
+  return { PreferenceServer: preferenceServer.PreferenceServer, preference }
+}
+
+function notificationPayload(server: TestPreferenceServer, index = 0): Record<string, unknown> {
+  return JSON.parse(new TextDecoder().decode(server.notifications[index]?.value))
+}
+
+test('read-only driver type publishes the platform value and rejects BLE overrides', async () => {
+  const { PreferenceServer, preference } = await setup()
+  preference.resetPreference({ 'driver.type': 'scservo' })
+  const server = new PreferenceServer({
+    keys: PREF_KEYS,
+    effectiveValues: { 'driver.type': 'm5stackchan' },
+    readOnlyKeys: ['driver.type'],
+  }) as TestPreferenceServer
+
+  server.onCharacteristicNotifyEnabled({ name: 'tx' })
+  assert.deepEqual(notificationPayload(server), {
+    prop: 'driver.type',
+    value: 'm5stackchan',
+    readOnly: true,
+  })
+
+  server.receiveAndSetPreference(DOMAIN.driver, 'type', 'dynamixel')
+  assert.equal(preference.default.get(DOMAIN.driver, 'type'), 'scservo')
+  assert.deepEqual(notificationPayload(server, 1), {
+    prop: 'driver.type',
+    value: 'm5stackchan',
+    readOnly: true,
+  })
+})
+
+test('unlocked driver type remains writable for other platforms', async () => {
+  const { PreferenceServer, preference } = await setup()
+  const server = new PreferenceServer({
+    keys: PREF_KEYS,
+    effectiveValues: { 'driver.type': 'm5stackchan' },
+  }) as TestPreferenceServer
+
+  server.onCharacteristicNotifyEnabled({ name: 'tx' })
+  server.receiveAndSetPreference(DOMAIN.driver, 'type', 'scservo')
+
+  assert.equal(preference.default.get(DOMAIN.driver, 'type'), 'scservo')
+  assert.deepEqual(notificationPayload(server, 1), { prop: 'driver.type', value: 'scservo' })
+})

--- a/firmware/host/modules/connectivity/__tests__/preference-server.test.ts
+++ b/firmware/host/modules/connectivity/__tests__/preference-server.test.ts
@@ -3,8 +3,8 @@ import { dirname, resolve } from 'node:path'
 import { test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-import { writeAliasPackage } from '../../testing/node-alias-package.js'
 import { DOMAIN, PREF_KEYS } from '../../preferences/consts.js'
+import { writeAliasPackage } from '../../testing/node-alias-package.js'
 
 type FakePreference = {
   resetPreference(values?: Record<string, unknown>): void

--- a/firmware/host/modules/connectivity/preference-server.ts
+++ b/firmware/host/modules/connectivity/preference-server.ts
@@ -10,10 +10,14 @@ type PreferenceServerProps = {
   onConnected?: () => void
   onDisconnected?: () => void
   keys?: typeof PREF_KEYS
+  effectiveValues?: Readonly<Record<string, PreferenceValue>>
+  readOnlyKeys?: readonly string[]
 }
 export class PreferenceServer extends UARTServer {
   #tx_characteristic
   #keys
+  #effectiveValues
+  #readOnlyKeys
   #rxBuffer = ''
   #timeout
   #handlePreferenceChanged?: (key: string, value: PreferenceValue) => void
@@ -28,6 +32,8 @@ export class PreferenceServer extends UARTServer {
       this.#handleDisconnected = option.onDisconnected
     }
     this.#keys = Array.isArray(option.keys) ? option.keys.slice() : []
+    this.#effectiveValues = option?.effectiveValues ?? {}
+    this.#readOnlyKeys = option?.readOnlyKeys ?? []
   }
   onConnected() {
     super.onConnected()
@@ -48,9 +54,13 @@ export class PreferenceServer extends UARTServer {
       this.#tx_characteristic = characteristic
       for (const item of this.#keys) {
         const [domain, key] = item
-        const currentValue = Preference.get(domain, key)
+        const prop = `${domain}.${key}`
+        const readOnly = this.#readOnlyKeys.includes(prop)
+        const currentValue = readOnly
+          ? this.#effectiveValues[prop]
+          : (Preference.get(domain, key) ?? this.#effectiveValues[prop])
         if (currentValue != null) {
-          this.notifyPreference(`${domain}.${key}`, currentValue)
+          this.notifyPreference(prop, currentValue, readOnly)
         }
       }
     }
@@ -103,7 +113,7 @@ export class PreferenceServer extends UARTServer {
     }
   }
 
-  notifyPreference(prop, value) {
+  notifyPreference(prop, value, readOnly = false) {
     if (this.#tx_characteristic == null) {
       return
     }
@@ -113,19 +123,26 @@ export class PreferenceServer extends UARTServer {
         JSON.stringify({
           prop,
           value,
+          ...(readOnly ? { readOnly: true } : {}),
         }),
       ),
     )
   }
 
   receiveAndSetPreference(domain: string, key: string, value: PreferenceValue) {
-    const currentValue = Preference.get(domain, key)
+    const prop = `${domain}.${key}`
+    if (this.#readOnlyKeys.includes(prop)) {
+      trace(`ignoring read-only preference ... ${prop}: ${value}\n`)
+      const currentValue = this.#effectiveValues[prop]
+      if (currentValue != null) this.notifyPreference(prop, currentValue, true)
+      return
+    }
+    const currentValue = Preference.get(domain, key) ?? this.#effectiveValues[prop]
     if (currentValue !== value) {
       trace(`changing preference ... ${domain}.${key}: ${value}\n`)
       Preference.set(domain, key, value)
-      const pref = `${domain}.${key}`
-      this.notifyPreference(pref, value)
-      this.#handlePreferenceChanged?.(pref, value)
+      this.notifyPreference(prop, value)
+      this.#handlePreferenceChanged?.(prop, value)
     }
   }
 }

--- a/firmware/host/modules/connectivity/preference-server.ts
+++ b/firmware/host/modules/connectivity/preference-server.ts
@@ -31,7 +31,7 @@ export class PreferenceServer extends UARTServer {
       this.#handleConnected = option.onConnected
       this.#handleDisconnected = option.onDisconnected
     }
-    this.#keys = Array.isArray(option.keys) ? option.keys.slice() : []
+    this.#keys = Array.isArray(option?.keys) ? option.keys.slice() : []
     this.#effectiveValues = option?.effectiveValues ?? {}
     this.#readOnlyKeys = option?.readOnlyKeys ?? []
   }

--- a/firmware/host/modules/preferences/loadPreference.test.ts
+++ b/firmware/host/modules/preferences/loadPreference.test.ts
@@ -53,7 +53,7 @@ async function setup() {
   modules.resetModules()
   config.resetConfig({ ui: { type: 'simple' } })
   preference.resetPreference()
-  return { loadPreferences: loadPreference.default, preference, traces }
+  return { loadPreferences: loadPreference.default, modules, config, preference, traces }
 }
 
 test('loadPreferences migrates legacy renderer.type to ui.type when ui.type is absent', async () => {
@@ -86,4 +86,48 @@ test('loadPreferences keeps explicit ui.type when legacy renderer.type also exis
 
   assert.equal(loadPreferences(DOMAIN.ui).type, 'simple')
   assert.equal(preference.default.get(DOMAIN.ui, 'type'), 'simple')
+})
+
+test('loadPreferences ignores a stored driver type when the platform locks its driver', async () => {
+  const { loadPreferences, config, preference, traces } = await setup()
+  config.resetConfig({
+    driver: { type: 'm5stackchan', typeLocked: true },
+  })
+  preference.resetPreference({
+    'driver.type': 'scservo',
+  })
+
+  const driver = loadPreferences(DOMAIN.driver)
+
+  assert.equal(driver.type, 'm5stackchan')
+  assert.equal(driver.typeLocked, true)
+  assert.deepEqual(traces, ['[preferences] ignored stored driver.type=scservo; platform locks it to m5stackchan\n'])
+})
+
+test('loadPreferences keeps stored driver selection on an unlocked platform', async () => {
+  const { loadPreferences, config, preference } = await setup()
+  config.resetConfig({
+    driver: { type: 'm5stackchan' },
+  })
+  preference.resetPreference({
+    'driver.type': 'scservo',
+  })
+
+  assert.equal(loadPreferences(DOMAIN.driver).type, 'scservo')
+})
+
+test('loadPreferences does not let MOD config relax a platform driver lock', async () => {
+  const { modules, config } = await setup()
+  modules.resetModules({
+    'mod/config': { driver: { type: 'scservo', typeLocked: false } },
+  })
+  config.resetConfig({
+    driver: { type: 'm5stackchan', typeLocked: true },
+  })
+  const freshModule = await import(new URL('./loadPreference.js?platform-lock', import.meta.url).href)
+
+  const driver = freshModule.default(DOMAIN.driver)
+
+  assert.equal(driver.type, 'm5stackchan')
+  assert.equal(driver.typeLocked, true)
 })

--- a/firmware/host/modules/preferences/loadPreference.ts
+++ b/firmware/host/modules/preferences/loadPreference.ts
@@ -39,11 +39,25 @@ export default function loadPreferences(category: PreferenceDomain): ConfigRecor
   const modPreference = structuredClone((loadModConfig()[category.toLowerCase()] ?? {}) as ConfigRecord)
 
   const preference = { ...mcPreference, ...modPreference }
+  const lockedDriverType =
+    category === DOMAIN.driver && mcPreference.typeLocked === true && typeof mcPreference.type === 'string'
+      ? mcPreference.type
+      : undefined
+  if (lockedDriverType !== undefined) {
+    preference.type = lockedDriverType
+    preference.typeLocked = true
+  }
 
   const keys = PREF_KEYS.filter((s) => s[0] === category)
   for (const [domain, key, ctor] of keys) {
     const value = Preference.get(domain, key)
     if (value != null) {
+      if (domain === DOMAIN.driver && key === 'type' && lockedDriverType !== undefined) {
+        if (String(value) !== lockedDriverType) {
+          trace(`[preferences] ignored stored driver.type=${value}; platform locks it to ${lockedDriverType}\n`)
+        }
+        continue
+      }
       preference[key] = ctor(value)
     }
   }

--- a/firmware/host/platforms/m5stackchan_cores3/manifest.json
+++ b/firmware/host/platforms/m5stackchan_cores3/manifest.json
@@ -16,6 +16,7 @@
   "config": {
     "driver": {
       "type": "m5stackchan",
+      "typeLocked": true,
       "panId": 1,
       "tiltId": 2,
       "yawZeroPosition": 460,

--- a/firmware/host/platforms/platform-manifest.architecture.ts
+++ b/firmware/host/platforms/platform-manifest.architecture.ts
@@ -13,7 +13,10 @@ type Subplatform = {
     include?: string[]
     build?: { SUBPLATFORM?: string }
     defines?: { camera?: { i2c_port?: number } }
-    config?: { serial?: unknown; driver?: { serial?: unknown } }
+    config?: {
+      serial?: unknown
+      driver?: { type?: string; typeLocked?: boolean; serial?: unknown }
+    }
   }
 }
 
@@ -89,6 +92,19 @@ describe('Stack-chan platform manifest', () => {
       if (manifest.config?.serial && manifest.config?.driver?.serial) {
         assert.deepEqual(manifest.config.serial, manifest.config.driver.serial)
       }
+    }
+  })
+
+  test('dedicated smart-servo platforms lock their hardware driver', () => {
+    const expectedDrivers = new Map([
+      ['m5stackchan_cores3', 'm5stackchan'],
+      ['stackchan_rt', 'dynamixel'],
+    ])
+
+    for (const [platform, expectedType] of expectedDrivers) {
+      const manifest = readJson(join('host/platforms', platform, 'manifest.json'))
+      assert.equal(manifest.config?.driver?.type, expectedType)
+      assert.equal(manifest.config?.driver?.typeLocked, true)
     }
   })
 

--- a/firmware/host/platforms/stackchan_rt/manifest.json
+++ b/firmware/host/platforms/stackchan_rt/manifest.json
@@ -10,6 +10,7 @@
   "config": {
     "driver": {
       "type": "dynamixel",
+      "typeLocked": true,
       "panId": 1,
       "tiltId": 2,
       "serial": {

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -121,6 +121,9 @@
       "timer": [
         "host/modules/testing/fakes/timer.ts"
       ],
+      "uartserver": [
+        "host/modules/connectivity/__tests__/fakes/uartserver.ts"
+      ],
       "time": [
         "host/modules/testing/fakes/time.ts"
       ],

--- a/web/preference/index.html
+++ b/web/preference/index.html
@@ -73,12 +73,17 @@
                 <label class="form-field form-field-wide"
                   ><span>ドライバー</span
                   ><select name="driver.type" id="driver.type">
-                    <option value="scservo">SCServo</option>
+                    <option value="m5stackchan">M5StackChan Servo（CoreS3専用・推奨）</option>
+                    <option value="scservo">SCServo（汎用・外部配線向け）</option>
                     <option value="dynamixel">Dynamixel（Protocol 2）</option>
                     <option value="rs30x">RS30X</option>
                     <option value="pwm">PWM（SG-90）</option>
                     <option value="none">なし</option>
-                  </select></label
+                  </select>
+                  <small class="form-hint"
+                    >M5StackChan
+                    Servoは専用UART、ゼロ位置、可動域、PY32サーボ電源を設定します。CoreS3専用ファームウェアではこの項目に固定されます。</small
+                  ></label
                 ><label class="form-field"
                   ><span>パン オフセット</span
                   ><input type="number" name="driver.offsetPan" id="driver.offsetPan" value="0" /></label

--- a/web/preference/preference.css
+++ b/web/preference/preference.css
@@ -37,6 +37,11 @@
   font-size: 0.78rem;
   line-height: 1.3;
 }
+.form-hint {
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1.5;
+}
 .wifi-clear-button {
   margin-top: 16px;
 }

--- a/web/preference/preference.mjs
+++ b/web/preference/preference.mjs
@@ -153,7 +153,6 @@ export function initializePreferencePage({
         !readOnlyProps.has(prop) &&
         dirtyProps.has(prop) &&
         value != null &&
-        value.trimEnd().length > 0 &&
         currentValues.get(prop) !== value
       ) {
         payload[prop] = value

--- a/web/preference/preference.mjs
+++ b/web/preference/preference.mjs
@@ -25,17 +25,44 @@ export function initializePreferencePage({
   const connectionStatus = requiredElement('connection-status')
   const saveStatus = requiredElement('save-status')
   const controls = [...form.querySelectorAll('input, select, textarea, button')]
+  const preferenceProps = [
+    'wifi.ssid',
+    'wifi.password',
+    'driver.type',
+    'driver.offsetPan',
+    'driver.offsetTilt',
+    'ui.type',
+    'tts.type',
+    'tts.host',
+    'tts.port',
+    'tts.token',
+    'tts.voice',
+    'tts.volume',
+    'ai.token',
+    'ai.context',
+  ]
   let submitting = false
   const currentValues = new Map()
+  const dirtyProps = new Set()
+  const readOnlyProps = new Set()
 
   const setStatus = (element, text, state = '') => {
     element.textContent = text
     element.dataset.state = state
   }
-  const onCharacteristicValueChanged = ({ prop, value }) => {
+  const onCharacteristicValueChanged = ({ prop, value, readOnly = false }) => {
     currentValues.set(prop, String(value))
     const element = pageDocument.querySelector(`[name="${prop}"]`)
-    if (element != null) element.value = value
+    if (readOnly) {
+      readOnlyProps.add(prop)
+      dirtyProps.delete(prop)
+    } else {
+      readOnlyProps.delete(prop)
+    }
+    if (element != null) {
+      if (!dirtyProps.has(prop)) element.value = value
+      element.disabled = !client.isConnected() || readOnlyProps.has(prop)
+    }
   }
   const client =
     suppliedClient ??
@@ -48,10 +75,16 @@ export function initializePreferencePage({
     connectButton.hidden = connected
     disconnectButton.hidden = !connected
     controls.forEach((control) => {
-      control.disabled = !connected
+      control.disabled = !connected || readOnlyProps.has(control.name)
     })
     setStatus(connectionStatus, connected ? '接続済み' : '未接続', connected ? 'success' : '')
   }
+  const markDirty = (event) => {
+    const prop = event.target?.name
+    if (preferenceProps.includes(prop) && !readOnlyProps.has(prop)) dirtyProps.add(prop)
+  }
+  form.addEventListener('input', markDirty)
+  form.addEventListener('change', markDirty)
 
   connectButton.addEventListener('click', async () => {
     connectButton.disabled = true
@@ -95,6 +128,7 @@ export function initializePreferencePage({
       await client.send({ _batch: payload })
       for (const [prop, value] of Object.entries(payload)) {
         currentValues.set(prop, value)
+        dirtyProps.delete(prop)
         const element = pageDocument.getElementById(prop)
         if (element != null) element.value = value
       }
@@ -112,26 +146,16 @@ export function initializePreferencePage({
   form.addEventListener('submit', async (event) => {
     event.preventDefault()
     if (!client.isConnected() || submitting) return
-    const props = [
-      'wifi.ssid',
-      'wifi.password',
-      'driver.type',
-      'driver.offsetPan',
-      'driver.offsetTilt',
-      'ui.type',
-      'tts.type',
-      'tts.host',
-      'tts.port',
-      'tts.token',
-      'tts.voice',
-      'tts.volume',
-      'ai.token',
-      'ai.context',
-    ]
     const payload = {}
-    for (const prop of props) {
+    for (const prop of preferenceProps) {
       const value = pageDocument.getElementById(prop)?.value
-      if (value != null && value.trimEnd().length > 0 && currentValues.get(prop) !== value) {
+      if (
+        !readOnlyProps.has(prop) &&
+        dirtyProps.has(prop) &&
+        value != null &&
+        value.trimEnd().length > 0 &&
+        currentValues.get(prop) !== value
+      ) {
         payload[prop] = value
       }
     }
@@ -144,7 +168,10 @@ export function initializePreferencePage({
     submitting = true
     try {
       await client.send({ _batch: payload })
-      for (const [prop, value] of Object.entries(payload)) currentValues.set(prop, value)
+      for (const [prop, value] of Object.entries(payload)) {
+        currentValues.set(prop, value)
+        dirtyProps.delete(prop)
+      }
       setStatus(saveStatus, '設定を送信しました。', 'success')
     } catch (error) {
       console.error(error)
@@ -158,6 +185,8 @@ export function initializePreferencePage({
   client.onDisconnected = () => {
     submitting = false
     currentValues.clear()
+    dirtyProps.clear()
+    readOnlyProps.clear()
     setStatus(saveStatus, '接続が切れました。保存されていない項目を確認してください。', 'warning')
     updateView()
   }

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -216,8 +216,9 @@ function createPreferencePage() {
   const ssid = new FakeElement({ id: 'wifi.ssid', name: 'wifi.ssid' })
   const password = new FakeElement({ id: 'wifi.password', name: 'wifi.password' })
   const driverType = new FakeElement({ id: 'driver.type', name: 'driver.type' })
+  const aiToken = new FakeElement({ id: 'ai.token', name: 'ai.token' })
   driverType.value = 'm5stackchan'
-  form.controls = [ssid, password, driverType, clear, submit]
+  form.controls = [ssid, password, driverType, aiToken, clear, submit]
   const document = new FakeDocument([
     form,
     connect,
@@ -229,8 +230,9 @@ function createPreferencePage() {
     ssid,
     password,
     driverType,
+    aiToken,
   ])
-  return { document, form, submit, clear, saveStatus, ssid, password, driverType }
+  return { document, form, submit, clear, saveStatus, ssid, password, driverType, aiToken }
 }
 
 test('preference page displays and locks the effective M5StackChan driver reported over BLE', () => {
@@ -269,6 +271,19 @@ test('explicitly selecting generic SCServo sends only the driver change', async 
   await page.form.dispatch('submit')
 
   assert.deepEqual(client.messages, [{ _batch: { 'driver.type': 'scservo' } }])
+})
+
+test('explicitly clearing an optional text field sends the empty value', async () => {
+  const page = createPreferencePage()
+  const client = new FakePreferenceClient()
+  const { onCharacteristicValueChanged } = initializePreferencePage({ document: page.document, client })
+  onCharacteristicValueChanged({ prop: 'ai.token', value: 'stored-token' })
+
+  page.aiToken.value = ''
+  await page.form.dispatch('input', page.aiToken)
+  await page.form.dispatch('submit')
+
+  assert.deepEqual(client.messages, [{ _batch: { 'ai.token': '' } }])
 })
 
 test('Wi-Fi clear confirms, sends both empty credentials, updates fields, and restores controls', async () => {

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -155,8 +155,8 @@ class FakeElement {
     return this.controls
   }
 
-  async dispatch(type) {
-    const event = { preventDefault() {} }
+  async dispatch(type, target = this) {
+    const event = { target, preventDefault() {} }
     for (const listener of this.listeners.get(type) ?? []) await listener(event)
   }
 
@@ -215,7 +215,9 @@ function createPreferencePage() {
   const saveStatus = new FakeElement({ id: 'save-status' })
   const ssid = new FakeElement({ id: 'wifi.ssid', name: 'wifi.ssid' })
   const password = new FakeElement({ id: 'wifi.password', name: 'wifi.password' })
-  form.controls = [ssid, password, clear, submit]
+  const driverType = new FakeElement({ id: 'driver.type', name: 'driver.type' })
+  driverType.value = 'm5stackchan'
+  form.controls = [ssid, password, driverType, clear, submit]
   const document = new FakeDocument([
     form,
     connect,
@@ -226,9 +228,48 @@ function createPreferencePage() {
     saveStatus,
     ssid,
     password,
+    driverType,
   ])
-  return { document, submit, clear, saveStatus, ssid, password }
+  return { document, form, submit, clear, saveStatus, ssid, password, driverType }
 }
+
+test('preference page displays and locks the effective M5StackChan driver reported over BLE', () => {
+  const page = createPreferencePage()
+  const client = new FakePreferenceClient()
+  const { onCharacteristicValueChanged } = initializePreferencePage({ document: page.document, client })
+
+  page.driverType.value = 'scservo'
+  onCharacteristicValueChanged({ prop: 'driver.type', value: 'm5stackchan', readOnly: true })
+
+  assert.equal(page.driverType.value, 'm5stackchan')
+  assert.equal(page.driverType.disabled, true)
+})
+
+test('saving another field never sends an untouched driver HTML default', async () => {
+  const page = createPreferencePage()
+  const client = new FakePreferenceClient()
+  initializePreferencePage({ document: page.document, client })
+
+  page.driverType.value = 'scservo'
+  page.ssid.value = 'new-ap'
+  await page.form.dispatch('input', page.ssid)
+  await page.form.dispatch('submit')
+
+  assert.deepEqual(client.messages, [{ _batch: { 'wifi.ssid': 'new-ap' } }])
+})
+
+test('explicitly selecting generic SCServo sends only the driver change', async () => {
+  const page = createPreferencePage()
+  const client = new FakePreferenceClient()
+  const { onCharacteristicValueChanged } = initializePreferencePage({ document: page.document, client })
+  onCharacteristicValueChanged({ prop: 'driver.type', value: 'm5stackchan' })
+
+  page.driverType.value = 'scservo'
+  await page.form.dispatch('change', page.driverType)
+  await page.form.dispatch('submit')
+
+  assert.deepEqual(client.messages, [{ _batch: { 'driver.type': 'scservo' } }])
+})
 
 test('Wi-Fi clear confirms, sends both empty credentials, updates fields, and restores controls', async () => {
   const page = createPreferencePage()


### PR DESCRIPTION
## Summary

- lock M5StackChan CoreS3 firmware to the `m5stackchan` servo driver and Stack-chan RT firmware to `dynamixel`
- publish resolved manifest defaults over BLE, mark platform-owned settings read-only, and reject writes to locked preferences in firmware
- update the BLE preference UI to send only fields the user actually changed
- catch servo-test motion and torque errors so a rejected servo command cannot abort and restart XS
- add firmware, web, architecture, and Moddable regression coverage

## Root cause

The BLE preference server only returned values already persisted in `Preference`. When `driver.type` had not been stored, the web form kept its first HTML option, generic `scservo`. Saving an unrelated setting sent every differing control, so the generic driver could be persisted accidentally.

On M5StackChan CoreS3, generic SCServo uses the generic serial configuration instead of the board-specific TX6/RX7 bus, zero positions, motion limits, and PY32 servo-power control. The resulting command timeouts rejected promises that the default servo test discarded, and the unhandled rejection aborted XS and restarted the device.

## Impact

M5StackChan and Stack-chan RT now keep their hardware-compatible driver even when an old or third-party BLE client attempts to write another driver type. Other platforms remain configurable. Existing incompatible stored values are preserved but ignored on locked platforms.

The web UI displays the effective driver reported by firmware, disables locked driver controls, and no longer sends untouched HTML defaults.

## Validation

- `npm run test:unit`
- `npm run check:architecture`
- `npm run lint`
- `npm test` in `web`
- Prettier check for changed web files
- `npm run check:manifest` (6 targets)
- `STACKCHAN_MODULE_TEST_FILTER=face-init npm run test:moddable`
- `npm run build:m5stackchan_cores3`
- `npm run build:stackchan_rt`
- M5StackChan CoreS3 hardware: stale `scservo` preference ignored, TX6/RX7 selected, servo test moved successfully, no exception or restart
- Stack-chan RT hardware: Dynamixel TX7/RX6 selected, servo initialized and moved successfully, no exception or restart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **M5StackChan** as a selectable servo driver option, including CoreS3-specific guidance.
  * Platform driver type can now be **locked as read-only**, reflecting the forced driver behavior from device firmware.
  * Preference syncing now tracks **dirty vs read-only** fields to prevent unintended overwrites.

* **Bug Fixes**
  * Improved **Servo test** flow to handle hardware/servo errors gracefully, show visible feedback, and support successful retries.

* **Documentation**
  * Updated English and Japanese flashing/config docs to document **m5stackchan** support and platform-locked driver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->