### PR TITLE
fix: normalize UI display list capacity

### DIFF
--- a/firmware/host/app/compose.architecture.ts
+++ b/firmware/host/app/compose.architecture.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const composeSource = readFileSync('host/app/compose.ts', 'utf8')
+
+test('main UI display list capacity is independent of the startup path', () => {
+  assert.match(composeSource, /const DEFAULT_UI_DISPLAY_LIST_LENGTH = 4096/)
+  assert.match(composeSource, /displayListLength: options\.displayListLength \?\? DEFAULT_UI_DISPLAY_LIST_LENGTH/)
+  assert.doesNotMatch(composeSource, /displayListLength = 2048/)
+})

--- a/firmware/host/app/compose.ts
+++ b/firmware/host/app/compose.ts
@@ -63,18 +63,20 @@ export type HostDeviceEnvironment = GlobalEnvironment['device']
 
 type WebRadioPlayerConstructor = new () => WebRadioCapability
 
+const DEFAULT_UI_DISPLAY_LIST_LENGTH = 4096
+
 function asUIOptions(param: unknown): UIOptions {
   return (param ?? {}) as UIOptions
 }
 
-function createStackchanUI(face: PiuContainer, options: UIOptions = {}, displayListLength = 2048): RobotUI {
+function createStackchanUI(face: PiuContainer, options: UIOptions = {}): RobotUI {
   return createAppControllerApplication(
     {
       face,
       appBar: new ChatStatusBar(),
       drawerButtons: options.drawerButtons,
     },
-    { displayListLength },
+    { displayListLength: options.displayListLength ?? DEFAULT_UI_DISPLAY_LIST_LENGTH },
   )
 }
 
@@ -127,11 +129,7 @@ export function createStackchanContext(
       'image',
       (param) => {
         const options = asUIOptions(param)
-        return createStackchanUI(
-          new ImageAvatarFace({ pack: options.avatar }),
-          options,
-          options.displayListLength ?? 4096,
-        )
+        return createStackchanUI(new ImageAvatarFace({ pack: options.avatar }), options)
       },
     ],
     ['small-face', (param) => createStackchanUI(new SmallFace(), asUIOptions(param))],

--- a/web/simulator/visual-test.mjs
+++ b/web/simulator/visual-test.mjs
@@ -390,6 +390,21 @@ async function inspectViewport(page, name, width, height) {
     )
     const sampleModSignature = await waitForScreenChange(beforeSampleSignature, 10_000)
     assert.notEqual(sampleModSignature, beforeSampleSignature, 'the checked-in sample MOD must visibly update the face')
+    const sampleModLog = await page.locator('#trace-log').textContent()
+    assert.doesNotMatch(
+      sampleModLog,
+      /display list overflowed|# Exception|XS abort/,
+      'the checked-in sample MOD must render without a runtime exception'
+    )
+    const sampleModHasVisiblePixels = await page.evaluate(() => {
+      const screen = document.querySelector('#simulator-screen')
+      const pixels = screen.getContext('2d').getImageData(0, 0, screen.width, screen.height).data
+      for (let index = 0; index < pixels.length; index += 4) {
+        if (pixels[index] || pixels[index + 1] || pixels[index + 2]) return true
+      }
+      return false
+    })
+    assert.equal(sampleModHasVisiblePixels, true, 'the checked-in sample MOD must not leave a black screen')
     await page.screenshot({ path: '/tmp/stackchan-sample-mod.png', fullPage: true })
     await savePiuScreen('sample-mod')
     await page.locator('#mod-clear-button').click()


### PR DESCRIPTION
## What changed

- Default every Stack-chan main UI to a 4,096-byte Poco display list.
- Continue honoring an explicit `ui.displayListLength` override for every face type.
- Add an architecture guard for startup-path-independent capacity.
- Harden the simulator sample-MOD visual test against runtime exceptions and black screens.

## Root cause

The normal startup splash creates a 4,096-byte Piu application that the main UI reuses.
A MOD that overrides `onLaunch` can skip that splash, causing the main UI to create a fresh 2,048-byte application instead.
Rendering the standard face with a speech balloon then overflows the Poco display list and aborts in `onIdle`.

## Impact

Main UI capacity no longer depends on whether the startup splash ran.
This adds about 2 KiB of persistent native heap only on paths that previously created a 2,048-byte main UI buffer.

## Validation

- `npm test` (firmware): 187 passed
- `npm run check:architecture`: 62 passed
- `npm run lint`
- `npm run build:wasm`
- `npm run test:visual`: sample MOD renders with no exception and no black screen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the default UI display list capacity to improve rendering headroom.
  - Ensured configured display list lengths are applied consistently.

- **Tests**
  - Added coverage to verify display list defaults and prevent regressions.
  - Enhanced simulator visual checks to detect runtime errors and black-screen failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->