### PR TITLE
feat(web): add MOD Gallery and block samples

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -119,6 +119,8 @@ jobs:
           mkdir -p ./web/flash/tech.moddable.stackchan ./web/simulator
           cp -R ./firmware-bundle/. ./web/flash/tech.moddable.stackchan/
           cp -R ./wasm-simulator/. ./web/simulator/
+          mkdir -p ./web/schemas
+          cp ./website-source/docs/specs/stackchan-mod.schema.json ./web/schemas/stackchan-mod.schema.json
       - name: Commit bundle update
         run: |
           git config user.name 'GitHub Action'

--- a/docs/specs/stackchan-mod.md
+++ b/docs/specs/stackchan-mod.md
@@ -1,0 +1,53 @@
+# Stack-chan MOD定義
+
+## 対象
+
+**Stack-chan MOD定義**は、MOD Galleryと各エディタが共有する配布用メタデータです。
+
+Moddableの`manifest.json`はビルド方法を定義します。
+
+`.stackchan-blocks.json`はブロックエディタで再編集するプロジェクトを保存します。
+
+`stackchan-mod.json`は両者を置き換えず、正本となる編集ソースを`source.path`から参照します。
+
+## 形式
+
+ルートオブジェクトは次の必須フィールドを持ちます。
+
+- **format**：`tech.stackchan.mod`です。
+- **schemaVersion**：MOD定義形式の互換性を示す整数です。
+- **id**：Gallery内でMODを識別する逆ドメイン形式の文字列です。
+- **version**：MOD自身のリリースバージョンです。
+- **type**：正本となる編集ソースの形式です。`text`または`block`を指定します。
+- **name**：Galleryへ表示する名前です。
+- **description**：Galleryへ表示する説明です。
+- **source.path**：MOD定義からの相対パスです。
+- **targets**：対応する実行対象のIDです。
+
+`type`は実行形式を表しません。
+
+テキストMODとブロックMODは、どちらもビルド後にXSアーカイブとして実行します。
+
+`type: "text"`では、`source.path`がModdableのmanifestを指します。
+
+`type: "block"`では、`source.path`が`.stackchan-blocks.json`を指します。
+
+## 実行成果物
+
+ビルド済みXSアーカイブを配布するMODは、任意の`artifacts`へ成果物を列挙します。
+
+各成果物は`format: "xsa"`、相対パス、対象機種を持ちます。
+
+Galleryは編集ソースと実行成果物を別々に扱い、`type`から実行互換性を推測しません。
+
+## パス
+
+すべてのパスは`stackchan-mod.json`があるディレクトリからの相対パスです。
+
+絶対パス、親ディレクトリ参照、バックスラッシュ、制御文字を含むパスは無効です。
+
+この制約により、一つのMODパッケージから別のパッケージにあるファイルを暗黙に参照することを防ぎます。
+
+## スキーマ
+
+機械検証には[`stackchan-mod.schema.json`](./stackchan-mod.schema.json)を使用します。

--- a/docs/specs/stackchan-mod.schema.json
+++ b/docs/specs/stackchan-mod.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json",
+  "title": "Stack-chan MOD definition",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "format",
+    "schemaVersion",
+    "id",
+    "version",
+    "type",
+    "name",
+    "description",
+    "source",
+    "targets"
+  ],
+  "properties": {
+    "$schema": { "type": "string", "format": "uri-reference" },
+    "format": { "const": "tech.stackchan.mod" },
+    "schemaVersion": { "const": 1 },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:[.-][a-z0-9]+)+$",
+      "maxLength": 128
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
+    },
+    "type": { "enum": ["block", "text"] },
+    "name": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "description": { "type": "string", "minLength": 1, "maxLength": 400 },
+    "author": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "license": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path"],
+      "properties": {
+        "path": { "$ref": "#/$defs/relativePath" }
+      }
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" }
+    },
+    "capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$"
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["format", "path", "target"],
+        "properties": {
+          "format": { "const": "xsa" },
+          "path": { "$ref": "#/$defs/relativePath" },
+          "target": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\)(?!.*[\\u0000-\\u001f:]).+$"
+    }
+  }
+}

--- a/web/editor/editor.mjs
+++ b/web/editor/editor.mjs
@@ -29,6 +29,7 @@ import {
 } from './project-library.mjs'
 import { createProjectStorage } from './project-storage.mjs'
 import { VISUAL_SAMPLES, sampleById } from './samples.mjs'
+import { fetchExternalProject, projectUrlFromSearch } from './external-project.mjs'
 import {
   clearFaceEditContext,
   clearStagedFaceTransfer,
@@ -1238,3 +1239,16 @@ removeDeviceButton.addEventListener('click', async () => {
     refreshDeviceActionButtons()
   }
 })
+
+try {
+  const linkedProjectUrl = projectUrlFromSearch(location.search, location.href)
+  if (linkedProjectUrl) {
+    const linkedProject = await fetchExternalProject(linkedProjectUrl)
+    activateProject(linkedProject, `Galleryから「${linkedProject.name}」を読み込みました`)
+    history.replaceState(null, '', location.pathname)
+    recordMetric('gallery_project_loaded', { source: linkedProjectUrl.pathname })
+  }
+} catch (error) {
+  setStatus(`Galleryのプロジェクトを読み込めませんでした: ${error.message}`)
+  log(String(error.message ?? error))
+}

--- a/web/editor/external-project.mjs
+++ b/web/editor/external-project.mjs
@@ -1,0 +1,23 @@
+import { MAX_PROJECT_JSON_BYTES, parseVisualProject } from './project-format.mjs'
+
+export function projectUrlFromSearch(search, pageUrl) {
+  const value = new URLSearchParams(String(search ?? '')).get('project')
+  if (!value) return null
+  const base = new URL(pageUrl)
+  const projectUrl = new URL(value, base)
+  if (projectUrl.origin !== base.origin) throw new TypeError('別のサイトにあるプロジェクトは開けません')
+  if (!projectUrl.pathname.endsWith('.stackchan-blocks.json')) {
+    throw new TypeError('ブロックプロジェクトのURLではありません')
+  }
+  return projectUrl
+}
+
+export async function fetchExternalProject(projectUrl, fetcher = globalThis.fetch) {
+  const response = await fetcher(projectUrl)
+  if (!response.ok) throw new Error(`プロジェクトを取得できませんでした (${response.status})`)
+  const declaredSize = Number(response.headers?.get?.('content-length'))
+  if (Number.isFinite(declaredSize) && declaredSize > MAX_PROJECT_JSON_BYTES) {
+    throw new TypeError(`プロジェクトが上限 ${MAX_PROJECT_JSON_BYTES} バイトを超えています`)
+  }
+  return parseVisualProject(await response.text())
+}

--- a/web/editor/external-project.test.mjs
+++ b/web/editor/external-project.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { fetchExternalProject, projectUrlFromSearch } from './external-project.mjs'
+
+const pageUrl = 'https://stack-chan.github.io/stack-chan/web/editor/'
+
+test('Galleryの同一オリジンブロックプロジェクトを解決する', () => {
+  const project = projectUrlFromSearch(
+    '?project=https%3A%2F%2Fstack-chan.github.io%2Fstack-chan%2Fweb%2Fmod-gallery%2Fsamples%2Fhello%2Fhello.stackchan-blocks.json',
+    pageUrl
+  )
+  assert.equal(
+    project.href,
+    'https://stack-chan.github.io/stack-chan/web/mod-gallery/samples/hello/hello.stackchan-blocks.json'
+  )
+  assert.equal(projectUrlFromSearch('', pageUrl), null)
+})
+
+test('外部オリジンとブロック形式でないURLを拒否する', () => {
+  assert.throws(
+    () => projectUrlFromSearch('?project=https%3A%2F%2Fexample.com%2Fproject.stackchan-blocks.json', pageUrl),
+    /別のサイト/
+  )
+  assert.throws(() => projectUrlFromSearch('?project=..%2Fmanifest.json', pageUrl), /ブロックプロジェクト/)
+})
+
+test('取得したプロジェクトを既存の形式検証へ渡す', async () => {
+  const project = {
+    format: 'tech.stackchan.visual-project',
+    version: 1,
+    id: 'gallery-test-project',
+    name: 'Gallery test',
+    target: 'm5stackchan-cores3',
+    workspace: { blocks: { languageVersion: 0, blocks: [{ type: 'stackchan_on_start' }] } },
+    assets: [],
+    settings: { educationalProfile: true, embedAssets: true, faceAsset: null },
+    createdAt: '2026-07-19T00:00:00.000Z',
+    updatedAt: '2026-07-19T00:00:00.000Z',
+  }
+  const result = await fetchExternalProject(
+    new URL('https://stack-chan.github.io/project.stackchan-blocks.json'),
+    async () => ({
+      ok: true,
+      headers: new Headers(),
+      text: async () => JSON.stringify(project),
+    })
+  )
+  assert.equal(result.name, 'Gallery test')
+  assert.deepEqual(result.workspace, project.workspace)
+})

--- a/web/index.html
+++ b/web/index.html
@@ -137,6 +137,11 @@
               ><span><strong>設定</strong><small>BLEで本体の設定を変更する</small></span
               ><i class="arrow" data-lucide="chevron-right"></i
             ></a>
+            <a class="tool-link" href="mod-gallery/"
+              ><span class="tool-icon"><i data-lucide="store"></i></span
+              ><span><strong>MOD Gallery</strong><small>公開済みMODを試して編集する</small></span
+              ><i class="arrow" data-lucide="chevron-right"></i
+            ></a>
             <a class="tool-link" href="simulator/"
               ><span class="tool-icon"><i data-lucide="box"></i></span
               ><span><strong>シミュレーター</strong><small>WASMと3Dモデルを実行する</small></span

--- a/web/mod-gallery/catalog.json
+++ b/web/mod-gallery/catalog.json
@@ -1,0 +1,11 @@
+{
+  "format": "tech.stackchan.mod-catalog",
+  "version": 1,
+  "definitions": [
+    "../simulator/samples/stackchan-mod.json",
+    "samples/hello/stackchan-mod.json",
+    "samples/buttons/stackchan-mod.json",
+    "samples/look-around/stackchan-mod.json",
+    "samples/sensors/stackchan-mod.json"
+  ]
+}

--- a/web/mod-gallery/index.html
+++ b/web/mod-gallery/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="../assets/stackchan-favicon-32.png" type="image/png" />
+    <link rel="apple-touch-icon" href="../assets/stackchan-apple-touch-icon.png" />
+    <link rel="stylesheet" href="../global.css" />
+    <link rel="stylesheet" href="./mod-gallery.css" />
+    <title>MOD Gallery | ｽﾀｯｸﾁｬﾝ</title>
+    <script
+      src="https://unpkg.com/lucide@1.24.0/dist/umd/lucide.min.js"
+      integrity="sha384-mooE85Luwgx+AyykX7e90VcN8/QCFTSIwPuHLmvcsLVoA0en7lKYb9XlOzn5G2co"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="topbar">
+        <a class="brand-link" href="../"
+          ><img src="../assets/stackchan-symbol.png" alt="" /><span
+            >ｽﾀｯｸﾁｬﾝ<span class="surface-name"> MOD Gallery</span></span
+          ></a
+        >
+      </header>
+      <section class="gallery" aria-labelledby="gallery-heading">
+        <header class="gallery-hero">
+          <span class="gallery-eyebrow">使う、まねる、作る</span>
+          <h1 id="gallery-heading">MOD Gallery</h1>
+          <p>公開されたMODを試したり、ブロックの作例から自分のMODを作ったりできます。</p>
+        </header>
+        <div class="gallery-controls" aria-label="MODを絞り込む">
+          <label class="search-control">
+            <span>検索</span>
+            <span class="search-input"
+              ><i data-lucide="search" aria-hidden="true"></i
+              ><input id="mod-search" type="search" placeholder="名前や機能で検索"
+            /></span>
+          </label>
+          <label>
+            <span>作り方</span>
+            <select id="type-filter">
+              <option value="all">すべて</option>
+              <option value="block">ブロック</option>
+              <option value="text">テキスト</option>
+            </select>
+          </label>
+        </div>
+        <div class="gallery-summary">
+          <p id="gallery-count" aria-live="polite">MODを読み込んでいます</p>
+          <p class="gallery-legend"><span class="type-dot block"></span>ブロックは編集可能なサンプルです</p>
+        </div>
+        <div id="mod-list" class="mod-list" aria-live="polite"></div>
+        <p id="gallery-empty" class="gallery-empty" hidden>条件に合うMODがありません。</p>
+        <p id="gallery-status" class="status-line" role="status"></p>
+      </section>
+    </main>
+    <script type="module" src="../tool-navigation.mjs"></script>
+    <script type="module" src="./mod-gallery.mjs"></script>
+    <script>
+      globalThis.lucide?.createIcons()
+    </script>
+  </body>
+</html>

--- a/web/mod-gallery/mod-definition.mjs
+++ b/web/mod-gallery/mod-definition.mjs
@@ -1,0 +1,137 @@
+export const STACKCHAN_MOD_FORMAT = 'tech.stackchan.mod'
+export const STACKCHAN_MOD_SCHEMA_VERSION = 1
+export const STACKCHAN_MOD_TYPES = Object.freeze(['block', 'text'])
+
+const ID_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)+$/
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function nonEmptyString(value, label, maxLength) {
+  const normalized = String(value ?? '').trim()
+  if (!normalized || normalized.length > maxLength) throw new TypeError(`${label}が不正です`)
+  return normalized
+}
+
+export function validatePackagePath(value, label = 'path') {
+  const path = String(value ?? '')
+  const segments = path.split('/')
+  if (
+    !path ||
+    path.startsWith('/') ||
+    path.includes('\\') ||
+    /[\u0000-\u001f:]/.test(path) ||
+    segments.some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new TypeError(`${label}が安全な相対パスではありません`)
+  }
+  return path
+}
+
+function stringList(value, label, { required = false } = {}) {
+  if (value === undefined && !required) return []
+  if (!Array.isArray(value) || (required && value.length === 0)) throw new TypeError(`${label}が不正です`)
+  const result = value.map((item) => nonEmptyString(item, label, 128))
+  if (new Set(result).size !== result.length) throw new TypeError(`${label}に重複があります`)
+  return result
+}
+
+function catalogDefinitionUrl(value, catalogUrl) {
+  const path = String(value ?? '')
+  if (!path || path.startsWith('/') || path.startsWith('//') || path.includes('\\') || /[\u0000-\u001f:]/.test(path)) {
+    throw new TypeError('definitionが安全なサイト内パスではありません')
+  }
+  const definitionUrl = new URL(path, catalogUrl)
+  if (definitionUrl.origin !== catalogUrl.origin || !definitionUrl.pathname.endsWith('/stackchan-mod.json')) {
+    throw new TypeError('definitionがStack-chan MOD定義を指していません')
+  }
+  return definitionUrl
+}
+
+export function parseModDefinition(value) {
+  if (!isRecord(value)) throw new TypeError('MOD定義がJSONオブジェクトではありません')
+  if (value.format !== STACKCHAN_MOD_FORMAT) throw new TypeError('未対応のMOD定義形式です')
+  if (value.schemaVersion !== STACKCHAN_MOD_SCHEMA_VERSION) {
+    throw new TypeError(`未対応のMOD定義バージョンです: ${value.schemaVersion ?? 'なし'}`)
+  }
+
+  const id = nonEmptyString(value.id, 'id', 128)
+  if (!ID_PATTERN.test(id)) throw new TypeError('idは逆ドメイン形式で指定してください')
+  const version = nonEmptyString(value.version, 'version', 80)
+  if (!VERSION_PATTERN.test(version)) throw new TypeError('versionはセマンティックバージョン形式で指定してください')
+  if (!STACKCHAN_MOD_TYPES.includes(value.type)) throw new TypeError('typeはblockまたはtextで指定してください')
+  if (!isRecord(value.source)) throw new TypeError('sourceがありません')
+
+  const sourcePath = validatePackagePath(value.source.path, 'source.path')
+  if (value.type === 'block' && !sourcePath.endsWith('.stackchan-blocks.json')) {
+    throw new TypeError('block MODのsource.pathは.stackchan-blocks.jsonを指す必要があります')
+  }
+  if (value.type === 'text' && !/(^|\/)manifest[^/]*\.json$/.test(sourcePath)) {
+    throw new TypeError('text MODのsource.pathはModdable manifestを指す必要があります')
+  }
+
+  const artifacts = value.artifacts === undefined ? [] : value.artifacts
+  if (!Array.isArray(artifacts)) throw new TypeError('artifactsが不正です')
+
+  return {
+    format: STACKCHAN_MOD_FORMAT,
+    schemaVersion: STACKCHAN_MOD_SCHEMA_VERSION,
+    id,
+    version,
+    type: value.type,
+    name: nonEmptyString(value.name, 'name', 80),
+    description: nonEmptyString(value.description, 'description', 400),
+    ...(value.author === undefined ? {} : { author: nonEmptyString(value.author, 'author', 120) }),
+    ...(value.license === undefined ? {} : { license: nonEmptyString(value.license, 'license', 80) }),
+    source: { path: sourcePath },
+    targets: stringList(value.targets, 'targets', { required: true }),
+    capabilities: stringList(value.capabilities, 'capabilities'),
+    artifacts: artifacts.map((artifact, index) => {
+      if (!isRecord(artifact) || artifact.format !== 'xsa') {
+        throw new TypeError(`artifacts[${index}]が不正です`)
+      }
+      return {
+        format: 'xsa',
+        path: validatePackagePath(artifact.path, `artifacts[${index}].path`),
+        target: nonEmptyString(artifact.target, `artifacts[${index}].target`, 128),
+      }
+    }),
+  }
+}
+
+async function fetchJson(url, fetcher) {
+  const response = await fetcher(url)
+  if (!response.ok) throw new Error(`${url.pathname}を取得できませんでした (${response.status})`)
+  return response.json()
+}
+
+export async function loadModCatalog(catalogUrl, fetcher = globalThis.fetch) {
+  const resolvedCatalogUrl = new URL(catalogUrl, globalThis.location?.href ?? 'http://localhost/')
+  const catalog = await fetchJson(resolvedCatalogUrl, fetcher)
+  if (catalog?.format !== 'tech.stackchan.mod-catalog' || catalog.version !== 1) {
+    throw new TypeError('未対応のMODカタログ形式です')
+  }
+  if (!Array.isArray(catalog.definitions)) throw new TypeError('カタログにdefinitionsがありません')
+
+  const definitions = await Promise.all(
+    catalog.definitions.map(async (entry) => {
+      const definitionUrl = catalogDefinitionUrl(entry, resolvedCatalogUrl)
+      const definition = parseModDefinition(await fetchJson(definitionUrl, fetcher))
+      return {
+        ...definition,
+        definitionUrl,
+        sourceUrl: new URL(definition.source.path, definitionUrl),
+        artifacts: definition.artifacts.map((artifact) => ({
+          ...artifact,
+          url: new URL(artifact.path, definitionUrl),
+        })),
+      }
+    })
+  )
+  if (new Set(definitions.map((definition) => definition.id)).size !== definitions.length) {
+    throw new TypeError('カタログ内のMOD IDが重複しています')
+  }
+  return definitions
+}

--- a/web/mod-gallery/mod-definition.test.mjs
+++ b/web/mod-gallery/mod-definition.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+import { isXsArchive, xsArchiveVersion } from '../editor/mod-builder.mjs'
+import { parseVisualProject } from '../editor/project-format.mjs'
+import { analyzeWorkspace } from '../editor/project-validator.mjs'
+import { loadModCatalog, parseModDefinition, validatePackagePath } from './mod-definition.mjs'
+
+const catalogUrl = new URL('./catalog.json', import.meta.url)
+
+async function fileFetch(url) {
+  try {
+    const text = readFileSync(url, 'utf8')
+    return { ok: true, status: 200, json: async () => JSON.parse(text) }
+  } catch {
+    return { ok: false, status: 404 }
+  }
+}
+
+test('共通MOD定義からテキストとブロックのGalleryを構成する', async () => {
+  const definitions = await loadModCatalog(catalogUrl, fileFetch)
+  assert.equal(definitions.length, 5)
+  assert.equal(definitions.filter((definition) => definition.type === 'text').length, 1)
+  assert.equal(definitions.filter((definition) => definition.type === 'block').length, 4)
+  assert.equal(new Set(definitions.map((definition) => definition.id)).size, definitions.length)
+
+  for (const definition of definitions) {
+    assert.equal(definition.sourceUrl.protocol, 'file:')
+    assert.doesNotThrow(() => readFileSync(definition.sourceUrl))
+    if (definition.type !== 'block') continue
+    const project = parseVisualProject(readFileSync(definition.sourceUrl, 'utf8'))
+    const analysis = analyzeWorkspace(project.workspace, { target: project.target })
+    assert.equal(analysis.canBuild, true, `${definition.id}: ${JSON.stringify(analysis.diagnostics)}`)
+    assert.deepEqual(analysis.diagnostics, [], `${definition.id}: 初期状態に診断を残さない`)
+    assert.deepEqual(analysis.requirements, [...definition.capabilities].sort())
+  }
+})
+
+test('テキストMODの成果物は既存の実行互換性を維持する', async () => {
+  const definitions = await loadModCatalog(catalogUrl, fileFetch)
+  const starter = definitions.find((definition) => definition.type === 'text')
+  assert.ok(starter)
+  assert.equal(starter.artifacts.length, 1)
+  const archive = readFileSync(starter.artifacts[0].url)
+  assert.equal(isXsArchive(archive), true)
+  assert.deepEqual(xsArchiveVersion(archive), [17, 8, 0])
+})
+
+test('MOD定義は形式別の正本と安全なパッケージパスを要求する', () => {
+  const base = {
+    format: 'tech.stackchan.mod',
+    schemaVersion: 1,
+    id: 'tech.stackchan.test.sample',
+    version: '1.0.0',
+    name: 'test',
+    description: 'test MOD',
+    targets: ['simulator'],
+  }
+  assert.throws(() => parseModDefinition({ ...base, type: 'block', source: { path: 'manifest.json' } }), /block MOD/)
+  assert.throws(
+    () => parseModDefinition({ ...base, type: 'text', source: { path: 'sample.stackchan-blocks.json' } }),
+    /text MOD/
+  )
+  for (const path of ['/manifest.json', '../manifest.json', 'mod/../manifest.json', 'mod\\manifest.json']) {
+    assert.throws(() => validatePackagePath(path), /安全な相対パス/)
+  }
+})
+
+test('JSON Schemaと実装が同じ形式識別子と必須フィールドを持つ', () => {
+  const schema = JSON.parse(
+    readFileSync(new URL('../../docs/specs/stackchan-mod.schema.json', import.meta.url), 'utf8')
+  )
+  assert.equal(schema.properties.format.const, 'tech.stackchan.mod')
+  assert.equal(schema.properties.schemaVersion.const, 1)
+  assert.equal(schema.$id, 'https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json')
+  for (const field of [
+    'format',
+    'schemaVersion',
+    'id',
+    'version',
+    'type',
+    'name',
+    'description',
+    'source',
+    'targets',
+  ]) {
+    assert.ok(schema.required.includes(field), `${field} must be required`)
+  }
+  const workflow = readFileSync(new URL('../../.github/workflows/bundle.yml', import.meta.url), 'utf8')
+  assert.match(workflow, /docs\/specs\/stackchan-mod\.schema\.json \.\/web\/schemas\/stackchan-mod\.schema\.json/)
+})

--- a/web/mod-gallery/mod-gallery.css
+++ b/web/mod-gallery/mod-gallery.css
@@ -1,0 +1,227 @@
+.gallery {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  padding: 42px 24px 64px;
+}
+
+.gallery-hero {
+  max-width: 690px;
+  margin-bottom: 30px;
+}
+
+.gallery-eyebrow {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+}
+
+.gallery-hero h1 {
+  margin-bottom: 8px;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  letter-spacing: -0.04em;
+}
+
+.gallery-hero p,
+.gallery-summary,
+.gallery-empty {
+  color: var(--muted);
+}
+
+.gallery-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(150px, 220px);
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+}
+
+.gallery-controls label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 650;
+}
+
+.search-input {
+  position: relative;
+  display: block;
+}
+
+.search-input svg {
+  position: absolute;
+  z-index: 1;
+  top: 11px;
+  left: 11px;
+  width: 19px;
+  height: 19px;
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.search-input input {
+  padding-left: 40px;
+}
+
+.gallery-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 18px 0 12px;
+  font-size: 0.78rem;
+}
+
+.gallery-summary p {
+  margin: 0;
+}
+
+.gallery-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.type-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.type-dot.block {
+  background: var(--accent);
+}
+
+.mod-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.mod-card {
+  display: grid;
+  min-width: 0;
+  min-height: 260px;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+}
+
+.mod-card:hover {
+  border-color: var(--line-hover);
+  background: var(--surface-raised);
+}
+
+.mod-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mod-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mod-version {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.mod-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.mod-type[data-type='block'] {
+  border-color: var(--accent-strong);
+  color: var(--accent);
+}
+
+.mod-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.mod-capabilities {
+  display: flex;
+  align-content: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mod-capability {
+  padding: 4px 7px;
+  border-radius: 4px;
+  background: #101214;
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.mod-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.mod-actions .button,
+.mod-actions button {
+  min-height: 38px;
+  padding: 7px 10px;
+  font-size: 0.75rem;
+}
+
+.mod-actions .primary-button {
+  flex: 1 1 auto;
+}
+
+.gallery-empty {
+  padding: 42px 16px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 9px;
+  text-align: center;
+}
+
+#gallery-status:not(:empty) {
+  margin-top: 18px;
+  color: var(--warning);
+}
+
+@media (max-width: 680px) {
+  .gallery {
+    padding: 28px 16px 48px;
+  }
+
+  .gallery-controls,
+  .mod-list {
+    grid-template-columns: 1fr;
+  }
+
+  .gallery-summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/web/mod-gallery/mod-gallery.mjs
+++ b/web/mod-gallery/mod-gallery.mjs
@@ -1,0 +1,197 @@
+import { inspectDeploymentCompatibility, profileFor } from '../editor/capabilities.mjs'
+import { createEsptoolLoader, DEVICE_OPERATION_STATUS, installModToDevice } from '../editor/esptool-installer.mjs'
+import { xsArchiveVersion } from '../editor/mod-builder.mjs'
+import { createModStorage } from '../simulator/mod-storage.mjs'
+import { loadModCatalog } from './mod-definition.mjs'
+
+const list = document.getElementById('mod-list')
+const count = document.getElementById('gallery-count')
+const empty = document.getElementById('gallery-empty')
+const status = document.getElementById('gallery-status')
+const search = document.getElementById('mod-search')
+const typeFilter = document.getElementById('type-filter')
+
+let definitions = []
+
+function setStatus(message = '') {
+  status.textContent = message
+}
+
+function typeLabel(type) {
+  return type === 'block' ? 'ブロック' : 'テキスト'
+}
+
+function targetLabel(target) {
+  return profileFor(target).label
+}
+
+async function fetchArchive(artifact) {
+  const response = await fetch(artifact.url)
+  if (!response.ok) throw new Error(`MODを取得できませんでした (${response.status})`)
+  return new Uint8Array(await response.arrayBuffer())
+}
+
+async function installToSimulator(definition, artifact) {
+  setStatus(`「${definition.name}」を準備しています`)
+  const bytes = await fetchArchive(artifact)
+  const compatibility = inspectDeploymentCompatibility('simulator', {
+    xsVersion: xsArchiveVersion(bytes),
+    requireArchive: true,
+  })
+  if (!compatibility.compatible) {
+    throw new Error(compatibility.diagnostics.map((item) => item.message).join(' / '))
+  }
+  await createModStorage().saveInstalledMod({ name: `${definition.id}.xsa`, bytes })
+  location.href = `../simulator/?gallery=${encodeURIComponent(definition.id)}`
+}
+
+async function installToDevice(definition, artifact) {
+  if (!('serial' in navigator)) throw new Error('実機への書き込みにはChromeまたはEdgeを使ってください')
+  const bytes = await fetchArchive(artifact)
+  const archiveVersion = xsArchiveVersion(bytes)
+  const port = await navigator.serial.requestPort()
+  setStatus(`「${definition.name}」を実機へ書き込んでいます`)
+  const result = await installModToDevice(createEsptoolLoader, port, bytes, {
+    onPrompt: setStatus,
+    onPreflight: ({ chip, firmware }) => {
+      const compatibility = inspectDeploymentCompatibility(artifact.target, {
+        chip,
+        xsVersion: archiveVersion,
+        firmwareVersion: firmware.version,
+        requireArchive: true,
+        requireFirmware: true,
+      })
+      if (!compatibility.compatible) {
+        throw new Error(compatibility.diagnostics.map((item) => item.message).join(' / '))
+      }
+      return true
+    },
+  })
+  if (result.status === DEVICE_OPERATION_STATUS.CANCELLED) {
+    setStatus(`「${definition.name}」の書き込みをキャンセルしました`)
+    return
+  }
+  setStatus(`「${definition.name}」を実機へ書き込みました`)
+}
+
+function actionButton(label, icon, action, className = '') {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = className
+  const iconElement = document.createElement('i')
+  iconElement.dataset.lucide = icon
+  const copy = document.createElement('span')
+  copy.textContent = label
+  button.append(iconElement, copy)
+  button.addEventListener('click', async () => {
+    button.disabled = true
+    setStatus()
+    try {
+      await action()
+    } catch (error) {
+      setStatus(error.message ?? String(error))
+    } finally {
+      button.disabled = false
+    }
+  })
+  return button
+}
+
+function linkAction(label, icon, href, className = '') {
+  const anchor = document.createElement('a')
+  anchor.className = `button ${className}`.trim()
+  anchor.href = href
+  const iconElement = document.createElement('i')
+  iconElement.dataset.lucide = icon
+  const copy = document.createElement('span')
+  copy.textContent = label
+  anchor.append(iconElement, copy)
+  return anchor
+}
+
+function renderCard(definition) {
+  const card = document.createElement('article')
+  card.className = 'mod-card'
+  card.dataset.modId = definition.id
+  card.dataset.modType = definition.type
+
+  const header = document.createElement('header')
+  header.className = 'mod-card-header'
+  const heading = document.createElement('div')
+  const title = document.createElement('h2')
+  title.textContent = definition.name
+  const version = document.createElement('div')
+  version.className = 'mod-version'
+  version.textContent = `v${definition.version} · ${definition.author ?? '作者不明'}`
+  heading.append(title, version)
+  const type = document.createElement('span')
+  type.className = 'mod-type'
+  type.dataset.type = definition.type
+  type.textContent = typeLabel(definition.type)
+  header.append(heading, type)
+
+  const description = document.createElement('p')
+  description.className = 'mod-description'
+  description.textContent = definition.description
+
+  const capabilities = document.createElement('div')
+  capabilities.className = 'mod-capabilities'
+  for (const capability of definition.capabilities) {
+    const badge = document.createElement('span')
+    badge.className = 'mod-capability'
+    badge.textContent = capability
+    capabilities.append(badge)
+  }
+  for (const target of definition.targets) {
+    const badge = document.createElement('span')
+    badge.className = 'mod-capability'
+    badge.textContent = targetLabel(target)
+    capabilities.append(badge)
+  }
+
+  const actions = document.createElement('div')
+  actions.className = 'mod-actions'
+  if (definition.type === 'block') {
+    const editorUrl = new URL('../editor/', import.meta.url)
+    editorUrl.searchParams.set('project', definition.sourceUrl.href)
+    actions.append(linkAction('ブロックで開く', 'blocks', editorUrl.href, 'primary-button'))
+  } else {
+    const artifact = definition.artifacts[0]
+    if (artifact) {
+      actions.append(
+        actionButton('シミュレーターで試す', 'play', () => installToSimulator(definition, artifact), 'primary-button'),
+        actionButton('実機へ書き込む', 'usb', () => installToDevice(definition, artifact))
+      )
+    }
+    actions.append(linkAction('ソースを見る', 'file-code-2', definition.sourceUrl.href))
+  }
+  card.append(header, description, capabilities, actions)
+  return card
+}
+
+function render() {
+  const query = search.value.trim().toLocaleLowerCase('ja')
+  const selectedType = typeFilter.value
+  const visible = definitions.filter((definition) => {
+    const matchesType = selectedType === 'all' || definition.type === selectedType
+    const haystack = [definition.name, definition.description, ...definition.capabilities]
+      .join(' ')
+      .toLocaleLowerCase('ja')
+    return matchesType && (!query || haystack.includes(query))
+  })
+  list.replaceChildren(...visible.map(renderCard))
+  count.textContent = `${visible.length}件のMOD`
+  empty.hidden = visible.length !== 0
+  globalThis.lucide?.createIcons()
+}
+
+search.addEventListener('input', render)
+typeFilter.addEventListener('change', render)
+
+try {
+  definitions = await loadModCatalog('./catalog.json')
+  render()
+} catch (error) {
+  count.textContent = 'MODを読み込めませんでした'
+  setStatus(`Galleryの読み込みに失敗しました: ${error.message}`)
+}

--- a/web/mod-gallery/samples/buttons/buttons.stackchan-blocks.json
+++ b/web/mod-gallery/samples/buttons/buttons.stackchan-blocks.json
@@ -1,0 +1,82 @@
+{
+  "format": "tech.stackchan.visual-project",
+  "version": 1,
+  "id": "gallery-block-buttons",
+  "name": "ボタンでリアクション",
+  "target": "m5stackchan-cores3",
+  "workspace": {
+    "blocks": {
+      "languageVersion": 0,
+      "blocks": [
+        {
+          "type": "stackchan_on_button",
+          "x": 24,
+          "y": 24,
+          "fields": { "BUTTON": "a" },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_set_emotion",
+                "fields": { "EMOTION": "HAPPY" },
+                "next": {
+                  "block": {
+                    "type": "stackchan_say",
+                    "inputs": { "TEXT": { "shadow": { "type": "text", "fields": { "TEXT": "うれしい!" } } } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "stackchan_on_button",
+          "x": 280,
+          "y": 24,
+          "fields": { "BUTTON": "b" },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_set_emotion",
+                "fields": { "EMOTION": "SLEEPY" },
+                "next": {
+                  "block": {
+                    "type": "stackchan_say",
+                    "inputs": { "TEXT": { "shadow": { "type": "text", "fields": { "TEXT": "ねむいな" } } } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "stackchan_on_button",
+          "x": 536,
+          "y": 24,
+          "fields": { "BUTTON": "c" },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_set_emotion",
+                "fields": { "EMOTION": "DOUBTFUL" },
+                "next": {
+                  "block": {
+                    "type": "stackchan_say",
+                    "inputs": { "TEXT": { "shadow": { "type": "text", "fields": { "TEXT": "なんだろう?" } } } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "assets": [],
+  "settings": {
+    "educationalProfile": true,
+    "embedAssets": true,
+    "faceAsset": null
+  },
+  "createdAt": "2026-07-19T00:00:00.000Z",
+  "updatedAt": "2026-07-19T00:00:00.000Z"
+}

--- a/web/mod-gallery/samples/buttons/stackchan-mod.json
+++ b/web/mod-gallery/samples/buttons/stackchan-mod.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json",
+  "format": "tech.stackchan.mod",
+  "schemaVersion": 1,
+  "id": "tech.stackchan.samples.block-buttons",
+  "version": "1.0.0",
+  "type": "block",
+  "name": "ボタンでリアクション",
+  "description": "A、B、Cボタンごとに違う表情とせりふを実行します。",
+  "author": "Stack-chan Community",
+  "license": "Apache-2.0",
+  "source": {
+    "path": "buttons.stackchan-blocks.json"
+  },
+  "targets": ["m5stackchan-cores3"],
+  "capabilities": ["face", "audio.speech", "input.buttons"]
+}

--- a/web/mod-gallery/samples/hello/hello.stackchan-blocks.json
+++ b/web/mod-gallery/samples/hello/hello.stackchan-blocks.json
@@ -1,0 +1,59 @@
+{
+  "format": "tech.stackchan.visual-project",
+  "version": 1,
+  "id": "gallery-block-hello",
+  "name": "あいさつと表情",
+  "target": "m5stackchan-cores3",
+  "workspace": {
+    "blocks": {
+      "languageVersion": 0,
+      "blocks": [
+        {
+          "type": "stackchan_on_start",
+          "x": 24,
+          "y": 24,
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_set_emotion",
+                "fields": { "EMOTION": "HAPPY" },
+                "next": {
+                  "block": {
+                    "type": "stackchan_show_balloon",
+                    "inputs": {
+                      "TEXT": { "shadow": { "type": "text", "fields": { "TEXT": "こんにちは!" } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "stackchan_on_button",
+          "x": 24,
+          "y": 220,
+          "fields": { "BUTTON": "a" },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_say",
+                "inputs": {
+                  "TEXT": { "shadow": { "type": "text", "fields": { "TEXT": "ぼく ｽﾀｯｸﾁｬﾝ!" } } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "assets": [],
+  "settings": {
+    "educationalProfile": true,
+    "embedAssets": true,
+    "faceAsset": null
+  },
+  "createdAt": "2026-07-19T00:00:00.000Z",
+  "updatedAt": "2026-07-19T00:00:00.000Z"
+}

--- a/web/mod-gallery/samples/hello/stackchan-mod.json
+++ b/web/mod-gallery/samples/hello/stackchan-mod.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json",
+  "format": "tech.stackchan.mod",
+  "schemaVersion": 1,
+  "id": "tech.stackchan.samples.block-hello",
+  "version": "1.0.0",
+  "type": "block",
+  "name": "あいさつと表情",
+  "description": "起動時に笑顔と吹き出しを表示し、Aボタンを押すと話します。",
+  "author": "Stack-chan Community",
+  "license": "Apache-2.0",
+  "source": {
+    "path": "hello.stackchan-blocks.json"
+  },
+  "targets": ["m5stackchan-cores3"],
+  "capabilities": ["face", "audio.speech", "input.buttons", "ui.drawer"]
+}

--- a/web/mod-gallery/samples/look-around/look-around.stackchan-blocks.json
+++ b/web/mod-gallery/samples/look-around/look-around.stackchan-blocks.json
@@ -1,0 +1,43 @@
+{
+  "format": "tech.stackchan.visual-project",
+  "version": 1,
+  "id": "gallery-block-look-around",
+  "name": "定期的に見回す",
+  "target": "m5stackchan-cores3",
+  "workspace": {
+    "blocks": {
+      "languageVersion": 0,
+      "blocks": [
+        {
+          "type": "stackchan_every",
+          "x": 24,
+          "y": 24,
+          "fields": { "SECONDS": 3 },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_look_at",
+                "fields": { "X": 1, "Y": 0.5, "Z": 0 },
+                "next": {
+                  "block": {
+                    "type": "stackchan_wait",
+                    "fields": { "DURATION": 500 },
+                    "next": { "block": { "type": "stackchan_look_away" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "assets": [],
+  "settings": {
+    "educationalProfile": true,
+    "embedAssets": true,
+    "faceAsset": null
+  },
+  "createdAt": "2026-07-19T00:00:00.000Z",
+  "updatedAt": "2026-07-19T00:00:00.000Z"
+}

--- a/web/mod-gallery/samples/look-around/stackchan-mod.json
+++ b/web/mod-gallery/samples/look-around/stackchan-mod.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json",
+  "format": "tech.stackchan.mod",
+  "schemaVersion": 1,
+  "id": "tech.stackchan.samples.block-look-around",
+  "version": "1.0.0",
+  "type": "block",
+  "name": "定期的に見回す",
+  "description": "3秒ごとに向きを変え、少し待って正面へ戻ります。",
+  "author": "Stack-chan Community",
+  "license": "Apache-2.0",
+  "source": {
+    "path": "look-around.stackchan-blocks.json"
+  },
+  "targets": ["m5stackchan-cores3"],
+  "capabilities": ["motion"]
+}

--- a/web/mod-gallery/samples/sensors/sensors.stackchan-blocks.json
+++ b/web/mod-gallery/samples/sensors/sensors.stackchan-blocks.json
@@ -1,0 +1,52 @@
+{
+  "format": "tech.stackchan.visual-project",
+  "version": 1,
+  "id": "gallery-block-sensors",
+  "name": "センサーとLED",
+  "target": "m5stackchan-cores3",
+  "workspace": {
+    "blocks": {
+      "languageVersion": 0,
+      "blocks": [
+        {
+          "type": "stackchan_on_imu",
+          "x": 24,
+          "y": 24,
+          "fields": { "MOTION": "shake" },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_light_rainbow",
+                "fields": { "NAME": "a" }
+              }
+            }
+          }
+        },
+        {
+          "type": "stackchan_on_head_touch",
+          "x": 340,
+          "y": 24,
+          "fields": { "GESTURE": "forwardSwipe" },
+          "inputs": {
+            "DO": {
+              "block": {
+                "type": "stackchan_show_balloon",
+                "inputs": {
+                  "TEXT": { "shadow": { "type": "text", "fields": { "TEXT": "スワイプしたね!" } } }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "assets": [],
+  "settings": {
+    "educationalProfile": true,
+    "embedAssets": true,
+    "faceAsset": null
+  },
+  "createdAt": "2026-07-19T00:00:00.000Z",
+  "updatedAt": "2026-07-19T00:00:00.000Z"
+}

--- a/web/mod-gallery/samples/sensors/stackchan-mod.json
+++ b/web/mod-gallery/samples/sensors/stackchan-mod.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json",
+  "format": "tech.stackchan.mod",
+  "schemaVersion": 1,
+  "id": "tech.stackchan.samples.block-sensors",
+  "version": "1.0.0",
+  "type": "block",
+  "name": "センサーとLED",
+  "description": "本体を振るとLEDを虹色にし、頭部をスワイプすると吹き出しを表示します。",
+  "author": "Stack-chan Community",
+  "license": "Apache-2.0",
+  "source": {
+    "path": "sensors.stackchan-blocks.json"
+  },
+  "targets": ["m5stackchan-cores3"],
+  "capabilities": ["input.imu", "input.headTouch", "lighting", "ui.drawer"]
+}

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "description": "Stack-chan development server",
   "scripts": {
     "dev": "node static-server.mjs",
-    "test": "node --test simulator/*.test.mjs editor/*.test.mjs face-editor/*.test.mjs *.test.mjs",
+    "test": "node --test simulator/*.test.mjs editor/*.test.mjs face-editor/*.test.mjs mod-gallery/*.test.mjs *.test.mjs",
     "check:editor-artifacts": "node check-editor-artifacts.mjs",
     "test:visual": "node visual-pages-test.mjs && node simulator/visual-test.mjs",
     "metrics:aggregate": "node editor/aggregate-metrics-cli.mjs"

--- a/web/simulator/samples/stackchan-mod.json
+++ b/web/simulator/samples/stackchan-mod.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://stack-chan.github.io/stack-chan/web/schemas/stackchan-mod.schema.json",
+  "format": "tech.stackchan.mod",
+  "schemaVersion": 1,
+  "id": "tech.stackchan.samples.starter",
+  "version": "1.0.0",
+  "type": "text",
+  "name": "はじめてのMOD",
+  "description": "顔の色と吹き出しを変えて、MODのインストールを確認するスターターです。",
+  "author": "Stack-chan Community",
+  "license": "Apache-2.0",
+  "source": {
+    "path": "sample-mod/manifest.json"
+  },
+  "targets": ["m5stackchan-cores3", "simulator"],
+  "capabilities": ["face", "ui.drawer"],
+  "artifacts": [
+    {
+      "format": "xsa",
+      "path": "stackchan-sample-mod.xsa",
+      "target": "m5stackchan-cores3"
+    }
+  ]
+}

--- a/web/tool-navigation.mjs
+++ b/web/tool-navigation.mjs
@@ -15,6 +15,13 @@ export const TOOL_NAVIGATION_ITEMS = Object.freeze([
     icon: 'sliders-horizontal',
   },
   {
+    id: 'mod-gallery',
+    href: 'mod-gallery/',
+    label: 'MOD Gallery',
+    description: '公開済みMODを試して編集する',
+    icon: 'store',
+  },
+  {
     id: 'simulator',
     href: 'simulator/',
     label: 'シミュレーター',
@@ -52,6 +59,7 @@ export function navigationItemForPath(pathname) {
   if (/\/editor\/tutorial\.html$/.test(normalized)) return 'tutorial'
   if (/\/face-editor\/?$/.test(normalized)) return 'face-editor'
   if (/\/editor\/?$/.test(normalized)) return 'editor'
+  if (/\/mod-gallery\/?$/.test(normalized)) return 'mod-gallery'
   if (/\/simulator\/?$/.test(normalized)) return 'simulator'
   if (/\/preference\/?$/.test(normalized)) return 'preference'
   if (/\/flash\/?$/.test(normalized)) return 'flash'

--- a/web/tool-navigation.test.mjs
+++ b/web/tool-navigation.test.mjs
@@ -6,7 +6,7 @@ import { GUIDE_NAVIGATION_ITEMS, navigationItemForPath, TOOL_NAVIGATION_ITEMS } 
 test('tool navigation exposes every primary web surface in the left drawer', () => {
   assert.deepEqual(
     TOOL_NAVIGATION_ITEMS.map((item) => item.id),
-    ['home', 'flash', 'preference', 'simulator', 'editor', 'face-editor']
+    ['home', 'flash', 'preference', 'mod-gallery', 'simulator', 'editor', 'face-editor']
   )
   assert.deepEqual(
     GUIDE_NAVIGATION_ITEMS.map((item) => item.id),
@@ -17,6 +17,7 @@ test('tool navigation exposes every primary web surface in the left drawer', () 
 test('tool navigation selects the exact surface instead of every parent path', () => {
   assert.equal(navigationItemForPath('/stack-chan/'), 'home')
   assert.equal(navigationItemForPath('/stack-chan/editor/'), 'editor')
+  assert.equal(navigationItemForPath('/stack-chan/mod-gallery/'), 'mod-gallery')
   assert.equal(navigationItemForPath('/stack-chan/editor/tutorial.html'), 'tutorial')
   assert.equal(navigationItemForPath('/stack-chan/face-editor/index.html'), 'face-editor')
 })

--- a/web/visual-pages-test.mjs
+++ b/web/visual-pages-test.mjs
@@ -76,6 +76,7 @@ const pages = [
   ['home', '/'],
   ['flash', '/flash/'],
   ['preference', '/preference/'],
+  ['mod-gallery', '/mod-gallery/'],
   ['editor', '/editor/'],
   ['tutorial', '/editor/tutorial.html'],
   ['face-editor', '/face-editor/'],
@@ -276,11 +277,29 @@ try {
       if (pageName === 'home' && viewportName === 'desktop') {
         await page.locator('.tool-menu-button').click()
         await page.locator('#tool-drawer[open]').waitFor({ state: 'visible' })
-        assert.equal(await page.locator('#tool-drawer .tool-drawer-link').count(), 7)
+        assert.equal(await page.locator('#tool-drawer .tool-drawer-link').count(), 8)
         assert.match(await page.locator('#tool-drawer [aria-current="page"]').innerText(), /ホーム/)
         await page.screenshot({ path: '/tmp/stackchan-tool-drawer.png', fullPage: true })
         await page.keyboard.press('Escape')
         await page.locator('#tool-drawer').waitFor({ state: 'hidden' })
+      }
+      if (pageName === 'mod-gallery' && viewportName === 'desktop') {
+        await page.locator('.mod-card').first().waitFor({ state: 'visible' })
+        assert.equal(await page.locator('.mod-card').count(), 5, 'gallery: common catalog entries')
+        assert.equal(await page.locator('.mod-card[data-mod-type="block"]').count(), 4, 'gallery: block samples')
+        await page.locator('#type-filter').selectOption('block')
+        assert.equal(await page.locator('.mod-card').count(), 4, 'gallery: block filter')
+        const editorHref = await page.locator('.mod-card .primary-button').first().getAttribute('href')
+        assert.match(editorHref, /\/editor\/\?project=/, 'gallery: block editor hand-off')
+        assert.match(decodeURIComponent(editorHref), /\.stackchan-blocks\.json$/, 'gallery: editable project URL')
+        const editorPage = await browser.newPage()
+        await editorPage.goto(editorHref, { waitUntil: 'domcontentloaded' })
+        await editorPage.waitForFunction(
+          () => document.querySelector('#project-name-label')?.textContent === 'あいさつと表情'
+        )
+        assert.equal(await editorPage.locator('#project-name-label').innerText(), 'あいさつと表情')
+        assert.match(await editorPage.locator('#build-status').innerText(), /Galleryから/)
+        await editorPage.close()
       }
       if (pageName === 'face-editor' && viewportName === 'mobile') {
         assert.equal(await page.locator('#send-to-editor span').isVisible(), true)

--- a/web/web-ui.test.mjs
+++ b/web/web-ui.test.mjs
@@ -10,6 +10,7 @@ const pages = [
   'preference/index.html',
   'editor/index.html',
   'editor/tutorial.html',
+  'mod-gallery/index.html',
   'face-editor/index.html',
   'simulator/index.html',
 ]
@@ -32,7 +33,7 @@ test('tool pages load the shared left drawer without changing integration ids', 
     assert.doesNotMatch(html, /class="tool-nav"/, `${page} should not duplicate the retired right navigation`)
   }
   const navigation = readFileSync('tool-navigation.mjs', 'utf8')
-  for (const id of ['home', 'flash', 'preference', 'simulator', 'editor', 'face-editor', 'tutorial']) {
+  for (const id of ['home', 'flash', 'preference', 'mod-gallery', 'simulator', 'editor', 'face-editor', 'tutorial']) {
     assert.match(navigation, new RegExp(`id: '${id}'`), `drawer should expose ${id}`)
   }
   assert.match(navigation, /topbar\.prepend\(button\)/)


### PR DESCRIPTION
## Summary

- define a versioned `stackchan-mod.json` metadata format and JSON Schema shared by text and block MODs
- add a MOD Gallery to the web UI, including search/type filtering and safe same-origin handoff to the block editor
- register the existing starter text MOD and add four editable block samples for greetings, buttons, motion, and sensors
- publish the schema with the Pages bundle and cover the new navigation and Gallery flow with automated tests

## Why

Beginners currently move from flashing the host directly into tools with different sample formats and little continuity. A common MOD definition and Gallery provide a single discovery surface while preserving each MOD's editable source format.

## Impact

Users can browse MODs, distinguish text and block sources, open block samples directly in the editor, and install compatible built artifacts without treating the source type as the runtime format.

## Validation

- `npm test` in `web`: 195 passed
- `npm run test:visual` in `web`: passed
- `npm test` in `firmware`: 187 passed
- `npm run check:architecture` in `firmware`: 62 passed
- `npm run lint` in `firmware`: passed
- `npm run build:wasm`: passed
- manual M5StackChan CoreS3 test: release host flashed and MOD Gallery sample startup/behavior confirmed on device


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a MOD Gallery for browsing, searching, filtering, and trying published MODs.
  * Added support for opening gallery projects directly in the visual editor.
  * Added simulator installation and device deployment actions for compatible MODs.
  * Added sample MODs covering buttons, greetings, sensors, and movement.
* **Documentation**
  * Documented the MOD metadata format and validation rules.
* **Bug Fixes**
  * Improved error handling when external projects cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->