### PR TITLE
fix: use head LED in block sample

### DIFF
--- a/web/editor/samples.mjs
+++ b/web/editor/samples.mjs
@@ -110,7 +110,7 @@ export const VISUAL_SAMPLES = Object.freeze([
             x: 24,
             y: 24,
             fields: { MOTION: 'shake' },
-            inputs: { DO: { block: { type: 'stackchan_light_rainbow', fields: { NAME: 'a' } } } },
+            inputs: { DO: { block: { type: 'stackchan_light_rainbow', fields: { NAME: 'head' } } } },
           },
           {
             type: 'stackchan_on_head_touch',

--- a/web/editor/samples.test.mjs
+++ b/web/editor/samples.test.mjs
@@ -36,3 +36,12 @@ test('five representative samples have unique ids and buildable workspace struct
   }
   assert.equal(sampleById('missing'), VISUAL_SAMPLES[0])
 })
+
+test('sensor sample targets the CoreS3 head LED', () => {
+  const sensorBlocks = sampleById('sensors').workspace.blocks.blocks
+  const imuBlock = sensorBlocks.find((block) => block.type === 'stackchan_on_imu')
+  const rainbowBlock = imuBlock?.inputs?.DO?.block
+
+  assert.equal(rainbowBlock?.type, 'stackchan_light_rainbow')
+  assert.equal(rainbowBlock?.fields?.NAME, 'head')
+})


### PR DESCRIPTION
## Summary

- change the `4. センサーとLED` Blockly sample to target the CoreS3 `head` LED
- add a regression test for the sample LED name

## Why

The sample used the generic LED name `a`, while the M5StackChan CoreS3 platform config registers its head LEDs as `head`. Generated code therefore silently skipped the rainbow effect.

## Validation

- `node --test simulator/*.test.mjs editor/*.test.mjs face-editor/*.test.mjs *.test.mjs` (23/23 passed)
- `node check-editor-artifacts.mjs`
- Prettier check for the changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sensors sample so the IMU shake action targets the stackchan’s head.

* **Tests**
  * Added validation to ensure the sample’s sensor wiring and target name are configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->