### PR TITLE
chore: migrate agent guidance to AGENTS.md

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+reviews:
+  path_instructions:
+    - path: "**/*.test.*"
+      instructions: |
+        Apply the test-design rules in AGENTS.md. Flag tests that read production
+        source as text only to re-assert constants, configuration values, or
+        implementation fragments. Do not flag relational invariants,
+        generated-artifact validation, dependency-boundary checks, documented
+        tombstones, or cases where source structure is the maintained contract.
+    - path: "**/*.architecture.*"
+      instructions: |
+        Apply the test-design rules in AGENTS.md. Flag tests that read production
+        source as text only to re-assert constants, configuration values, or
+        implementation fragments. Do not flag relational invariants,
+        generated-artifact validation, dependency-boundary checks, documented
+        tombstones, or cases where source structure is the maintained contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides repository-wide guidance for coding agents working in this repository.
 
 ## Project Overview
 
@@ -102,7 +102,21 @@ Moddable test modules live under the target implementation with `manifest.test.j
 Cheap constructor smokes are consolidated into shared manifests (`firmware/host/modules/__tests__/module-smoke`, `firmware/mods/examples/provider-dialogues/__tests__/dialogue-smoke`) because each manifest pays a full mcconfig build.
 Node.js unit tests live next to pure helper implementations and run through `npm run test:unit`.
 Prefer XS-driven Moddable tests for behavior that touches the platform (Piu, Timer, drivers); keep Node.js tests for pure logic.
-Tests must exercise behavior — do not write tests that merely re-assert source text or manifest values; record such constraints as why-comments in the source instead.
+Tests must verify observable behavior or relational invariants.
+
+Do not:
+
+- Read production source as text merely to assert exact constants, configuration values, code fragments, or regular-expression matches.
+- Add tests that fail on a legitimate implementation-literal change without detecting a behavioral or architectural regression.
+
+It is valid to:
+
+- Parse generated artifacts or manifests and validate their schema.
+- Compare independently maintained files or dynamically discovered entries.
+- Verify dependency boundaries, completeness, tombstones, and relational invariants.
+- Read source when its structure is itself the maintained contract.
+
+If a constraint cannot be tested through behavior or a relational invariant, document the reason next to the source or configuration instead of adding a source-mirroring test.
 
 ## Pull Request Review Guidance
 

--- a/docs/architecture/firmware-rearchitecture_ja.md
+++ b/docs/architecture/firmware-rearchitecture_ja.md
@@ -467,7 +467,7 @@ flowchart TD
 - [x] 対応済み：`firmware/docs/0002-image-face.md` の旧 renderer 前提を削除または更新する。
 - [x] 対応済み：`firmware/face-context-as-views.md` を `FaceState` 方針に合わせて削除または更新する。
 - [x] 対応済み：`firmware/piu-faster.md`（現 `firmware/docs/piu-performance-policy.md`）を UI performance 方針として統合する。
-- [x] 対応済み：`CLAUDE.md` の旧構成参照を削除または更新する。
+- [x] 対応済み：`AGENTS.md` の旧構成参照を削除または更新する。
 - [x] 対応済み：`renderer.type`、`renderers-piu`、旧 renderer API を説明する残存文書を削除または更新する。
 - [x] 対応済み：tracked tree に旧 `firmware/stackchan/renderers` と旧 `firmware/stackchan/renderers-piu` が残っていないことを確認する。
 - [x] 対応済み：ローカルに空ディレクトリが残る場合でも、manifest、import、document から参照しない。


### PR DESCRIPTION
## Summary

- rename the repository-wide agent guidance from `CLAUDE.md` to `AGENTS.md`
- clarify the distinction between source-mirroring tests and valid relational or architectural checks
- configure CodeRabbit to apply the same guidance specifically to test and architecture-test files
- update the remaining documentation reference to the guidance filename

## Why

The test policy was stored in a Claude-specific file, so agents that do not load
`CLAUDE.md` could miss it. Its previous wording also left room to interpret all
source- or manifest-reading tests as invalid, even when they verify a genuine
relational invariant or architectural contract.

This change makes the guidance agent-neutral and gives both implementation
agents and CodeRabbit explicit allowed and forbidden examples.

## Scope

This PR changes guidance and review configuration only. It intentionally does
not remove existing source-mirroring tests or add a deterministic static
checker; those can be handled separately after the remaining tests are audited.

## Release impact

`none` — repository guidance and review configuration only; no firmware or web
runtime behavior changes. No changeset is required.

## Verification

- parsed `.coderabbit.yaml` with `yaml.safe_load`
- ran `git diff --check`
- confirmed the staged change is recognized as `CLAUDE.md -> AGENTS.md`
- pre-commit hook passed (no matching Biome-managed source files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated repository-wide development guidance with clearer testing principles focused on observable behavior and meaningful invariants.
  - Clarified when source-structure and generated-artifact checks are appropriate.
  - Updated firmware rearchitecture documentation to reference the current guidance structure.

- **Chores**
  - Enhanced automated review configuration for test and architecture-related changes, helping surface issues against the project’s documented standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->