### PR TITLE
feat: add realtime robot conversation tools

### DIFF
--- a/.changeset/realtime-robot-tools.md
+++ b/.changeset/realtime-robot-tools.md
@@ -1,0 +1,5 @@
+---
+"stack-chan": minor
+---
+
+Realtime Conversation に感情・モーション・LED・メロディ再生・ロボット状態取得のツールを追加し、会話音声と効果音を同時に扱える共有 AudioOut を導入します。

--- a/firmware/host/app/__tests__/robot-chat-tools.test.ts
+++ b/firmware/host/app/__tests__/robot-chat-tools.test.ts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { writeAliasPackage } from '../../modules/testing/node-alias-package.js'
+
+type RobotChatToolsModule = typeof import('../robot-chat-tools.js')
+
+function installBareSpecifierPackages(): void {
+  const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+  writeAliasPackage(hostRoot, 'face-state', resolve(hostRoot, 'modules/ui/state/face-state.js'))
+  writeAliasPackage(hostRoot, 'timer', resolve(hostRoot, 'modules/testing/fakes/timer.js'), { hasDefaultExport: true })
+}
+
+type RobotFixture = ReturnType<typeof createRobot>
+
+function createRobot(options: { led?: boolean; sample?: object } = {}) {
+  const calls = {
+    emotions: [] as number[],
+    poses: [] as { position: { x: number; y: number; z: number }; rotation: { y: number; p: number; r: number } }[],
+    torque: [] as boolean[],
+    lookAway: 0,
+    lights: [] as unknown[][],
+    tones: [] as { hz: number; duration: number; volume?: number }[],
+  }
+  const body = {
+    position: { x: 0.01, y: 0.02, z: 0.03 },
+    rotation: { y: 0.1, p: -0.2, r: 0.03 },
+  }
+  const led = options.led === false ? {} : { head: {} }
+  const robot = {
+    face: {
+      setEmotion: (emotion: number) => calls.emotions.push(emotion),
+    },
+    motion: {
+      pose: { body },
+      lookAway: () => {
+        calls.lookAway += 1
+      },
+      setTorque: async (enabled: boolean) => {
+        calls.torque.push(enabled)
+      },
+      setPose: async (pose: (typeof calls.poses)[number]) => {
+        calls.poses.push(structuredClone(pose))
+        body.position = { ...pose.position }
+        body.rotation = { ...pose.rotation }
+      },
+    },
+    lighting: {
+      led,
+      lightOn: (...args: unknown[]) => calls.lights.push(['on', ...args]),
+      lightOff: (...args: unknown[]) => calls.lights.push(['off', ...args]),
+      lightBlink: (...args: unknown[]) => calls.lights.push(['blink', ...args]),
+      lightRainbow: (...args: unknown[]) => calls.lights.push(['rainbow', ...args]),
+    },
+    audio: {
+      tone: async (hz: number, duration: number, volume?: number) => {
+        calls.tones.push({ hz, duration, volume })
+      },
+    },
+    input: {
+      imu: options.sample === undefined ? undefined : { lastSample: structuredClone(options.sample) },
+    },
+  }
+  return { robot, calls, body }
+}
+
+async function loadTools(fixture: RobotFixture, options: Record<string, unknown> = {}) {
+  installBareSpecifierPackages()
+  const { createRobotChatTools } = (await import('../robot-chat-tools.js')) as RobotChatToolsModule
+  return createRobotChatTools(fixture.robot as never, { delay: async () => {}, ...options })
+}
+
+test('robot chat tools expose nested JSON schemas and omit unsupported LEDs', async () => {
+  const withLed = await loadTools(createRobot())
+  assert.deepEqual(Object.keys(withLed).sort(), [
+    'get_robot_status',
+    'play_melody',
+    'play_motion',
+    'set_emotion',
+    'set_led',
+  ])
+  assert.deepEqual(withLed.play_motion.parameters?.properties.motion.enum, [
+    'nod',
+    'shake_head',
+    'look_left',
+    'look_right',
+    'look_up',
+    'look_down',
+    'center',
+  ])
+  assert.equal(withLed.play_melody.parameters?.properties.tones.items?.type, 'string')
+
+  const withoutLed = await loadTools(createRobot({ led: false }))
+  assert.equal(withoutLed.set_led, undefined)
+})
+
+test('emotion and LED tools validate and forward actions', async () => {
+  const fixture = createRobot()
+  const tools = await loadTools(fixture)
+
+  assert.equal(await tools.set_emotion.execute?.({ emotion: 'happy' }), 'Emotion set to HAPPY')
+  assert.deepEqual(fixture.calls.emotions, [3])
+  assert.throws(() => tools.set_emotion.execute?.({ emotion: 'surprised' }), /Unknown emotion/)
+
+  await tools.set_led.execute?.({ led: 'head', mode: 'solid', red: 10, green: 20, blue: 30 })
+  await tools.set_led.execute?.({ led: 'head', mode: 'blink', red: 1, green: 2, blue: 3, interval_ms: 250 })
+  await tools.set_led.execute?.({ led: 'head', mode: 'rainbow' })
+  await tools.set_led.execute?.({ led: 'head', mode: 'off' })
+  assert.deepEqual(fixture.calls.lights, [
+    ['on', 'head', 10, 20, 30],
+    ['blink', 'head', 1, 2, 3, 250],
+    ['rainbow', 'head'],
+    ['off', 'head'],
+  ])
+  assert.throws(
+    () => tools.set_led.execute?.({ led: 'head', mode: 'solid', red: 300, green: 0, blue: 0 }),
+    /red must be between/,
+  )
+})
+
+test('play_motion performs semantic gestures and always releases torque', async () => {
+  const fixture = createRobot()
+  const startingRotation = { ...fixture.body.rotation }
+  const tools = await loadTools(fixture)
+
+  assert.equal(await tools.play_motion.execute?.({ motion: 'nod' }), 'Motion played: nod')
+  assert.equal(fixture.calls.lookAway, 1)
+  assert.deepEqual(fixture.calls.torque, [true, false])
+  assert.equal(fixture.calls.poses.length, 3)
+  assert.deepEqual(fixture.calls.poses[2].rotation, startingRotation)
+
+  fixture.robot.motion.setPose = async () => {
+    throw new Error('servo failed')
+  }
+  await assert.rejects(Promise.resolve(tools.play_motion.execute?.({ motion: 'center' })), /servo failed/)
+  assert.deepEqual(fixture.calls.torque.slice(-2), [true, false])
+})
+
+test('play_melody parses notes and rests inside an input suspension', async () => {
+  const fixture = createRobot()
+  const suspension: string[] = []
+  const rests: number[] = []
+  installBareSpecifierPackages()
+  const { createRobotChatTools } = (await import('../robot-chat-tools.js')) as RobotChatToolsModule
+  const tools = createRobotChatTools(fixture.robot as never, {
+    delay: async (milliseconds) => {
+      rests.push(milliseconds)
+    },
+    runWithInputSuspended: async (operation) => {
+      suspension.push('suspend')
+      try {
+        return await operation()
+      } finally {
+        suspension.push('resume')
+      }
+    },
+  })
+
+  const result = JSON.parse(
+    String(
+      await tools.play_melody.execute?.({ tones: ['C4:100', 'F#4:180', 'R:120', '440:200', 'invalid'], volume: 0.4 }),
+    ),
+  )
+  assert.deepEqual(fixture.calls.tones, [
+    { hz: 262, duration: 100, volume: 0.4 },
+    { hz: 370, duration: 180, volume: 0.4 },
+    { hz: 440, duration: 200, volume: 0.4 },
+  ])
+  assert.deepEqual(rests, [120])
+  assert.deepEqual(suspension, ['suspend', 'resume'])
+  assert.deepEqual(result, { played: 3, rests: 1, skipped: 1, truncated: 0, duration_ms: 600 })
+})
+
+test('get_robot_status returns copied pose, LED, and IMU state', async () => {
+  const fixture = createRobot({ sample: { accelerometer: { x: 1, y: 2, z: 3 } } })
+  const tools = await loadTools(fixture)
+
+  const status = JSON.parse(String(await tools.get_robot_status.execute?.({})))
+  assert.deepEqual(status.pose, {
+    position: { x: 0.01, y: 0.02, z: 0.03 },
+    rotation: { y: 0.1, p: -0.2, r: 0.03 },
+  })
+  assert.deepEqual(status.leds, ['head'])
+  assert.deepEqual(status.imu, { available: true, sample: { accelerometer: { x: 1, y: 2, z: 3 } } })
+})

--- a/firmware/host/app/manifest.json
+++ b/firmware/host/app/manifest.json
@@ -53,7 +53,8 @@
     "app-default-behavior": "./default-behavior/behavior",
     "app-default-behavior/on-context-created": "./default-behavior/on-context-created",
     "app-default-behavior/on-launch": "./default-behavior/on-launch",
-    "app-default-behavior/startup-choice": "./default-behavior/startup-choice"
+    "app-default-behavior/startup-choice": "./default-behavior/startup-choice",
+    "robot-chat-tools": "./robot-chat-tools"
   },
   "preload": [
     "runtime-context",

--- a/firmware/host/app/manifest_typings.json
+++ b/firmware/host/app/manifest_typings.json
@@ -1,6 +1,7 @@
 {
   "modules": {
     "*": ["../../typings/*"],
+    "embedded:io/audio/out-original": "../../typings/embedded/audio-out-original",
     "piu/*": ["../../typings/piu/*"]
   },
   "typescript": {

--- a/firmware/host/app/robot-chat-tools.ts
+++ b/firmware/host/app/robot-chat-tools.ts
@@ -1,0 +1,363 @@
+import { EmotionNames, emotionFromName } from 'face-state'
+import Timer from 'timer'
+import type { ChatTool } from '../modules/conversation/chat-tool.js'
+
+const MOTION_STEP_SECONDS = 0.22
+const MOTION_STEP_MS = MOTION_STEP_SECONDS * 1000
+const DEFAULT_TONE_DURATION_MS = 220
+const MIN_TONE_DURATION_MS = 30
+const MAX_TONE_DURATION_MS = 2000
+const MIN_TONE_HZ = 40
+const MAX_TONE_HZ = 4000
+const MAX_TONE_COUNT = 32
+const MAX_MELODY_DURATION_MS = 15_000
+
+const MOTION_NAMES = ['nod', 'shake_head', 'look_left', 'look_right', 'look_up', 'look_down', 'center'] as const
+const LED_MODES = ['solid', 'blink', 'rainbow', 'off'] as const
+
+type MotionName = (typeof MOTION_NAMES)[number]
+type LedMode = (typeof LED_MODES)[number]
+
+type Delay = (milliseconds: number) => Promise<void>
+
+type RobotChatContext = {
+  face: {
+    setEmotion(emotion: number): void
+  }
+  motion: {
+    pose: {
+      body: {
+        position: { x: number; y: number; z: number }
+        rotation: { y: number; p: number; r: number }
+      }
+    }
+    lookAway(): void
+    setPose(
+      pose: { position: { x: number; y: number; z: number }; rotation: { y: number; p: number; r: number } },
+      time?: number,
+    ): Promise<void>
+    setTorque(enabled: boolean): Promise<void>
+  }
+  audio: {
+    tone(hz: number, duration: number, volume?: number): Promise<void>
+  }
+  input: {
+    imu?: {
+      readonly lastSample: {
+        accelerometer?: { x: number; y: number; z: number }
+        gyroscope?: { x: number; y: number; z: number }
+      }
+    }
+  }
+  lighting: {
+    led: Record<string, unknown>
+    lightOn(ledName: string, r: number, g: number, b: number): void
+    lightOff(ledName: string): void
+    lightBlink(ledName: string, r: number, g: number, b: number, duration: number): void
+    lightRainbow(ledName: string): void
+  }
+}
+
+export type RobotChatToolOptions = {
+  delay?: Delay
+  runWithInputSuspended?: <T>(operation: () => Promise<T>) => Promise<T>
+}
+
+type ParsedTone = { type: 'tone'; hz: number; duration: number } | { type: 'rest'; duration: number }
+
+const NOTE_OFFSETS_FROM_A: Record<string, number> = {
+  C: -9,
+  D: -7,
+  E: -5,
+  F: -4,
+  G: -2,
+  A: 0,
+  B: 2,
+}
+
+const REST_NAMES = ['R', 'REST', 'PAUSE']
+
+function defaultDelay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => Timer.set(() => resolve(), milliseconds))
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value))
+}
+
+function finiteInteger(value: unknown, name: string, minimum: number, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new TypeError(`${name} must be an integer`)
+  }
+  if (value < minimum || value > maximum) throw new RangeError(`${name} must be between ${minimum} and ${maximum}`)
+  return value
+}
+
+function optionalVolume(value: unknown): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new RangeError('volume must be between 0 and 1')
+  }
+  return value
+}
+
+function parseDuration(rawDuration: string | undefined): number {
+  const parsed = Number.parseInt(rawDuration ?? `${DEFAULT_TONE_DURATION_MS}`, 10)
+  if (!Number.isFinite(parsed)) return DEFAULT_TONE_DURATION_MS
+  return clamp(parsed, MIN_TONE_DURATION_MS, MAX_TONE_DURATION_MS)
+}
+
+function noteToHz(noteName: string, accidental: string, octaveRaw?: string): number | undefined {
+  const baseOffset = NOTE_OFFSETS_FROM_A[noteName]
+  if (baseOffset === undefined) return undefined
+  let offset = baseOffset
+  if (accidental === '#') offset += 1
+  if (accidental === 'b' || accidental === 'B') offset -= 1
+  const octave = octaveRaw === undefined ? 4 : Number.parseInt(octaveRaw, 10)
+  if (!Number.isFinite(octave)) return undefined
+  offset += (octave - 4) * 12
+  return clamp(Math.round(440 * 2 ** (offset / 12)), MIN_TONE_HZ, MAX_TONE_HZ)
+}
+
+export function parseToneToken(token: unknown): ParsedTone | undefined {
+  if (typeof token !== 'string') return undefined
+  const trimmed = token.trim()
+  if (!trimmed) return undefined
+
+  const restMatch = /^([A-Za-z]+)(?:[:/,]\s*(\d+))?$/.exec(trimmed)
+  if (restMatch && REST_NAMES.includes(restMatch[1].toUpperCase())) {
+    return { type: 'rest', duration: parseDuration(restMatch[2]) }
+  }
+
+  const noteMatch = /^([A-Ga-g])([#b]?)(-?\d+)?(?:[:/,]\s*(\d+))?$/.exec(trimmed)
+  if (noteMatch) {
+    const hz = noteToHz(noteMatch[1].toUpperCase(), noteMatch[2], noteMatch[3])
+    if (hz === undefined) return undefined
+    return { type: 'tone', hz, duration: parseDuration(noteMatch[4]) }
+  }
+
+  const frequencyMatch = /^(\d+(?:\.\d+)?)(?:[:/,]\s*(\d+))?$/.exec(trimmed)
+  if (!frequencyMatch) return undefined
+  const frequency = Number.parseFloat(frequencyMatch[1])
+  if (!Number.isFinite(frequency)) return undefined
+  return {
+    type: 'tone',
+    hz: clamp(Math.round(frequency), MIN_TONE_HZ, MAX_TONE_HZ),
+    duration: parseDuration(frequencyMatch[2]),
+  }
+}
+
+function poseFor(robot: RobotChatContext, rotation: { y: number; p: number; r: number }) {
+  return {
+    position: { ...robot.motion.pose.body.position },
+    rotation,
+  }
+}
+
+async function playMotion(robot: RobotChatContext, motion: MotionName, delay: Delay): Promise<string> {
+  const start = { ...robot.motion.pose.body.rotation }
+  const left = { y: Math.PI / 6, p: 0, r: 0 }
+  const right = { y: -Math.PI / 6, p: 0, r: 0 }
+  const up = { y: 0, p: -Math.PI / 6, r: 0 }
+  const down = { y: 0, p: Math.PI / 32, r: 0 }
+  const center = { y: 0, p: 0, r: 0 }
+
+  robot.motion.lookAway()
+  await robot.motion.setTorque(true)
+  try {
+    if (motion === 'nod') {
+      await robot.motion.setPose(poseFor(robot, down), MOTION_STEP_SECONDS)
+      await delay(MOTION_STEP_MS)
+      await robot.motion.setPose(poseFor(robot, up), MOTION_STEP_SECONDS)
+      await delay(MOTION_STEP_MS)
+      await robot.motion.setPose(poseFor(robot, start), MOTION_STEP_SECONDS)
+    } else if (motion === 'shake_head') {
+      await robot.motion.setPose(poseFor(robot, left), MOTION_STEP_SECONDS)
+      await delay(MOTION_STEP_MS)
+      await robot.motion.setPose(poseFor(robot, right), MOTION_STEP_SECONDS)
+      await delay(MOTION_STEP_MS)
+      await robot.motion.setPose(poseFor(robot, start), MOTION_STEP_SECONDS)
+    } else {
+      const target = {
+        look_left: left,
+        look_right: right,
+        look_up: up,
+        look_down: down,
+        center,
+      }[motion as Exclude<MotionName, 'nod' | 'shake_head'>]
+      await robot.motion.setPose(poseFor(robot, target), MOTION_STEP_SECONDS)
+    }
+  } finally {
+    await robot.motion.setTorque(false)
+  }
+  return `Motion played: ${motion}`
+}
+
+function parseMotion(value: unknown): MotionName {
+  if (typeof value !== 'string' || !MOTION_NAMES.includes(value as MotionName)) {
+    throw new RangeError(`motion must be one of: ${MOTION_NAMES.join(', ')}`)
+  }
+  return value as MotionName
+}
+
+function parseLedMode(value: unknown): LedMode {
+  if (typeof value !== 'string' || !LED_MODES.includes(value as LedMode)) {
+    throw new RangeError(`mode must be one of: ${LED_MODES.join(', ')}`)
+  }
+  return value as LedMode
+}
+
+function createLedTool(robot: RobotChatContext, ledNames: string[]): ChatTool {
+  return {
+    name: 'set_led',
+    description: "Control Stack-chan's configured LEDs",
+    parameters: {
+      type: 'object',
+      properties: {
+        led: { type: 'string', enum: ledNames, description: 'LED name' },
+        mode: { type: 'string', enum: [...LED_MODES], description: 'Lighting mode' },
+        red: { type: 'integer', minimum: 0, maximum: 255 },
+        green: { type: 'integer', minimum: 0, maximum: 255 },
+        blue: { type: 'integer', minimum: 0, maximum: 255 },
+        interval_ms: { type: 'integer', minimum: 50, maximum: 10_000 },
+      },
+      required: ['led', 'mode'],
+      additionalProperties: false,
+    },
+    execute: ({ led, mode, red, green, blue, interval_ms }) => {
+      if (typeof led !== 'string' || !ledNames.includes(led)) throw new RangeError(`Unknown LED: ${String(led)}`)
+      const parsedMode = parseLedMode(mode)
+      if (parsedMode === 'off') robot.lighting.lightOff(led)
+      else if (parsedMode === 'rainbow') robot.lighting.lightRainbow(led)
+      else {
+        const r = finiteInteger(red, 'red', 0, 255)
+        const g = finiteInteger(green, 'green', 0, 255)
+        const b = finiteInteger(blue, 'blue', 0, 255)
+        if (parsedMode === 'solid') robot.lighting.lightOn(led, r, g, b)
+        else robot.lighting.lightBlink(led, r, g, b, finiteInteger(interval_ms, 'interval_ms', 50, 10_000))
+      }
+      return `LED ${led} set to ${parsedMode}`
+    },
+  }
+}
+
+export function createRobotChatTools(
+  robot: RobotChatContext,
+  options: RobotChatToolOptions = {},
+): Record<string, ChatTool> {
+  const delay = options.delay ?? defaultDelay
+  const runWithInputSuspended =
+    options.runWithInputSuspended ?? (async <T>(operation: () => Promise<T>): Promise<T> => operation())
+  const ledNames = Object.keys(robot.lighting.led)
+
+  const tools: Record<string, ChatTool> = {
+    set_emotion: {
+      name: 'set_emotion',
+      description: "Set Stack-chan's facial emotion",
+      parameters: {
+        type: 'object',
+        properties: {
+          emotion: { type: 'string', enum: [...EmotionNames], description: 'Facial emotion' },
+        },
+        required: ['emotion'],
+        additionalProperties: false,
+      },
+      execute: ({ emotion }) => {
+        const nextEmotion = typeof emotion === 'string' ? emotionFromName(emotion) : undefined
+        if (nextEmotion === undefined) throw new RangeError(`Unknown emotion: ${String(emotion)}`)
+        robot.face.setEmotion(nextEmotion)
+        return `Emotion set to ${String(emotion).toUpperCase()}`
+      },
+    },
+    play_motion: {
+      name: 'play_motion',
+      description: 'Play a safe, semantic head motion',
+      parameters: {
+        type: 'object',
+        properties: {
+          motion: { type: 'string', enum: [...MOTION_NAMES], description: 'Motion to play' },
+        },
+        required: ['motion'],
+        additionalProperties: false,
+      },
+      execute: ({ motion }) => playMotion(robot, parseMotion(motion), delay),
+    },
+    play_melody: {
+      name: 'play_melody',
+      description: 'Play notes, frequencies, and rests as a short melody',
+      parameters: {
+        type: 'object',
+        properties: {
+          tones: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 1,
+            maxItems: MAX_TONE_COUNT,
+            description: 'Tokens such as C4:220, F#4:180, 440:200, or R:120',
+          },
+          volume: { type: 'number', minimum: 0, maximum: 1 },
+        },
+        required: ['tones'],
+        additionalProperties: false,
+      },
+      execute: async ({ tones, volume }) => {
+        if (!Array.isArray(tones) || tones.length === 0) throw new RangeError('tones must be a non-empty array')
+        const parsedVolume = optionalVolume(volume)
+        const parsed = tones.slice(0, MAX_TONE_COUNT).map(parseToneToken)
+        let played = 0
+        let rests = 0
+        const skipped = parsed.filter((tone) => tone === undefined).length
+        let durationMs = 0
+        let truncated = Math.max(0, tones.length - MAX_TONE_COUNT)
+
+        await runWithInputSuspended(async () => {
+          for (let index = 0; index < parsed.length; index += 1) {
+            const tone = parsed[index]
+            if (!tone) continue
+            if (durationMs + tone.duration > MAX_MELODY_DURATION_MS) {
+              truncated += parsed.slice(index).filter((candidate) => candidate !== undefined).length
+              break
+            }
+            durationMs += tone.duration
+            if (tone.type === 'rest') {
+              rests += 1
+              await delay(tone.duration)
+            } else {
+              played += 1
+              await robot.audio.tone(tone.hz, tone.duration, parsedVolume)
+            }
+          }
+        })
+
+        return JSON.stringify({ played, rests, skipped, truncated, duration_ms: durationMs })
+      },
+    },
+    get_robot_status: {
+      name: 'get_robot_status',
+      description: "Read Stack-chan's pose and available hardware state",
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      execute: () => {
+        const imu = robot.input.imu
+        return JSON.stringify({
+          pose: {
+            position: { ...robot.motion.pose.body.position },
+            rotation: { ...robot.motion.pose.body.rotation },
+          },
+          leds: ledNames,
+          imu: {
+            available: imu !== undefined,
+            sample: imu?.lastSample ?? {},
+          },
+        })
+      },
+    },
+  }
+
+  if (ledNames.length > 0) tools.set_led = createLedTool(robot, ledNames)
+  return tools
+}

--- a/firmware/host/modules/audio/__tests__/shared-audio-out.test.ts
+++ b/firmware/host/modules/audio/__tests__/shared-audio-out.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createSharedAudioOutClass, type ModernAudioOutOptions } from '../shared-audio-out.js'
+
+class FakePhysicalAudioOut {
+  static readonly instances: FakePhysicalAudioOut[] = []
+  readonly sampleRate: number
+  readonly bitsPerSample: number
+  readonly channels: number
+  readonly writes: Uint8Array[] = []
+  readonly onWritable?: (size: number) => void
+  format = 'buffer'
+  volume = 1
+  starts = 0
+  stops = 0
+  closes = 0
+
+  constructor(options: ModernAudioOutOptions = {}) {
+    this.sampleRate = options.sampleRate ?? 24_000
+    this.bitsPerSample = options.bitsPerSample ?? 16
+    this.channels = options.channels ?? options.numChannels ?? 1
+    this.onWritable = options.onWritable
+    FakePhysicalAudioOut.instances.push(this)
+  }
+
+  write(samples: ArrayBuffer | ArrayBufferView): void {
+    const bytes = ArrayBuffer.isView(samples)
+      ? new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength)
+      : new Uint8Array(samples)
+    this.writes.push(new Uint8Array(bytes))
+  }
+
+  start(): void {
+    this.starts += 1
+  }
+
+  stop(): void {
+    this.stops += 1
+  }
+
+  close(): void {
+    this.closes += 1
+  }
+
+  writable(size: number): void {
+    this.onWritable?.call(this, size)
+  }
+
+  static reset(): void {
+    FakePhysicalAudioOut.instances.length = 0
+  }
+}
+
+function pcm(...samples: number[]): Int16Array {
+  return Int16Array.from(samples)
+}
+
+function writtenSamples(output: FakePhysicalAudioOut): number[] {
+  return output.writes.flatMap((bytes) => {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    const samples: number[] = []
+    for (let offset = 0; offset < bytes.byteLength; offset += 2) samples.push(view.getInt16(offset, true))
+    return samples
+  })
+}
+
+test('shared AudioOut mixes tracks with volume and saturates PCM16', () => {
+  FakePhysicalAudioOut.reset()
+  const SharedAudioOut = createSharedAudioOutClass(FakePhysicalAudioOut)
+  const first = new SharedAudioOut({ sampleRate: 24_000, bitsPerSample: 16, channels: 1 })
+  const second = new SharedAudioOut({ sampleRate: 24_000, bitsPerSample: 16, channels: 1 })
+  first.volume = 1
+  second.volume = 0.5
+  first.start()
+  second.start()
+
+  const physical = FakePhysicalAudioOut.instances[0]
+  physical.writable(4)
+  first.write(pcm(20_000, -20_000))
+  second.write(pcm(30_000, -30_000))
+  physical.writable(4)
+
+  assert.equal(FakePhysicalAudioOut.instances.length, 1)
+  assert.deepEqual(writtenSamples(physical).slice(-2), [32_767, -32_768])
+  assert.equal(physical.starts, 1)
+  first.close()
+  assert.equal(physical.closes, 0)
+  second.close()
+  assert.equal(physical.stops, 1)
+  assert.equal(physical.closes, 1)
+})
+
+test('a track may write after its writable callback and is mixed on the next cycle', () => {
+  FakePhysicalAudioOut.reset()
+  const SharedAudioOut = createSharedAudioOutClass(FakePhysicalAudioOut)
+  const track = new SharedAudioOut({ sampleRate: 24_000, bitsPerSample: 16, channels: 1 })
+  track.start()
+  const physical = FakePhysicalAudioOut.instances[0]
+
+  physical.writable(4)
+  assert.deepEqual(writtenSamples(physical), [0, 0])
+  track.write(pcm(123, -456))
+  physical.writable(4)
+  assert.deepEqual(writtenSamples(physical).slice(-2), [123, -456])
+  track.close()
+})
+
+test('Async tracks accept queued writes and invoke callbacks after mixing', () => {
+  FakePhysicalAudioOut.reset()
+  const SharedAudioOut = createSharedAudioOutClass(FakePhysicalAudioOut)
+  const track = new SharedAudioOut.Async({ sampleRate: 24_000, bitsPerSample: 16, channels: 1 })
+  let callbackError: unknown = Symbol('not called')
+  track.write(pcm(321, -654), (error) => {
+    callbackError = error
+  })
+  track.start()
+  const physical = FakePhysicalAudioOut.instances[0]
+  physical.writable(4)
+
+  assert.equal(callbackError, undefined)
+  assert.deepEqual(writtenSamples(physical), [321, -654])
+  track.close()
+})
+
+test('shared AudioOut rejects format conflicts and more than four tracks', () => {
+  FakePhysicalAudioOut.reset()
+  const SharedAudioOut = createSharedAudioOutClass(FakePhysicalAudioOut)
+  const tracks = Array.from(
+    { length: 4 },
+    () => new SharedAudioOut({ sampleRate: 24_000, bitsPerSample: 16, channels: 1 }),
+  )
+
+  assert.throws(() => new SharedAudioOut({ sampleRate: 16_000 }), /sample rate conflict/)
+  assert.throws(() => new SharedAudioOut({ bitsPerSample: 8 }), /bits-per-sample conflict/)
+  assert.throws(() => new SharedAudioOut({ channels: 2 }), /channel conflict/)
+  assert.throws(() => new SharedAudioOut(), /too many shared AudioOut tracks/)
+
+  for (const track of tracks) track.close()
+})

--- a/firmware/host/modules/audio/__tests__/speaker.test.ts
+++ b/firmware/host/modules/audio/__tests__/speaker.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { afterEach, beforeEach, test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import {
+  getModernAudioOutInstances,
+  resetModernAudioOut,
+  setModernAudioOutConstructorFailure,
+} from '../../testing/fakes/modern-audio-out.js'
+import { writeAliasPackage } from '../../testing/node-alias-package.js'
+import type { BorrowedAudioBuffer } from '../audio-buffer.js'
+
+const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+writeAliasPackage(modulesRoot, 'modern-audio-out', resolve(modulesRoot, 'testing/fakes/modern-audio-out.js'), {
+  hasDefaultExport: true,
+})
+const { default: Speaker } = await import('../speaker.js')
+
+const WAV_HEADER_SIZE = 44
+
+function wav(samples: number[], sampleRate = 16_000, channels = 1): BorrowedAudioBuffer {
+  const buffer = new ArrayBuffer(WAV_HEADER_SIZE + samples.length * 2)
+  const view = new DataView(buffer)
+  view.setUint16(22, channels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint16(34, 16, true)
+  for (let index = 0; index < samples.length; index += 1) {
+    view.setInt16(WAV_HEADER_SIZE + index * 2, samples[index], true)
+  }
+  return buffer as BorrowedAudioBuffer
+}
+
+beforeEach(() => {
+  resetModernAudioOut()
+  ;(globalThis as typeof globalThis & { trace: (message: string) => void }).trace = () => {}
+})
+
+afterEach(() => {
+  delete (globalThis as Partial<typeof globalThis & { trace: (message: string) => void }>).trace
+})
+
+test('tone streams PCM and waits for the queued audio to drain', async () => {
+  const speaker = new Speaker({ volume: 0.25 })
+  const playing = speaker.tone(440, 1)
+  const output = getModernAudioOutInstances()[0]
+
+  assert.equal(output.sampleRate, 24_000)
+  assert.equal(output.channels, 1)
+  assert.equal(output.volume, 0.25)
+  assert.equal(output.started, 1)
+
+  output.emitWritable(48)
+  assert.equal(output.writes.length, 1)
+  assert.equal(output.writes[0].byteLength, 48)
+  assert.ok(output.writes[0].some((byte) => byte !== 0))
+  assert.equal(output.closed, false)
+  output.emitWritable(48)
+  await playing
+
+  assert.equal(output.stopped, 1)
+  assert.equal(output.closed, true)
+})
+
+test('WAV playback forwards PCM through modern AudioOut and pads the final write', async () => {
+  const speaker = new Speaker({ volume: 0.4 })
+  const playing = speaker.play(wav([123, -456], 16_000, 1))
+  const output = getModernAudioOutInstances()[0]
+  output.emitWritable(8)
+  output.emitWritable(8)
+
+  assert.equal(await playing, true)
+  assert.equal(output.sampleRate, 16_000)
+  assert.equal(output.volume, 0.4)
+  const bytes = output.writes[0]
+  const samples = new Int16Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 2)
+  assert.deepEqual(Array.from(samples), [123, -456, 0, 0])
+})
+
+test('WAV playback reports invalid input and AudioOut construction failures', async () => {
+  const speaker = new Speaker()
+  assert.equal(await speaker.play(new ArrayBuffer(10) as BorrowedAudioBuffer), false)
+  const invalid = wav([1])
+  new DataView(invalid).setUint16(34, 8, true)
+  assert.equal(await speaker.play(invalid), false)
+
+  setModernAudioOutConstructorFailure(new Error('output busy'))
+  assert.equal(await speaker.play(wav([1])), false)
+  await assert.rejects(speaker.tone(440, 10), /output busy/)
+})

--- a/firmware/host/modules/audio/modern-audio-out.ts
+++ b/firmware/host/modules/audio/modern-audio-out.ts
@@ -1,0 +1,1 @@
+export { default } from 'embedded:io/audio/out'

--- a/firmware/host/modules/audio/shared-audio-out.ts
+++ b/firmware/host/modules/audio/shared-audio-out.ts
@@ -1,0 +1,373 @@
+const BYTES_PER_SAMPLE = 2
+const MAX_TRACKS = 4
+const MAX_TRACK_BUFFER_BYTES = 512 * 1024
+
+type AudioOutCallback = (error?: unknown) => void
+
+export type ModernAudioOutOptions = {
+  sampleRate?: number
+  bitsPerSample?: number
+  channels?: number
+  numChannels?: number
+  onWritable?: (size: number) => void
+}
+
+export type ModernAudioOut = {
+  readonly sampleRate: number
+  readonly bitsPerSample: number
+  readonly channels: number
+  format: string
+  volume: number
+  write(samples: ArrayBuffer | ArrayBufferView, callback?: AudioOutCallback): void
+  start(): void
+  stop(): void
+  close(): void
+}
+
+export type ModernAudioOutConstructor = new (options?: ModernAudioOutOptions) => ModernAudioOut
+
+export type SharedAudioOutConstructor = ModernAudioOutConstructor & {
+  Async: ModernAudioOutConstructor
+}
+
+type SharedAudioOutHooks = {
+  onFormat?: (format: { sampleRate: number; bitsPerSample: number; channels: number }) => void
+}
+
+type QueueEntry = {
+  remaining: number
+  callback?: AudioOutCallback
+}
+
+function asBytes(samples: ArrayBuffer | ArrayBufferView): Uint8Array {
+  if (ArrayBuffer.isView(samples)) {
+    return new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength)
+  }
+  return new Uint8Array(samples)
+}
+
+function nextCapacity(required: number): number {
+  let capacity = 4096
+  while (capacity < required) capacity *= 2
+  if (capacity > MAX_TRACK_BUFFER_BYTES) throw new RangeError('shared AudioOut track buffer overflow')
+  return capacity
+}
+
+function clampPCM16(value: number): number {
+  if (value > 0x7fff) return 0x7fff
+  if (value < -0x8000) return -0x8000
+  return value
+}
+
+class AudioTrack {
+  readonly owner: ModernAudioOut
+  readonly manager: AudioMixer
+  readonly asynchronous: boolean
+  readonly onWritable?: (size: number) => void
+  started = false
+  closed = false
+  volume = 1
+  writeBudget = 0
+  #buffer = new Uint8Array(0)
+  #readOffset = 0
+  #writeOffset = 0
+  #byteLength = 0
+  #entries: QueueEntry[] = []
+
+  constructor(owner: ModernAudioOut, manager: AudioMixer, options: ModernAudioOutOptions, asynchronous: boolean) {
+    this.owner = owner
+    this.manager = manager
+    this.asynchronous = asynchronous
+    this.onWritable = options.onWritable
+  }
+
+  prepare(size: number): void {
+    if (!this.started || this.closed || this.asynchronous) return
+    this.writeBudget = size
+    try {
+      this.onWritable?.call(this.owner, size)
+    } catch (error) {
+      this.manager.reportError(error)
+    }
+  }
+
+  enqueue(samples: ArrayBuffer | ArrayBufferView, callback?: AudioOutCallback): void {
+    if (this.closed) throw new Error('AudioOut is closed')
+    const source = asBytes(samples)
+    if (source.byteLength % BYTES_PER_SAMPLE !== 0) throw new RangeError('full PCM16 samples only')
+    if (source.byteLength === 0) {
+      callback?.call(this.owner)
+      return
+    }
+    if (!this.asynchronous) {
+      if (source.byteLength > this.writeBudget) throw new Error('insufficient space')
+      this.writeBudget -= source.byteLength
+    }
+    this.ensureCapacity(this.#byteLength + source.byteLength)
+    const first = Math.min(source.byteLength, this.#buffer.byteLength - this.#writeOffset)
+    this.#buffer.set(source.subarray(0, first), this.#writeOffset)
+    this.#buffer.set(source.subarray(first), 0)
+    this.#writeOffset = (this.#writeOffset + source.byteLength) % this.#buffer.byteLength
+    this.#byteLength += source.byteLength
+    this.#entries.push({ remaining: source.byteLength, callback })
+  }
+
+  consume(accumulator: Int32Array, requestedBytes: number, callbacks: AudioOutCallback[]): void {
+    let use = Math.min(this.#byteLength, requestedBytes)
+    use -= use % BYTES_PER_SAMPLE
+    const samples = use / BYTES_PER_SAMPLE
+    for (let index = 0; index < samples; index += 1) {
+      const low = this.#buffer[this.#readOffset]
+      this.#readOffset = (this.#readOffset + 1) % this.#buffer.byteLength
+      const high = this.#buffer[this.#readOffset]
+      this.#readOffset = (this.#readOffset + 1) % this.#buffer.byteLength
+      let sample = low | (high << 8)
+      if (sample & 0x8000) sample -= 0x1_0000
+      accumulator[index] += Math.round(sample * this.volume)
+    }
+    this.#byteLength -= use
+    this.completeEntries(use, callbacks)
+  }
+
+  discard(reason: Error): void {
+    this.#readOffset = 0
+    this.#writeOffset = 0
+    this.#byteLength = 0
+    for (const entry of this.#entries) {
+      if (entry.callback) entry.callback.call(this.owner, reason)
+    }
+    this.#entries.length = 0
+  }
+
+  #ensureBufferWithExistingData(capacity: number): void {
+    const replacement = new Uint8Array(capacity)
+    if (this.#byteLength > 0) {
+      const first = Math.min(this.#byteLength, this.#buffer.byteLength - this.#readOffset)
+      replacement.set(this.#buffer.subarray(this.#readOffset, this.#readOffset + first), 0)
+      replacement.set(this.#buffer.subarray(0, this.#byteLength - first), first)
+    }
+    this.#buffer = replacement
+    this.#readOffset = 0
+    this.#writeOffset = this.#byteLength
+  }
+
+  private ensureCapacity(required: number): void {
+    if (required <= this.#buffer.byteLength) return
+    this.#ensureBufferWithExistingData(nextCapacity(required))
+  }
+
+  private completeEntries(consumed: number, callbacks: AudioOutCallback[]): void {
+    let remaining = consumed
+    while (remaining > 0 && this.#entries.length > 0) {
+      const entry = this.#entries[0]
+      const use = Math.min(remaining, entry.remaining)
+      entry.remaining -= use
+      remaining -= use
+      if (entry.remaining === 0) {
+        this.#entries.shift()
+        if (entry.callback) callbacks.push((error) => entry.callback?.call(this.owner, error))
+      }
+    }
+  }
+}
+
+class AudioMixer {
+  readonly physical: ModernAudioOut
+  readonly sampleRate: number
+  readonly bitsPerSample: number
+  readonly channels: number
+  readonly #onEmpty: () => void
+  readonly #tracks: AudioTrack[] = []
+  #running = false
+  #closed = false
+  #accumulator = new Int32Array(0)
+  #output = new Uint8Array(0)
+
+  constructor(
+    PhysicalAudioOut: ModernAudioOutConstructor,
+    options: ModernAudioOutOptions,
+    hooks: SharedAudioOutHooks,
+    onEmpty: () => void,
+  ) {
+    this.#onEmpty = onEmpty
+    this.physical = new PhysicalAudioOut({
+      sampleRate: options.sampleRate,
+      bitsPerSample: options.bitsPerSample,
+      channels: options.channels ?? options.numChannels,
+      onWritable: (size) => this.onWritable(size),
+    })
+    this.sampleRate = this.physical.sampleRate
+    this.bitsPerSample = this.physical.bitsPerSample
+    this.channels = this.physical.channels
+    if (this.bitsPerSample !== 16) {
+      this.physical.close()
+      throw new RangeError('shared AudioOut supports 16-bit PCM only')
+    }
+    this.physical.volume = 1
+    hooks.onFormat?.({ sampleRate: this.sampleRate, bitsPerSample: this.bitsPerSample, channels: this.channels })
+  }
+
+  add(owner: ModernAudioOut, options: ModernAudioOutOptions, asynchronous: boolean): AudioTrack {
+    const requestedChannels = options.channels ?? options.numChannels
+    if (options.sampleRate !== undefined && options.sampleRate !== this.sampleRate)
+      throw new Error('AudioOut sample rate conflict')
+    if (options.bitsPerSample !== undefined && options.bitsPerSample !== this.bitsPerSample) {
+      throw new Error('AudioOut bits-per-sample conflict')
+    }
+    if (requestedChannels !== undefined && requestedChannels !== this.channels)
+      throw new Error('AudioOut channel conflict')
+    if (this.#tracks.length >= MAX_TRACKS) throw new RangeError('too many shared AudioOut tracks')
+    const track = new AudioTrack(owner, this, options, asynchronous)
+    this.#tracks.push(track)
+    return track
+  }
+
+  start(track: AudioTrack): void {
+    if (track.closed || track.started) return
+    track.started = true
+    if (!this.#running) {
+      this.#running = true
+      this.physical.start()
+    }
+  }
+
+  stop(track: AudioTrack): void {
+    if (!track.started) return
+    track.started = false
+    track.writeBudget = 0
+    track.discard(new Error('AudioOut stopped'))
+    if (this.#running && !this.#tracks.some((candidate) => candidate.started)) {
+      this.#running = false
+      this.physical.stop()
+    }
+  }
+
+  close(track: AudioTrack): void {
+    if (track.closed) return
+    this.stop(track)
+    track.closed = true
+    track.discard(new Error('AudioOut closed'))
+    const index = this.#tracks.indexOf(track)
+    if (index >= 0) this.#tracks.splice(index, 1)
+    if (this.#tracks.length === 0) {
+      this.#closed = true
+      this.physical.close()
+      this.#onEmpty()
+    }
+  }
+
+  reportError(error: unknown): void {
+    const global = globalThis as typeof globalThis & { trace?: (message: string) => void }
+    global.trace?.(`[SharedAudioOut] ${String(error)}\n`)
+  }
+
+  private onWritable(rawSize: number): void {
+    const size = rawSize - (rawSize % BYTES_PER_SAMPLE)
+    if (size <= 0) return
+    const sampleCount = size / BYTES_PER_SAMPLE
+    if (this.#accumulator.length < sampleCount) this.#accumulator = new Int32Array(sampleCount)
+    if (this.#output.byteLength < size) this.#output = new Uint8Array(size)
+    this.#accumulator.fill(0, 0, sampleCount)
+
+    for (const track of [...this.#tracks]) track.prepare(size)
+    if (this.#closed || this.#tracks.length === 0) return
+
+    const callbacks: AudioOutCallback[] = []
+    for (const track of this.#tracks) {
+      if (track.started && !track.closed) track.consume(this.#accumulator, size, callbacks)
+    }
+
+    const view = new DataView(this.#output.buffer)
+    for (let index = 0; index < sampleCount; index += 1) {
+      view.setInt16(index * BYTES_PER_SAMPLE, clampPCM16(this.#accumulator[index]), true)
+    }
+    try {
+      this.physical.write(this.#output.subarray(0, size))
+      for (const callback of callbacks) callback()
+    } catch (error) {
+      for (const callback of callbacks) callback(error)
+      this.reportError(error)
+    }
+  }
+}
+
+export function createSharedAudioOutClass(
+  PhysicalAudioOut: ModernAudioOutConstructor,
+  hooks: SharedAudioOutHooks = {},
+): SharedAudioOutConstructor {
+  let mixer: AudioMixer | undefined
+
+  class SharedAudioOut implements ModernAudioOut {
+    static Async: ModernAudioOutConstructor
+    readonly #track: AudioTrack
+
+    constructor(options: ModernAudioOutOptions = {}, asynchronous = false) {
+      const created = mixer === undefined
+      const current = mixer ?? new AudioMixer(PhysicalAudioOut, options, hooks, () => (mixer = undefined))
+      if (created) mixer = current
+      try {
+        this.#track = current.add(this, options, asynchronous)
+      } catch (error) {
+        if (created) {
+          current.physical.close()
+          mixer = undefined
+        }
+        throw error
+      }
+    }
+
+    get sampleRate(): number {
+      return this.#track.manager.sampleRate
+    }
+
+    get bitsPerSample(): number {
+      return this.#track.manager.bitsPerSample
+    }
+
+    get channels(): number {
+      return this.#track.manager.channels
+    }
+
+    get format(): string {
+      return 'buffer'
+    }
+
+    set format(value: string) {
+      if (value !== 'buffer') throw new RangeError('invalid format')
+    }
+
+    get volume(): number {
+      return this.#track.volume
+    }
+
+    set volume(value: number) {
+      if (!Number.isFinite(value) || value < 0 || value > 1) throw new RangeError('invalid volume')
+      this.#track.volume = value
+    }
+
+    write(samples: ArrayBuffer | ArrayBufferView, callback?: AudioOutCallback): void {
+      this.#track.enqueue(samples, callback)
+    }
+
+    start(): void {
+      this.#track.manager.start(this.#track)
+    }
+
+    stop(): void {
+      this.#track.manager.stop(this.#track)
+    }
+
+    close(): void {
+      this.#track.manager.close(this.#track)
+    }
+  }
+
+  class AsyncSharedAudioOut extends SharedAudioOut {
+    constructor(options: ModernAudioOutOptions = {}) {
+      super(options, true)
+    }
+  }
+
+  SharedAudioOut.Async = AsyncSharedAudioOut
+  return SharedAudioOut as SharedAudioOutConstructor
+}

--- a/firmware/host/modules/audio/speaker.ts
+++ b/firmware/host/modules/audio/speaker.ts
@@ -1,38 +1,79 @@
-/* global SharedArrayBuffer */
-
 import type { BorrowedAudioBuffer } from 'audio-buffer'
-import AudioOut from 'pins/audioout'
+import AudioOut from 'modern-audio-out'
 
 const WAV_HEADER_SIZE = 44
+const TONE_SAMPLE_RATE = 24_000
+const BITS_PER_SAMPLE = 16
+const BYTES_PER_SAMPLE = BITS_PER_SAMPLE / 8
+
+type ModernAudioOut = {
+  volume: number
+  write(samples: ArrayBuffer | ArrayBufferView): void
+  start(): void
+  stop(): void
+  close(): void
+}
+
+type ModernAudioOutConstructor = new (options: {
+  sampleRate: number
+  bitsPerSample: number
+  channels: number
+  onWritable: (size: number) => void
+}) => ModernAudioOut
 
 export type ToneProperty = {
   volume?: number
 }
 
+type PCMSource = {
+  readonly byteLength: number
+  fill(target: Uint8Array, sourceOffset: number, byteLength: number): void
+}
+
+function checkedVolume(volume: number): number {
+  if (!Number.isFinite(volume) || volume < 0 || volume > 1) {
+    throw new RangeError('volume must be between 0 and 1')
+  }
+  return volume
+}
+
+function bufferSource(buffer: BorrowedAudioBuffer, byteOffset: number): PCMSource {
+  const source = new Uint8Array(buffer, byteOffset)
+  return {
+    byteLength: source.byteLength,
+    fill(target, sourceOffset, byteLength) {
+      target.set(source.subarray(sourceOffset, sourceOffset + byteLength))
+    },
+  }
+}
+
+function toneSource(hz: number, duration: number): PCMSource {
+  if (!Number.isFinite(hz) || hz <= 0) throw new RangeError('tone frequency must be positive')
+  if (!Number.isFinite(duration) || duration <= 0) throw new RangeError('tone duration must be positive')
+  const sampleCount = Math.max(1, Math.round((TONE_SAMPLE_RATE * duration) / 1000))
+  return {
+    byteLength: sampleCount * BYTES_PER_SAMPLE,
+    fill(target, sourceOffset, byteLength) {
+      const view = new DataView(target.buffer, target.byteOffset, byteLength)
+      const firstSample = sourceOffset / BYTES_PER_SAMPLE
+      const samples = byteLength / BYTES_PER_SAMPLE
+      for (let index = 0; index < samples; index += 1) {
+        const phase = (2 * Math.PI * hz * (firstSample + index)) / TONE_SAMPLE_RATE
+        view.setInt16(index * BYTES_PER_SAMPLE, Math.round(Math.sin(phase) * 0x7fff), true)
+      }
+    },
+  }
+}
+
 export default class Speaker {
   volume: number
 
-  constructor(props: ToneProperty) {
-    this.volume = props.volume ?? 0.5
+  constructor(props: ToneProperty = {}) {
+    this.volume = checkedVolume(props.volume ?? 0.5)
   }
-  async tone(hz: number, duration: number, volume?: number): Promise<void> {
-    const audio = new AudioOut({
-      streams: 1,
-      sampleRate: 24000,
-      bitsPerSample: 16,
-    })
-    return new Promise((resolve) => {
-      audio.enqueue(0, AudioOut.Flush)
-      audio.enqueue(0, AudioOut.Volume, Math.round((volume ?? this.volume) * 256))
-      audio.enqueue(0, AudioOut.Tone, hz, (audio.sampleRate * duration) / 1000)
-      audio.enqueue(0, AudioOut.Callback, 1)
-      audio.start()
 
-      audio.callback = (_id) => {
-        audio.close()
-        resolve()
-      }
-    })
+  async tone(hz: number, duration: number, volume?: number): Promise<void> {
+    await this.playPCM(toneSource(hz, duration), TONE_SAMPLE_RATE, 1, checkedVolume(volume ?? this.volume))
   }
 
   async play(buffer: BorrowedAudioBuffer): Promise<boolean> {
@@ -42,32 +83,93 @@ export default class Speaker {
       const numChannels = view.getUint16(22, true)
       const sampleRate = view.getUint32(24, true)
       const bitsPerSample = view.getUint16(34, true)
-      if (bitsPerSample !== 16 || (numChannels !== 1 && numChannels !== 2)) return false
-      if (sampleRate < 8000 || sampleRate > 48000) return false
-
-      // AudioOut.RawSamples requires a non-relocatable buffer; a plain ArrayBuffer is
-      // relocatable and rejected, so copy the PCM payload into a SharedArrayBuffer.
+      if (bitsPerSample !== BITS_PER_SAMPLE || (numChannels !== 1 && numChannels !== 2)) return false
+      if (sampleRate < 8000 || sampleRate > 48_000) return false
       const pcmLength = buffer.byteLength - WAV_HEADER_SIZE
-      const shared = new SharedArrayBuffer(pcmLength)
-      new Uint8Array(shared).set(new Uint8Array(buffer, WAV_HEADER_SIZE))
-
-      const audio = new AudioOut({ streams: 1, sampleRate, numChannels, bitsPerSample })
-      return await new Promise<boolean>((resolve) => {
-        audio.enqueue(0, AudioOut.Flush)
-        audio.enqueue(0, AudioOut.Volume, Math.round(this.volume * 256))
-        // `shared` is retained by this closure until the callback fires, so it is not collected.
-        // AudioOut.enqueue is typed for HostBuffer; the native layer also accepts a SharedArrayBuffer.
-        audio.enqueue(0, AudioOut.RawSamples, shared as unknown as HostBuffer)
-        audio.enqueue(0, AudioOut.Callback, 1)
-        audio.start()
-        audio.callback = () => {
-          audio.close()
-          resolve(true)
-        }
-      })
+      if (pcmLength % BYTES_PER_SAMPLE !== 0) return false
+      await this.playPCM(bufferSource(buffer, WAV_HEADER_SIZE), sampleRate, numChannels, this.volume)
+      return true
     } catch (error) {
-      trace(`Speaker.play error ${error}\n`)
+      trace(`Speaker.play error ${String(error)}\n`)
       return false
     }
+  }
+
+  private playPCM(source: PCMSource, sampleRate: number, channels: number, volume: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let output: ModernAudioOut | undefined
+      let sourceOffset = 0
+      let freeBytes = 0
+      let pendingBytes = 0
+      let draining = false
+      let settled = false
+      let scratch = new Uint8Array(0)
+
+      const close = () => {
+        const current = output
+        output = undefined
+        if (!current) return
+        try {
+          current.stop()
+        } finally {
+          current.close()
+        }
+      }
+
+      const finish = (error?: unknown) => {
+        if (settled) return
+        settled = true
+        try {
+          close()
+        } catch (closeError) {
+          if (error === undefined) error = closeError
+        }
+        if (error === undefined) resolve()
+        else reject(error)
+      }
+
+      const onWritable = (rawSize: number) => {
+        if (!output || settled) return
+        try {
+          const writable = rawSize - (rawSize % BYTES_PER_SAMPLE)
+          const consumed = Math.max(0, writable - freeBytes)
+          pendingBytes = Math.max(0, pendingBytes - consumed)
+          freeBytes = writable
+          if (draining) {
+            if (pendingBytes === 0) finish()
+            return
+          }
+          if (writable === 0) return
+
+          if (scratch.byteLength < writable) scratch = new Uint8Array(writable)
+          const chunk = scratch.subarray(0, writable)
+          chunk.fill(0)
+          const remaining = source.byteLength - sourceOffset
+          const use = Math.min(writable, remaining)
+          source.fill(chunk, sourceOffset, use)
+          sourceOffset += use
+          output.write(chunk)
+          freeBytes -= writable
+          pendingBytes += writable
+          if (sourceOffset >= source.byteLength) draining = true
+        } catch (error) {
+          finish(error)
+        }
+      }
+
+      try {
+        const Output = AudioOut as unknown as ModernAudioOutConstructor
+        output = new Output({
+          sampleRate,
+          bitsPerSample: BITS_PER_SAMPLE,
+          channels,
+          onWritable,
+        })
+        output.volume = checkedVolume(volume)
+        output.start()
+      } catch (error) {
+        finish(error)
+      }
+    })
   }
 }

--- a/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
+++ b/firmware/host/modules/conversation/__tests__/chat-service/chat-service.test.ts
@@ -41,6 +41,10 @@ const ChatAudioIOAny = ChatAudioIO as unknown as {
     emitFunctionCall: (call: string, name: string, parameters: Record<string, unknown>) => void
     lastText?: string
     lastFunctionResult?: { call: string }
+    microphone?: boolean
+    inputSuspended?: boolean
+    suspendInputCalls?: number
+    resumeInputCalls?: number
   }[]
   CONNECTED?: number
 }
@@ -112,5 +116,23 @@ service.start()
 equal(service.transcript.input, '', 'start should clear input transcript for the next session')
 equal(service.transcript.output, '', 'start should clear output transcript for the next session')
 
-trace('ok\n')
+void (async () => {
+  await service.runWithInputSuspended(async () => {
+    equal(instance.inputSuspended, true, 'input should be suspended while the operation runs')
+    await service.runWithInputSuspended(async () => {
+      equal(instance.suspendInputCalls, 1, 'nested suspension should reuse the active suspension')
+    })
+  })
+  equal(instance.inputSuspended, false, 'input should resume after the operation')
+  equal(instance.suspendInputCalls, 1, 'input should only be suspended once')
+  equal(instance.resumeInputCalls, 1, 'input should only be resumed once')
+
+  service.setMicrophoneEnabled(false)
+  await service.runWithInputSuspended(async () => {
+    equal(instance.inputSuspended, true, 'disabled microphone input should still suspend physically')
+  })
+  equal(instance.inputSuspended, false, 'input should resume after the second operation')
+  equal(instance.microphone, false, 'resume should preserve the requested microphone state')
+  trace('ok\n')
+})()
 Timer.set(() => {}, 1000)

--- a/firmware/host/modules/conversation/chat-audioio-stub.ts
+++ b/firmware/host/modules/conversation/chat-audioio-stub.ts
@@ -40,5 +40,9 @@ export default class ChatAudioIO {
 
   changeMicrophone(_enabled: boolean): void {}
 
+  suspendInput(): void {}
+
+  resumeInput(_microphoneEnabled: boolean): void {}
+
   changeVolume(_volume: number): void {}
 }

--- a/firmware/host/modules/conversation/chat-audioio/worker-stack.js
+++ b/firmware/host/modules/conversation/chat-audioio/worker-stack.js
@@ -2,6 +2,25 @@ import ChatAudioIOBase from 'ChatAudioIOBase'
 import Worker from 'worker'
 
 export default class ChatAudioIO extends ChatAudioIOBase {
+  ensureInput() {
+    if (this.inputSuspended) return
+    super.ensureInput()
+  }
+
+  suspendInput() {
+    this.inputSuspended = true
+    this.microphone = 0
+    this.input?.close()
+    this.input = null
+    this.ready = false
+  }
+
+  resumeInput(microphoneEnabled = true) {
+    this.inputSuspended = false
+    this.microphone = microphoneEnabled ? 1 : 0
+    if (this.state <= ChatAudioIOBase.SPEAKING) super.ensureInput()
+  }
+
   createWorker(specifier, instructions, functions, voiceID, providerID, modelID, apiKey) {
     this.worker = new Worker(specifier, {
       static: 512 * 1024,

--- a/firmware/host/modules/conversation/chat-tool.ts
+++ b/firmware/host/modules/conversation/chat-tool.ts
@@ -1,0 +1,30 @@
+export type ChatToolParameterSchema = {
+  type?: string
+  description?: string
+  enum?: (string | number | boolean | null)[]
+  properties?: Record<string, ChatToolParameterSchema>
+  items?: ChatToolParameterSchema
+  required?: string[]
+  additionalProperties?: boolean | ChatToolParameterSchema
+  minimum?: number
+  maximum?: number
+  minItems?: number
+  maxItems?: number
+}
+
+export type ChatToolObjectSchema = ChatToolParameterSchema & {
+  type: 'object'
+  properties: Record<string, ChatToolParameterSchema>
+}
+
+export type ChatToolSchema = {
+  name: string
+  description?: string
+  parameters?: ChatToolObjectSchema
+  // Dialogue互換 (inputSchema) を許容
+  inputSchema?: ChatToolObjectSchema
+}
+
+export type ChatTool = ChatToolSchema & {
+  execute?: (params: Record<string, unknown>) => Promise<unknown> | unknown
+}

--- a/firmware/host/modules/conversation/chat.ts
+++ b/firmware/host/modules/conversation/chat.ts
@@ -6,8 +6,15 @@ import {
   type ChatState as ChatStateValue,
   type ChatTranscriptSnapshot,
 } from 'chat-state'
+import type { ChatTool, ChatToolObjectSchema } from './chat-tool.js'
 
 export { ChatState, type ChatStateName, ChatStateNames, chatStateToName, MAX_TRANSCRIPT_CHARS } from 'chat-state'
+export type {
+  ChatTool,
+  ChatToolObjectSchema,
+  ChatToolParameterSchema,
+  ChatToolSchema,
+} from './chat-tool.js'
 
 export type ChatType = 'deepgramAgent' | 'elevenLabsAgent' | 'googleGeminiLive' | 'humeAIEVI' | 'openAIRealtime'
 
@@ -18,28 +25,6 @@ export type ChatConfig = {
   voiceID?: string
   providerID?: string
   modelID?: string
-}
-
-export type ChatToolSchema = {
-  name: string
-  description?: string
-  parameters?: {
-    type: 'object'
-    properties: Record<string, { type: string; description?: string }>
-    required?: string[]
-    additionalProperties?: boolean
-  }
-  // Dialogue互換 (inputSchema) を許容
-  inputSchema?: {
-    type: 'object'
-    properties: Record<string, { type: string; description?: string }>
-    required?: string[]
-    additionalProperties?: boolean
-  }
-}
-
-export type ChatTool = ChatToolSchema & {
-  execute?: (params: Record<string, unknown>) => Promise<unknown> | unknown
 }
 
 export type ChatCallbacks = {
@@ -62,12 +47,7 @@ type ChatServiceOptions = {
 type ChatFunctionSchema = {
   name: string
   description?: string
-  parameters: {
-    type: 'object'
-    properties: Record<string, { type: string; description?: string }>
-    required?: string[]
-    additionalProperties?: boolean
-  }
+  parameters: ChatToolObjectSchema
 }
 
 const noop = () => {}
@@ -133,6 +113,8 @@ export class ChatService {
   #error = ''
   #callbacks: Required<ChatCallbacks>
   #sessionState: ChatSessionState
+  #microphoneEnabled = true
+  #inputSuspendDepth = 0
 
   constructor(options: ChatServiceOptions) {
     this.#sessionState = options.sessionState ?? new ChatSessionState()
@@ -227,7 +209,37 @@ export class ChatService {
   }
 
   setMicrophoneEnabled(enabled: boolean): void {
-    this.#chat.changeMicrophone(enabled)
+    this.#microphoneEnabled = enabled
+    if (this.#inputSuspendDepth === 0) this.#chat.changeMicrophone(enabled)
+  }
+
+  async runWithInputSuspended<T>(operation: () => T | Promise<T>): Promise<T> {
+    const chat = this.#chat as ChatAudioIO & {
+      suspendInput?: () => void
+      resumeInput?: (microphoneEnabled: boolean) => void
+    }
+    const supportsInputSuspension = typeof chat.suspendInput === 'function' && typeof chat.resumeInput === 'function'
+
+    this.#inputSuspendDepth += 1
+    if (this.#inputSuspendDepth === 1) {
+      try {
+        if (supportsInputSuspension) chat.suspendInput?.()
+        else chat.changeMicrophone(false)
+      } catch (error) {
+        this.#inputSuspendDepth -= 1
+        throw error
+      }
+    }
+
+    try {
+      return await operation()
+    } finally {
+      this.#inputSuspendDepth -= 1
+      if (this.#inputSuspendDepth === 0) {
+        if (supportsInputSuspension) chat.resumeInput?.(this.#microphoneEnabled)
+        else chat.changeMicrophone(this.#microphoneEnabled)
+      }
+    }
   }
 
   setVolume(volume: number): void {

--- a/firmware/host/modules/input/__tests__/imu.test.ts
+++ b/firmware/host/modules/input/__tests__/imu.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { dirname, resolve } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { writeAliasPackage } from '../../testing/node-alias-package.js'
+import type { IMUSample } from '../imu-motion.js'
+
+type FakeTimer = {
+  advance(milliseconds: number): void
+  reset(): void
+}
+
+class FakeIMUDriver {
+  static current: FakeIMUDriver | undefined
+  #samples: Array<IMUSample | Error> = []
+
+  constructor(_options: unknown) {
+    FakeIMUDriver.current = this
+  }
+
+  configure(_options: unknown): void {}
+
+  sample(): IMUSample {
+    const sample = this.#samples.shift() ?? {}
+    if (sample instanceof Error) throw sample
+    return sample
+  }
+
+  queue(sample: IMUSample | Error): void {
+    this.#samples.push(sample)
+  }
+}
+
+function installBareSpecifierPackages(): void {
+  const modulesRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+  writeAliasPackage(modulesRoot, 'imu-motion', resolve(modulesRoot, 'input/imu-motion.js'))
+  writeAliasPackage(modulesRoot, 'input-event', resolve(modulesRoot, 'input/input-event.js'))
+  writeAliasPackage(modulesRoot, 'timer', resolve(modulesRoot, 'testing/fakes/timer.js'), { hasDefaultExport: true })
+  writeAliasPackage(modulesRoot, 'time', resolve(modulesRoot, 'testing/fakes/time.js'), { hasDefaultExport: true })
+}
+
+async function setup() {
+  installBareSpecifierPackages()
+  const [{ default: IMU }, { default: fakeTimer }] = await Promise.all([
+    import('../imu.js'),
+    import('timer') as Promise<{ default: FakeTimer }>,
+  ])
+  fakeTimer.reset()
+  FakeIMUDriver.current = undefined
+  ;(globalThis as typeof globalThis & { trace: (...messages: unknown[]) => void }).trace = () => {}
+  const imu = new IMU(FakeIMUDriver, { interval: 10 })
+  assert.ok(FakeIMUDriver.current)
+  return { imu, driver: FakeIMUDriver.current, fakeTimer }
+}
+
+test('IMU exposes a defensive copy of the latest successful sample', async () => {
+  const { imu, driver, fakeTimer } = await setup()
+  assert.deepEqual(imu.lastSample, {})
+
+  driver.queue({
+    accelerometer: { x: 1, y: 2, z: 3 },
+    gyroscope: { x: 4, y: 5, z: 6 },
+  })
+  imu.start()
+  fakeTimer.advance(10)
+
+  const sample = imu.lastSample
+  assert.deepEqual(sample, {
+    accelerometer: { x: 1, y: 2, z: 3 },
+    gyroscope: { x: 4, y: 5, z: 6 },
+  })
+  if (sample.accelerometer) sample.accelerometer.x = 99
+  assert.equal(imu.lastSample.accelerometer?.x, 1)
+
+  driver.queue(new Error('temporary read failure'))
+  fakeTimer.advance(10)
+  assert.equal(imu.lastSample.accelerometer?.x, 1)
+  imu.close()
+})

--- a/firmware/host/modules/input/imu.ts
+++ b/firmware/host/modules/input/imu.ts
@@ -23,7 +23,7 @@ type IMUConstructor = new (options: unknown) => IMUDriver
 
 export default class IMU {
   #driver: IMUDriver
-  #timer: Timer | undefined
+  #timer: ReturnType<typeof Timer.repeat> | undefined
   #recognizer: MotionRecognizer
   #interval: number
   #lastSample: IMUSample = {}
@@ -37,8 +37,13 @@ export default class IMU {
     this.#driver.configure?.({ order: 'zxy' })
   }
 
+  /** Latest successful sensor sample. The returned value can be mutated safely by callers. */
+  get lastSample(): IMUSample {
+    return copySample(this.#lastSample)
+  }
+
   #sample(): IMUSample {
-    this.#lastSample = this.#driver.sample()
+    this.#lastSample = copySample(this.#driver.sample())
     return copySample(this.#lastSample)
   }
 

--- a/firmware/host/modules/testing/fakes/ChatAudioIO.js
+++ b/firmware/host/modules/testing/fakes/ChatAudioIO.js
@@ -8,6 +8,9 @@ class ChatAudioIO {
     this.lastText = null
     this.lastFunctionResult = null
     this.microphone = true
+    this.inputSuspended = false
+    this.suspendInputCalls = 0
+    this.resumeInputCalls = 0
     this.volume = 1
   }
 
@@ -38,6 +41,18 @@ class ChatAudioIO {
 
   changeMicrophone(enabled) {
     this.microphone = enabled
+  }
+
+  suspendInput() {
+    this.suspendInputCalls += 1
+    this.inputSuspended = true
+    this.microphone = false
+  }
+
+  resumeInput(microphoneEnabled) {
+    this.resumeInputCalls += 1
+    this.inputSuspended = false
+    this.microphone = microphoneEnabled
   }
 
   changeVolume(volume) {

--- a/firmware/host/modules/testing/fakes/modern-audio-out.ts
+++ b/firmware/host/modules/testing/fakes/modern-audio-out.ts
@@ -1,0 +1,68 @@
+type AudioOutOptions = {
+  sampleRate?: number
+  bitsPerSample?: number
+  channels?: number
+  numChannels?: number
+  onWritable?: (size: number) => void
+}
+
+let constructorFailure: unknown
+const instances: ModernAudioOut[] = []
+
+export default class ModernAudioOut {
+  readonly sampleRate: number
+  readonly bitsPerSample: number
+  readonly channels: number
+  readonly writes: Uint8Array[] = []
+  readonly #onWritable?: (size: number) => void
+  format = 'buffer'
+  volume = 1
+  started = 0
+  stopped = 0
+  closed = false
+
+  constructor(options: AudioOutOptions = {}) {
+    if (constructorFailure !== undefined) throw constructorFailure
+    this.sampleRate = options.sampleRate ?? 24_000
+    this.bitsPerSample = options.bitsPerSample ?? 16
+    this.channels = options.channels ?? options.numChannels ?? 1
+    this.#onWritable = options.onWritable
+    instances.push(this)
+  }
+
+  write(samples: ArrayBuffer | ArrayBufferView): void {
+    const bytes = ArrayBuffer.isView(samples)
+      ? new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength)
+      : new Uint8Array(samples)
+    this.writes.push(new Uint8Array(bytes))
+  }
+
+  start(): void {
+    this.started += 1
+  }
+
+  stop(): void {
+    this.stopped += 1
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  emitWritable(size: number): void {
+    this.#onWritable?.call(this, size)
+  }
+}
+
+export function getModernAudioOutInstances(): ModernAudioOut[] {
+  return instances
+}
+
+export function setModernAudioOutConstructorFailure(error: unknown): void {
+  constructorFailure = error
+}
+
+export function resetModernAudioOut(): void {
+  constructorFailure = undefined
+  instances.length = 0
+}

--- a/firmware/host/platforms/m5stackchan_cores3/manifest.json
+++ b/firmware/host/platforms/m5stackchan_cores3/manifest.json
@@ -8,6 +8,8 @@
     "$(MODDABLE)/modules/drivers/sensors/si12t/manifest.json"
   ],
   "modules": {
+    "embedded:io/audio/out-original": "../physical_audioout",
+    "embedded:io/audio/out": "../shared_audioout",
     "embedded:sensor/Touch/FT6x06": "./host/ft6206_async_m5stackchan",
     "m5stack-cores3/setup-target": "$(BUILD)/devices/esp32/targets/m5stack_cores3/setup-target",
     "setup/target": "./setup-target",

--- a/firmware/host/platforms/physical_audioout.js
+++ b/firmware/host/platforms/physical_audioout.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024-2026 Moddable Tech, Inc.
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * This distinct module name keeps the physical ESP32 AudioOut binding available
+ * when the public embedded:io/audio/out module is replaced by SharedAudioOut.
+ */
+
+class PhysicalAudioOut extends Native('xs_audioout_destructor_') {
+  constructor(options) {
+    super()
+    native('xs_audioout_constructor_').call(this, options)
+  }
+
+  close() {
+    return native('xs_audioout_close_').call(this)
+  }
+
+  start() {
+    return native('xs_audioout_start_').call(this)
+  }
+
+  stop() {
+    return native('xs_audioout_stop_').call(this)
+  }
+
+  write(samples) {
+    return native('xs_audioout_writeSync_').call(this, samples)
+  }
+
+  get format() {
+    return native('xs_audioout_get_format_').call(this)
+  }
+
+  set format(value) {
+    native('xs_audioout_set_format_').call(this, value)
+  }
+
+  get bitsPerSample() {
+    return native('xs_audioout_get_bitsPerSample_').call(this)
+  }
+
+  get channels() {
+    return native('xs_audioout_get_numChannels_').call(this)
+  }
+
+  get sampleRate() {
+    return native('xs_audioout_get_sampleRate_').call(this)
+  }
+
+  get audioType() {
+    return 'LPCM'
+  }
+
+  get volume() {
+    return native('xs_audioout_get_volume_').call(this)
+  }
+
+  set volume(value) {
+    native('xs_audioout_set_volume_').call(this, value)
+  }
+
+  static {
+    PhysicalAudioOut.prototype[Symbol.dispose] = PhysicalAudioOut.prototype.close
+  }
+}
+
+PhysicalAudioOut.Async = class extends PhysicalAudioOut {
+  write(samples, callback) {
+    return native('xs_audioout_writeAsync_').call(this, samples, callback)
+  }
+}
+
+export default PhysicalAudioOut

--- a/firmware/host/platforms/platform-manifest.architecture.ts
+++ b/firmware/host/platforms/platform-manifest.architecture.ts
@@ -122,6 +122,17 @@ describe('Stack-chan platform manifest', () => {
     )
   })
 
+  test('conversation-capable CoreS3 targets route public and physical AudioOut separately', () => {
+    for (const target of ['m5stackchan_cores3', 'stackchan_rt']) {
+      const manifest = readJson(join('host/platforms', target, 'manifest.json'))
+      const publicAudioOut = manifest.modules?.['embedded:io/audio/out']
+      const physicalAudioOut = manifest.modules?.['embedded:io/audio/out-original']
+      assert.equal(publicAudioOut, '../shared_audioout')
+      assert.equal(physicalAudioOut, '../physical_audioout')
+      assert.notEqual(publicAudioOut, physicalAudioOut)
+    }
+  })
+
   test('camera-sharing subplatform providers pin the internal I2C bus to port 1', () => {
     // The camera SCCB reuses the internal I2C bus (defines.camera sda/scl=-1,
     // i2c_port=1). esp32-camera only finds the already-initialized bus handle

--- a/firmware/host/platforms/shared_audioout.ts
+++ b/firmware/host/platforms/shared_audioout.ts
@@ -1,0 +1,11 @@
+import PhysicalAudioOut from 'embedded:io/audio/out-original'
+import { createSharedAudioOutClass } from 'shared-audio-out'
+
+const SharedAudioOutBase = createSharedAudioOutClass(PhysicalAudioOut, {
+  onFormat: ({ sampleRate }) => {
+    const amp = (globalThis as typeof globalThis & { amp?: { sampleRate: number } }).amp
+    if (amp) amp.sampleRate = sampleRate
+  },
+})
+
+export default class SharedAudioOut extends SharedAudioOutBase {}

--- a/firmware/host/platforms/stackchan_rt/manifest.json
+++ b/firmware/host/platforms/stackchan_rt/manifest.json
@@ -4,6 +4,8 @@
   },
   "include": ["$(BUILD)/devices/esp32/targets/m5stack_cores3/manifest.json"],
   "modules": {
+    "embedded:io/audio/out-original": "../physical_audioout",
+    "embedded:io/audio/out": "../shared_audioout",
     "pins/audioout-original": "$(MODULES)/pins/i2s/audioout",
     "pins/audioout": "../core_s3_audioout"
   },

--- a/firmware/mods/examples/chat_audioio/mod.js
+++ b/firmware/mods/examples/chat_audioio/mod.js
@@ -3,8 +3,8 @@ import { ImageFace } from 'behaviors/face'
 import { ChatService, ChatState, chatStateToName } from 'chat'
 import { hasValidChatType, normalizeChatConfig } from 'chat-audioio-config'
 import { SpeechBalloon } from 'effects/speech-balloon'
-import { EmotionNames, emotionFromName } from 'face-state'
 import config from 'mc/config'
+import { createRobotChatTools } from 'robot-chat-tools'
 import { randomBetween } from 'stackchan-util'
 import Timer from 'timer'
 
@@ -18,90 +18,6 @@ const MOUTH_UPDATE_INTERVAL_MS = 125
 const MOUTH_QUANTIZE_STEP = 0.1
 const MOUTH_MAX_STEP = Math.round(1 / MOUTH_QUANTIZE_STEP)
 const MOUTH_LEVEL_STEP_DIVISOR = Math.round(MOUTH_QUANTIZE_STEP / DEFAULT_MOUTH_SCALE)
-const DEFAULT_TONE_DURATION_MS = 220
-const MIN_TONE_DURATION_MS = 30
-const MAX_TONE_DURATION_MS = 3000
-const MIN_TONE_HZ = 40
-const MAX_TONE_HZ = 4000
-// biome-ignore lint/correctness/noUnusedVariables: kept for the parked playTone implementation below.
-const MAX_TONE_COUNT = 64
-
-const NOTE_OFFSETS_FROM_A = {
-  C: -9,
-  D: -7,
-  E: -5,
-  F: -4,
-  G: -2,
-  A: 0,
-  B: 2,
-}
-
-const REST_NAMES = ['R', 'REST', 'PAUSE']
-
-const clampNumber = (value, min, max) => {
-  if (value < min) return min
-  if (value > max) return max
-  return value
-}
-
-// biome-ignore lint/correctness/noUnusedVariables: kept for the parked playTone implementation below.
-const wait = (durationMs) =>
-  new Promise((resolve) => {
-    Timer.set(resolve, durationMs)
-  })
-
-const parseToneDuration = (rawDuration) => {
-  const duration = Number.parseInt(rawDuration ?? `${DEFAULT_TONE_DURATION_MS}`, 10)
-  if (!Number.isFinite(duration)) return DEFAULT_TONE_DURATION_MS
-  return clampNumber(duration, MIN_TONE_DURATION_MS, MAX_TONE_DURATION_MS)
-}
-
-const noteToHz = (noteName, accidental, octaveRaw) => {
-  const baseOffset = NOTE_OFFSETS_FROM_A[noteName]
-  if (baseOffset == null) return null
-  let offset = baseOffset
-  if (accidental === '#') offset += 1
-  if (accidental === 'b' || accidental === 'B') offset -= 1
-  const octave = octaveRaw === undefined ? 4 : Number.parseInt(octaveRaw, 10)
-  if (!Number.isFinite(octave)) return null
-  offset += (octave - 4) * 12
-  const hz = Math.round(440 * 2 ** (offset / 12))
-  return clampNumber(hz, MIN_TONE_HZ, MAX_TONE_HZ)
-}
-
-// biome-ignore lint/correctness/noUnusedVariables: kept for the parked playTone implementation below.
-const parseToneToken = (token) => {
-  if (typeof token !== 'string') return null
-  const trimmed = token.trim()
-  if (trimmed.length === 0) return null
-
-  const restMatch = /^([A-Za-z]+)(?:[:/,]\s*(\d+))?$/.exec(trimmed)
-  if (restMatch && REST_NAMES.includes(restMatch[1].toUpperCase())) {
-    return { type: 'rest', duration: parseToneDuration(restMatch[2]) }
-  }
-
-  const noteMatch = /^([A-Ga-g])([#b]?)(-?\d+)?(?:[:/,]\s*(\d+))?$/.exec(trimmed)
-  if (noteMatch) {
-    const hz = noteToHz(noteMatch[1].toUpperCase(), noteMatch[2], noteMatch[3])
-    if (hz == null) return null
-    return {
-      type: 'tone',
-      hz,
-      duration: parseToneDuration(noteMatch[4]),
-    }
-  }
-
-  const freqMatch = /^(\d+(?:\.\d+)?)(?:[:/,]\s*(\d+))?$/.exec(trimmed)
-  if (freqMatch) {
-    const hz = clampNumber(Math.round(Number.parseFloat(freqMatch[1])), MIN_TONE_HZ, MAX_TONE_HZ)
-    return {
-      type: 'tone',
-      hz,
-      duration: parseToneDuration(freqMatch[2]),
-    }
-  }
-  return null
-}
 
 // biome-ignore lint/correctness/noUnusedVariables: alternative prompt kept for quick local switching.
 const INSTRUCTION_A = `
@@ -164,7 +80,7 @@ Conversation style:
 - Express energy and positivity clearly
 - Avoid childish expressions, slang, or baby talk
 - Do not act like a professional expert or a strict assistant
-- If the user asks to play music or melodies, call the playTone tool
+- If the user asks to play music or melodies, call the play_melody tool
 
 You are a cute, energetic, and polite community-built robot who enjoys talking with people.
 `
@@ -184,82 +100,10 @@ export function onContextCreated(robot) {
     return
   }
 
-  const tools = {
-    set_emotion: {
-      name: 'set_emotion',
-      description: "Set the robot's emotion",
-      parameters: {
-        type: 'object',
-        properties: {
-          emotion: {
-            type: 'string',
-            description: `Emotion to set for the robot. One of: ${EmotionNames.join(', ')}`,
-          },
-        },
-        required: ['emotion'],
-      },
-      execute: async ({ emotion }) => {
-        if (typeof emotion === 'string') {
-          const nextEmotion = emotionFromName(emotion)
-          if (nextEmotion !== undefined) {
-            robot.face.setEmotion(nextEmotion)
-            return `Emotion set to ${emotion.toUpperCase()}`
-          }
-        }
-        return `Invalid emotion: ${String(emotion)}`
-      },
-    },
-    playTone: {
-      name: 'playTone',
-      description:
-        'Play a sequence of tones. Each token can be note or frequency with optional duration: C4:220, F#4:180, 440:200, R:120.',
-      parameters: {
-        type: 'object',
-        properties: {
-          tones: {
-            type: 'array',
-            description: 'Ordered tone tokens to play',
-            items: {
-              type: 'string',
-            },
-          },
-        },
-        required: ['tones'],
-      },
-      // biome-ignore lint/correctness/noUnusedFunctionParameters: tone playback is currently stubbed while the implementation below is parked.
-      execute: async ({ tones }) => {
-        return new Promise((resolve) => {
-          Timer.set(() => {
-            trace('playTone finished\n')
-            resolve('playTone finished')
-          }, 3000)
-        })
-        /*
-        if (!Array.isArray(tones) || tones.length === 0) {
-          return 'No tones provided'
-        }
-        let played = 0
-        let skipped = 0
-        for (const rawToken of tones.slice(0, MAX_TONE_COUNT)) {
-          const parsed = parseToneToken(rawToken)
-          if (!parsed) {
-            skipped += 1
-            continue
-          }
-          if (parsed.type === 'rest') {
-            await wait(parsed.duration)
-            continue
-          }
-          await robot.audio.tone(parsed.hz, parsed.duration)
-          played += 1
-        }
-        const result = `playTone finished. played=${played}, skipped=${skipped}\n`
-        trace(result)
-        return result
-        */
-      },
-    },
-  }
+  let chat
+  const tools = createRobotChatTools(robot, {
+    runWithInputSuspended: (operation) => chat.runWithInputSuspended(operation),
+  })
 
   const app = robot.ui.application
   // robot.ui.setFace(new ImageFace({}))
@@ -492,7 +336,7 @@ export function onContextCreated(robot) {
     queueBalloonText(transcriptText, !more)
   }
 
-  const chat = new ChatService({
+  chat = new ChatService({
     config: chatConfig,
     tools,
     callbacks: {

--- a/firmware/tsconfig.json
+++ b/firmware/tsconfig.json
@@ -174,6 +174,9 @@
       "embedded:io/audio/*": [
 				"./node_modules/@moddable/typings/embedded_io/audio/*"
 			],
+      "embedded:io/audio/out-original": [
+        "./typings/embedded/audio-out-original.d.ts"
+      ],
       "embedded:io/bluetooth/*": [
 				"./node_modules/@moddable/typings/embedded_io/bluetooth/*"
 			],

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -40,6 +40,9 @@
       "embedded:io/audio/out": [
         "host/modules/testing/fakes/audio-out.ts"
       ],
+      "modern-audio-out": [
+        "host/modules/testing/fakes/modern-audio-out.ts"
+      ],
       "mp3streamer": [
         "host/modules/testing/fakes/mp3streamer.ts"
       ],

--- a/firmware/typings/embedded/audio-out-original.d.ts
+++ b/firmware/typings/embedded/audio-out-original.d.ts
@@ -1,0 +1,21 @@
+export type PhysicalAudioOutOptions = {
+  sampleRate?: number
+  bitsPerSample?: 8 | 16
+  channels?: 1 | 2
+  numChannels?: 1 | 2
+  onWritable?: (size: number) => void
+}
+
+export default class PhysicalAudioOut {
+  constructor(options?: PhysicalAudioOutOptions)
+  readonly sampleRate: number
+  readonly bitsPerSample: number
+  readonly channels: number
+  readonly audioType: 'LPCM'
+  format: 'buffer'
+  volume: number
+  write(samples: ArrayBuffer | ArrayBufferView): void
+  start(): void
+  stop(options?: { flush?: boolean }): void
+  close(): void
+}


### PR DESCRIPTION
## Summary

- Add built-in robot tools for Realtime Conversation: `set_emotion`, `play_motion`, optional `set_led`, `play_melody`, and `get_robot_status`.
- Reuse a single modern AudioOut through a four-track software mixer so conversation audio and melody/tone playback can coexist.
- Suspend only microphone input during melody playback while preserving the Realtime connection and output path.

## What Changed

- Add recursive tool parameter schemas and safe argument validation.
- Expose the latest successful IMU sample for robot status.
- Migrate `Speaker` to the modern streaming AudioOut API and route supported platforms through the shared mixer.
- Integrate the shared robot tools into the `chat_audioio` MOD.
- Add unit, Moddable, and architecture coverage.
- Release impact: `minor`
- Changeset: `.changeset/realtime-robot-tools.md`

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [x] `cd firmware && npx biome ci . --error-on-warnings`
- [x] `cd firmware && npm run test:unit` (48/48)
- [x] `cd firmware && npm run test:moddable` (33/33 manifests)
- [x] `cd firmware && npm run check:architecture`
- [x] `cd firmware && npm run check:legacy-names`
- [x] `cd firmware && npm run check:manifest`
- [x] `cd firmware && npm run build:m5stackchan_cores3`
- [x] `cd firmware && npm run build:stackchan_rt`
- [x] `cd firmware && npm run mod:m5stackchan_cores3 -- mods/examples/chat_audioio/manifest.json -t build`
- [x] `cd firmware && npm run mod:stackchan_rt -- mods/examples/chat_audioio/manifest.json -t build`
- [ ] Hardware test (deferred because the connected device is currently in use by another task)

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Related Issues

- None
