### PR TITLE
ci: add Cloudflare PR previews

### DIFF
--- a/.github/scripts/upsert-preview-comment.mjs
+++ b/.github/scripts/upsert-preview-comment.mjs
@@ -1,0 +1,19 @@
+export const PREVIEW_COMMENT_MARKER = '<!-- stackchan-cloudflare-preview -->'
+
+export async function upsertPreviewComment({ github, owner, repo, issueNumber, content }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+  })
+  const existing = comments.find(
+    (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(PREVIEW_COMMENT_MARKER)
+  )
+  const body = `${PREVIEW_COMMENT_MARKER}\n${content.trim()}`
+  const request = { owner, repo, body }
+  if (existing) {
+    await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
+  } else {
+    await github.rest.issues.createComment({ ...request, issue_number: issueNumber })
+  }
+}

--- a/.github/scripts/upsert-preview-comment.test.mjs
+++ b/.github/scripts/upsert-preview-comment.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { PREVIEW_COMMENT_MARKER, upsertPreviewComment } from './upsert-preview-comment.mjs'
+
+function githubStub(comments = []) {
+  const calls = []
+  const github = {
+    paginate: async () => comments,
+    rest: {
+      issues: {
+        listComments() {},
+        async createComment(request) {
+          calls.push({ operation: 'create', request })
+        },
+        async updateComment(request) {
+          calls.push({ operation: 'update', request })
+        },
+      },
+    },
+  }
+  return { calls, github }
+}
+
+test('creates a preview comment when the bot has not posted one', async () => {
+  const { calls, github } = githubStub([{ user: { login: 'contributor' }, body: PREVIEW_COMMENT_MARKER }])
+  await upsertPreviewComment({ github, owner: 'stack-chan', repo: 'stack-chan', issueNumber: 585, content: 'Ready' })
+  assert.equal(calls[0].operation, 'create')
+  assert.equal(calls[0].request.body, `${PREVIEW_COMMENT_MARKER}\nReady`)
+})
+
+test('updates an existing preview comment from the GitHub Actions bot', async () => {
+  const { calls, github } = githubStub([
+    { id: 42, user: { login: 'github-actions[bot]' }, body: `${PREVIEW_COMMENT_MARKER}\nOld` },
+  ])
+  await upsertPreviewComment({ github, owner: 'stack-chan', repo: 'stack-chan', issueNumber: 585, content: 'New' })
+  assert.deepEqual(calls[0], {
+    operation: 'update',
+    request: {
+      owner: 'stack-chan',
+      repo: 'stack-chan',
+      body: `${PREVIEW_COMMENT_MARKER}\nNew`,
+      comment_id: 42,
+    },
+  })
+})

--- a/.github/scripts/validate-cloudflare-config.mjs
+++ b/.github/scripts/validate-cloudflare-config.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export function validateCloudflareConfig(environment = process.env) {
+  const required = ['CLOUDFLARE_ACCOUNT_ID', 'CLOUDFLARE_API_TOKEN', 'CLOUDFLARE_PAGES_PROJECT']
+  for (const name of required) {
+    if (!environment[name]) throw new Error(`GitHub Actions setting ${name} is not configured`)
+  }
+  if (!/^[0-9a-f]{32}$/.test(environment.CLOUDFLARE_ACCOUNT_ID)) {
+    throw new Error('CLOUDFLARE_ACCOUNT_ID must be a 32-character hexadecimal ID')
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(environment.CLOUDFLARE_PAGES_PROJECT)) {
+    throw new Error('CLOUDFLARE_PAGES_PROJECT contains unsupported characters')
+  }
+}
+
+const isMain = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+if (isMain) {
+  try {
+    validateCloudflareConfig()
+    console.log('Validated Cloudflare Pages configuration')
+  } catch (error) {
+    console.error(`::error::${error instanceof Error ? error.message : error}`)
+    process.exit(1)
+  }
+}

--- a/.github/scripts/validate-cloudflare-config.test.mjs
+++ b/.github/scripts/validate-cloudflare-config.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { validateCloudflareConfig } from './validate-cloudflare-config.mjs'
+
+const validConfig = {
+  CLOUDFLARE_ACCOUNT_ID: '0123456789abcdef0123456789abcdef',
+  CLOUDFLARE_API_TOKEN: 'secret',
+  CLOUDFLARE_PAGES_PROJECT: 'stack-chan-pr-preview',
+}
+
+test('accepts the required Cloudflare Pages configuration', () => {
+  assert.doesNotThrow(() => validateCloudflareConfig(validConfig))
+})
+
+test('rejects missing and malformed Cloudflare Pages configuration', () => {
+  assert.throws(() => validateCloudflareConfig({}), /CLOUDFLARE_ACCOUNT_ID is not configured/)
+  assert.throws(
+    () => validateCloudflareConfig({ ...validConfig, CLOUDFLARE_ACCOUNT_ID: 'not-an-id' }),
+    /32-character hexadecimal ID/
+  )
+  assert.throws(
+    () => validateCloudflareConfig({ ...validConfig, CLOUDFLARE_PAGES_PROJECT: 'Invalid/project' }),
+    /unsupported characters/
+  )
+})

--- a/.github/scripts/validate-pages-preview.mjs
+++ b/.github/scripts/validate-pages-preview.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { lstat, readdir } from 'node:fs/promises'
+import { basename, join, relative, resolve, sep } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const MAX_FILE_COUNT = 20_000
+export const MAX_FILE_SIZE = 25 * 1024 * 1024
+
+const REQUIRED_FILES = [
+  'index.html',
+  'flash/tech.moddable.stackchan/m5stackchan_cores3/bootloader.bin',
+  'flash/tech.moddable.stackchan/m5stackchan_cores3/partition-table.bin',
+  'flash/tech.moddable.stackchan/m5stackchan_cores3/xs_esp32.bin',
+  'simulator/index.html',
+  'simulator/mc.js',
+  'simulator/mc.wasm',
+  'schemas/stackchan-mod.schema.json',
+  'schematics/index.html',
+]
+const FORBIDDEN_FILES = new Set(['.assetsignore', '_routes.json', '_worker.js'])
+
+function displayPath(root, path) {
+  return relative(root, path).split(sep).join('/') || '.'
+}
+
+export async function validatePagesPreview(directory) {
+  const root = resolve(directory)
+  const rootStat = await lstat(root)
+  if (!rootStat.isDirectory()) throw new Error(`Preview root is not a directory: ${root}`)
+
+  let fileCount = 0
+  const pending = [root]
+  while (pending.length > 0) {
+    const current = pending.pop()
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const path = join(current, entry.name)
+      const relativePath = displayPath(root, path)
+      const stat = await lstat(path)
+
+      if (stat.isSymbolicLink()) throw new Error(`Symbolic links are not allowed: ${relativePath}`)
+      if (entry.isDirectory()) {
+        if (relativePath === 'functions') {
+          throw new Error('Cloudflare Pages Functions are not allowed in PR previews')
+        }
+        pending.push(path)
+        continue
+      }
+      if (!entry.isFile()) throw new Error(`Unsupported filesystem entry: ${relativePath}`)
+      if (FORBIDDEN_FILES.has(basename(relativePath))) {
+        throw new Error(`Cloudflare runtime controls are not allowed in PR previews: ${relativePath}`)
+      }
+
+      fileCount += 1
+      if (fileCount > MAX_FILE_COUNT) {
+        throw new Error(`Preview contains more than ${MAX_FILE_COUNT} files`)
+      }
+      if (stat.size > MAX_FILE_SIZE) {
+        throw new Error(`File exceeds the Cloudflare Pages 25 MiB limit: ${relativePath}`)
+      }
+    }
+  }
+
+  for (const requiredFile of REQUIRED_FILES) {
+    let stat
+    try {
+      stat = await lstat(join(root, requiredFile))
+    } catch (error) {
+      if (error?.code === 'ENOENT') throw new Error(`Required preview file is missing: ${requiredFile}`)
+      throw error
+    }
+    if (!stat.isFile() || stat.size === 0) {
+      throw new Error(`Required preview file is empty or invalid: ${requiredFile}`)
+    }
+  }
+
+  return { fileCount }
+}
+
+const isMain = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+if (isMain) {
+  const directory = process.argv[2]
+  if (!directory) {
+    console.error('Usage: validate-pages-preview.mjs <preview-directory>')
+    process.exit(2)
+  }
+  try {
+    const result = await validatePagesPreview(directory)
+    console.log(`Validated ${result.fileCount} static preview files`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}

--- a/.github/scripts/validate-pages-preview.mjs
+++ b/.github/scripts/validate-pages-preview.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from 'node:url'
 export const MAX_FILE_COUNT = 20_000
 export const MAX_FILE_SIZE = 25 * 1024 * 1024
 
-const REQUIRED_FILES = [
+export const REQUIRED_FILES = [
   'index.html',
   'flash/tech.moddable.stackchan/m5stackchan_cores3/bootloader.bin',
   'flash/tech.moddable.stackchan/m5stackchan_cores3/partition-table.bin',
@@ -18,7 +18,7 @@ const REQUIRED_FILES = [
   'schemas/stackchan-mod.schema.json',
   'schematics/index.html',
 ]
-const FORBIDDEN_FILES = new Set(['.assetsignore', '_routes.json', '_worker.js'])
+const FORBIDDEN_FILES = new Set(['.assetsignore', '_headers', '_redirects', '_routes.json', '_worker.js'])
 
 function displayPath(root, path) {
   return relative(root, path).split(sep).join('/') || '.'

--- a/.github/scripts/validate-pages-preview.test.mjs
+++ b/.github/scripts/validate-pages-preview.test.mjs
@@ -3,19 +3,7 @@ import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { test } from 'node:test'
-import { validatePagesPreview } from './validate-pages-preview.mjs'
-
-const requiredFiles = [
-  'index.html',
-  'flash/tech.moddable.stackchan/m5stackchan_cores3/bootloader.bin',
-  'flash/tech.moddable.stackchan/m5stackchan_cores3/partition-table.bin',
-  'flash/tech.moddable.stackchan/m5stackchan_cores3/xs_esp32.bin',
-  'simulator/index.html',
-  'simulator/mc.js',
-  'simulator/mc.wasm',
-  'schemas/stackchan-mod.schema.json',
-  'schematics/index.html',
-]
+import { REQUIRED_FILES as requiredFiles, validatePagesPreview } from './validate-pages-preview.mjs'
 
 async function fixture() {
   const root = await mkdtemp(join(tmpdir(), 'stackchan-pages-preview-'))
@@ -50,6 +38,21 @@ test('rejects Cloudflare asset controls', async () => {
   const root = await fixture()
   await writeFile(join(root, '.assetsignore'), 'simulator/mc.wasm')
   await assert.rejects(validatePagesPreview(root), /Cloudflare runtime controls are not allowed/)
+})
+
+test('rejects Cloudflare header and redirect controls', async () => {
+  for (const file of ['_headers', '_redirects']) {
+    const root = await fixture()
+    await writeFile(join(root, file), '/* https://example.com/:splat 302')
+    await assert.rejects(validatePagesPreview(root), /Cloudflare runtime controls are not allowed/)
+  }
+})
+
+test('rejects a top-level functions directory', async () => {
+  const root = await fixture()
+  await mkdir(join(root, 'functions'), { recursive: true })
+  await writeFile(join(root, 'functions/index.js'), 'export default {}')
+  await assert.rejects(validatePagesPreview(root), /Cloudflare Pages Functions are not allowed/)
 })
 
 test('rejects symbolic links', async () => {

--- a/.github/scripts/validate-pages-preview.test.mjs
+++ b/.github/scripts/validate-pages-preview.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { test } from 'node:test'
+import { validatePagesPreview } from './validate-pages-preview.mjs'
+
+const requiredFiles = [
+  'index.html',
+  'flash/tech.moddable.stackchan/m5stackchan_cores3/bootloader.bin',
+  'flash/tech.moddable.stackchan/m5stackchan_cores3/partition-table.bin',
+  'flash/tech.moddable.stackchan/m5stackchan_cores3/xs_esp32.bin',
+  'simulator/index.html',
+  'simulator/mc.js',
+  'simulator/mc.wasm',
+  'schemas/stackchan-mod.schema.json',
+  'schematics/index.html',
+]
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'stackchan-pages-preview-'))
+  for (const file of requiredFiles) {
+    const path = join(root, file)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, 'test')
+  }
+  return root
+}
+
+test('accepts a complete static preview', async () => {
+  const root = await fixture()
+  assert.deepEqual(await validatePagesPreview(root), {
+    fileCount: requiredFiles.length,
+  })
+})
+
+test('rejects a missing generated artifact', async () => {
+  const root = await fixture()
+  await writeFile(join(root, 'simulator/mc.wasm'), '')
+  await assert.rejects(validatePagesPreview(root), /empty or invalid: simulator\/mc\.wasm/)
+})
+
+test('rejects Cloudflare runtime code', async () => {
+  const root = await fixture()
+  await writeFile(join(root, '_worker.js'), 'export default {}')
+  await assert.rejects(validatePagesPreview(root), /Cloudflare runtime controls are not allowed/)
+})
+
+test('rejects Cloudflare asset controls', async () => {
+  const root = await fixture()
+  await writeFile(join(root, '.assetsignore'), 'simulator/mc.wasm')
+  await assert.rejects(validatePagesPreview(root), /Cloudflare runtime controls are not allowed/)
+})
+
+test('rejects symbolic links', async () => {
+  const root = await fixture()
+  await symlink('index.html', join(root, 'linked-index.html'))
+  await assert.rejects(validatePagesPreview(root), /Symbolic links are not allowed/)
+})

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -8,8 +8,10 @@ on:
     paths:
       - "firmware/**"
       - "web/**"
+      - ".github/scripts/**"
       - ".github/actions/setup/action.yml"
       - ".github/workflows/bundle.yml"
+      - ".github/workflows/cloudflare-preview.yml"
   pull_request:
     branches:
       - develop
@@ -17,8 +19,10 @@ on:
     paths:
       - "firmware/**"
       - "web/**"
+      - ".github/scripts/**"
       - ".github/actions/setup/action.yml"
       - ".github/workflows/bundle.yml"
+      - ".github/workflows/cloudflare-preview.yml"
 
 permissions:
   contents: read
@@ -71,6 +75,56 @@ jobs:
         with:
           name: wasm-simulator
           path: ./web/simulator
+      - name: Checkout Pages baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          path: pages-baseline
+          persist-credentials: false
+      - name: Checkout clean preview source
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: preview-source
+          persist-credentials: false
+      - name: Assemble Cloudflare Pages preview
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          test -s ./pages-baseline/web/schematics/index.html
+          mkdir -p ./pages-preview
+          cp -R ./preview-source/web/. ./pages-preview/
+          rm -rf \
+            ./pages-preview/schematics \
+            ./pages-preview/flash/tech.moddable.stackchan \
+            ./pages-preview/simulator
+          mkdir -p \
+            ./pages-preview/flash/tech.moddable.stackchan \
+            ./pages-preview/simulator
+          cp -R ./pages-baseline/web/schematics ./pages-preview/schematics
+          cp -R \
+            ./firmware/host/app/tech.moddable.stackchan/. \
+            ./pages-preview/flash/tech.moddable.stackchan/
+          cp -R ./web/simulator/. ./pages-preview/simulator/
+          mkdir -p ./pages-preview/schemas
+          cp \
+            ./preview-source/docs/specs/stackchan-mod.schema.json \
+            ./pages-preview/schemas/stackchan-mod.schema.json
+      - name: Validate Cloudflare Pages preview
+        if: github.event_name == 'pull_request'
+        run: |
+          node --test .github/scripts/validate-pages-preview.test.mjs
+          node .github/scripts/validate-pages-preview.mjs ./pages-preview
+      - name: Upload Cloudflare Pages preview
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: cloudflare-pages-preview
+          path: ./pages-preview
+          retention-days: 2
+          if-no-files-found: error
 
   deploy:
     needs: build

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Validate Cloudflare Pages preview
         if: github.event_name == 'pull_request'
         run: |
-          node --test .github/scripts/validate-pages-preview.test.mjs
+          node --test .github/scripts/*.test.mjs
           node .github/scripts/validate-pages-preview.mjs ./pages-preview
       - name: Upload Cloudflare Pages preview
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -1,0 +1,338 @@
+name: Deploy Cloudflare PR Preview
+
+on:
+  workflow_run:
+    workflows:
+      - Bundle Stack-chan Firmware
+    types:
+      - completed
+  pull_request_target:
+    types:
+      - closed
+
+permissions: {}
+
+concurrency:
+  group: cloudflare-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Resolve current pull request
+        id: pull_request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const run = context.payload.workflow_run
+            let number = run.pull_requests?.[0]?.number
+            if (!number) {
+              const associated = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: run.head_sha,
+                },
+              )
+              number = associated.find((pull) => ['develop', 'main'].includes(pull.base.ref))?.number
+            }
+            if (!number) {
+              core.notice('No pull request is associated with this workflow run')
+              core.setOutput('eligible', 'false')
+              return
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+            })
+            const allowedBase = ['develop', 'main'].includes(pull.base.ref)
+            const currentCommit = [pull.head.sha, pull.merge_commit_sha].includes(run.head_sha)
+            const eligible = pull.state === 'open' && allowedBase && currentCommit
+            core.setOutput('number', String(number))
+            core.setOutput('head_sha', pull.head.sha)
+            core.setOutput('eligible', String(eligible))
+            if (!eligible) {
+              core.notice(`Skipping stale or ineligible preview run for PR #${number}`)
+            }
+
+      - name: Report failed preview build
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion != 'success'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        with:
+          script: |
+            const marker = '<!-- stackchan-cloudflare-preview -->'
+            const body = `${marker}
+            ## Cloudflare PR preview
+
+            The preview build **${process.env.RUN_CONCLUSION}**. No new deployment was published.
+
+            [Open the failed workflow run](${process.env.RUN_URL}). Any URL from an earlier comment is stale.`
+            const issue_number = Number(process.env.PR_NUMBER)
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            })
+            const existing = comments.find(
+              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            )
+            const request = { owner: context.repo.owner, repo: context.repo.repo, body }
+            if (existing) {
+              await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
+            } else {
+              await github.rest.issues.createComment({ ...request, issue_number })
+            }
+
+      - name: Download preview artifact
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cloudflare-pages-preview
+          path: preview-upload/site
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Checkout trusted validator
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted-source
+          persist-credentials: false
+
+      - name: Validate preview artifact
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
+        run: node ./trusted-source/.github/scripts/validate-pages-preview.mjs ./preview-upload/site
+
+      - name: Validate Cloudflare configuration
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_PAGES_PROJECT; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::GitHub Actions setting $name is not configured"
+              exit 1
+            fi
+          done
+          if [[ ! "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo '::error::CLOUDFLARE_ACCOUNT_ID must be a 32-character hexadecimal ID'
+            exit 1
+          fi
+          if [[ ! "$CLOUDFLARE_PAGES_PROJECT" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            echo '::error::CLOUDFLARE_PAGES_PROJECT contains unsupported characters'
+            exit 1
+          fi
+
+      - name: Deploy preview to Cloudflare Pages
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
+        id: cloudflare
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: preview-upload
+          packageManager: npm
+          command: >-
+            pages deploy site
+            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+            --branch=pr-${{ steps.pull_request.outputs.number }}
+            --commit-hash=${{ steps.pull_request.outputs.head_sha }}
+
+      - name: Publish preview link
+        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+          HEAD_SHA: ${{ steps.pull_request.outputs.head_sha }}
+          PREVIEW_URL: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
+          IMMUTABLE_URL: ${{ steps.cloudflare.outputs.deployment-url }}
+        with:
+          script: |
+            const marker = '<!-- stackchan-cloudflare-preview -->'
+            const previewUrl = process.env.PREVIEW_URL || process.env.IMMUTABLE_URL
+            if (!previewUrl) throw new Error('Cloudflare did not return a preview URL')
+            const body = `${marker}
+            ## Cloudflare PR preview
+
+            [Open the latest preview](${previewUrl}) for commit \`${process.env.HEAD_SHA.slice(0, 12)}\`.
+
+            Immutable deployment: ${process.env.IMMUTABLE_URL || previewUrl}
+
+            > [!WARNING]
+            > Pull request previews contain untrusted web and firmware code. Review the changes before granting WebSerial/Bluetooth permissions or flashing a device.`
+            const issue_number = Number(process.env.PR_NUMBER)
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            })
+            const existing = comments.find(
+              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            )
+            const request = { owner: context.repo.owner, repo: context.repo.repo, body }
+            if (existing) {
+              await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
+            } else {
+              await github.rest.issues.createComment({ ...request, issue_number })
+            }
+
+  close:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Find preview comment
+        id: preview
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const marker = '<!-- stackchan-cloudflare-preview -->'
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            })
+            const exists = comments.some(
+              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            )
+            core.setOutput('exists', String(exists))
+      - name: Validate Cloudflare configuration
+        if: steps.preview.outputs.exists == 'true'
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        run: |
+          set -euo pipefail
+          for name in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_PAGES_PROJECT; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::GitHub Actions setting $name is not configured"
+              exit 1
+            fi
+          done
+          if [[ ! "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo '::error::CLOUDFLARE_ACCOUNT_ID must be a 32-character hexadecimal ID'
+            exit 1
+          fi
+          if [[ ! "$CLOUDFLARE_PAGES_PROJECT" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            echo '::error::CLOUDFLARE_PAGES_PROJECT contains unsupported characters'
+            exit 1
+          fi
+      - name: Create closed preview page
+        if: steps.preview.outputs.exists == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p closed-upload/site
+          printf '%s\n' \
+            '<!doctype html>' \
+            '<html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex">' \
+            '<meta name="viewport" content="width=device-width,initial-scale=1">' \
+            "<title>PR #${PR_NUMBER} preview closed</title></head>" \
+            "<body><main><h1>PR #${PR_NUMBER} preview closed</h1>" \
+            '<p>This pull request is closed, so its preview is no longer available.</p></main></body></html>' \
+            > closed-upload/site/index.html
+      - name: Replace preview with closed page
+        if: steps.preview.outputs.exists == 'true'
+        id: cloudflare
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: closed-upload
+          packageManager: npm
+          command: >-
+            pages deploy site
+            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+            --branch=pr-${{ github.event.pull_request.number }}
+            --commit-hash=${{ github.event.pull_request.head.sha }}
+      - name: Delete superseded preview deployments
+        if: steps.preview.outputs.exists == 'true'
+        env:
+          BRANCH_NAME: pr-${{ github.event.pull_request.number }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+          KEEP_DEPLOYMENT_ID: ${{ steps.cloudflare.outputs.pages-deployment-id }}
+        run: |
+          set -euo pipefail
+          test -n "$KEEP_DEPLOYMENT_ID"
+          page=1
+          while true; do
+            response=$(curl -fsS \
+              --get \
+              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              --header 'Content-Type: application/json' \
+              --data-urlencode 'env=preview' \
+              --data-urlencode 'per_page=100' \
+              --data-urlencode "page=${page}" \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}/deployments")
+            echo "$response" | jq -e '.success == true' >/dev/null
+            echo "$response" | jq -r \
+              --arg branch "$BRANCH_NAME" \
+              --arg keep "$KEEP_DEPLOYMENT_ID" \
+              '.result[] | select(.deployment_trigger.metadata.branch == $branch and .id != $keep) | .id' \
+              >> deployments-to-delete.txt
+            total_pages=$(echo "$response" | jq -r '.result_info.total_pages // 1')
+            if [ "$page" -ge "$total_pages" ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+          sort -u deployments-to-delete.txt | while IFS= read -r deployment_id; do
+            if [ -z "$deployment_id" ]; then
+              continue
+            fi
+            curl -fsS \
+              --request DELETE \
+              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}/deployments/${deployment_id}?force=true" \
+              >/dev/null
+          done
+      - name: Mark preview as closed
+        if: steps.preview.outputs.exists == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
+        with:
+          script: |
+            const marker = '<!-- stackchan-cloudflare-preview -->'
+            const body = `${marker}
+            ## Cloudflare PR preview
+
+            This pull request is closed. Its preview has been replaced with a closed page${process.env.PREVIEW_URL ? ` at ${process.env.PREVIEW_URL}` : ''}.`
+            const issue_number = Number(process.env.PR_NUMBER)
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            })
+            const existing = comments.find(
+              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            )
+            const request = { owner: context.repo.owner, repo: context.repo.repo, body }
+            if (existing) {
+              await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
+            } else {
+              await github.rest.issues.createComment({ ...request, issue_number })
+            }

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -13,7 +13,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: cloudflare-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number || github.run_id }}
+  group: cloudflare-preview-${{ github.event.workflow_run.head_repository.id || github.event.pull_request.head.repo.id || github.repository_id }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -65,6 +65,14 @@ jobs:
               core.notice(`Skipping stale or ineligible preview run for PR #${number}`)
             }
 
+      - name: Checkout trusted preview scripts
+        if: steps.pull_request.outputs.eligible == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted-source
+          persist-credentials: false
+
       - name: Report failed preview build
         if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion != 'success'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -74,28 +82,23 @@ jobs:
           RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         with:
           script: |
-            const marker = '<!-- stackchan-cloudflare-preview -->'
-            const body = `${marker}
-            ## Cloudflare PR preview
+            const { pathToFileURL } = require('node:url')
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/trusted-source/.github/scripts/upsert-preview-comment.mjs`,
+            ).href
+            const { upsertPreviewComment } = await import(helperUrl)
+            const content = `## Cloudflare PR preview
 
             The preview build **${process.env.RUN_CONCLUSION}**. No new deployment was published.
 
             [Open the failed workflow run](${process.env.RUN_URL}). Any URL from an earlier comment is stale.`
-            const issue_number = Number(process.env.PR_NUMBER)
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await upsertPreviewComment({
+              github,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number,
+              issueNumber: Number(process.env.PR_NUMBER),
+              content,
             })
-            const existing = comments.find(
-              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
-            )
-            const request = { owner: context.repo.owner, repo: context.repo.repo, body }
-            if (existing) {
-              await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
-            } else {
-              await github.rest.issues.createComment({ ...request, issue_number })
-            }
 
       - name: Download preview artifact
         if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
@@ -105,14 +108,6 @@ jobs:
           path: preview-upload/site
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Checkout trusted validator
-        if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          path: trusted-source
-          persist-credentials: false
 
       - name: Validate preview artifact
         if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
@@ -124,22 +119,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
-        run: |
-          set -euo pipefail
-          for name in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_PAGES_PROJECT; do
-            if [ -z "${!name:-}" ]; then
-              echo "::error::GitHub Actions setting $name is not configured"
-              exit 1
-            fi
-          done
-          if [[ ! "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
-            echo '::error::CLOUDFLARE_ACCOUNT_ID must be a 32-character hexadecimal ID'
-            exit 1
-          fi
-          if [[ ! "$CLOUDFLARE_PAGES_PROJECT" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
-            echo '::error::CLOUDFLARE_PAGES_PROJECT contains unsupported characters'
-            exit 1
-          fi
+        run: node ./trusted-source/.github/scripts/validate-cloudflare-config.mjs
 
       - name: Deploy preview to Cloudflare Pages
         if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion == 'success'
@@ -166,11 +146,14 @@ jobs:
           IMMUTABLE_URL: ${{ steps.cloudflare.outputs.deployment-url }}
         with:
           script: |
-            const marker = '<!-- stackchan-cloudflare-preview -->'
+            const { pathToFileURL } = require('node:url')
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/trusted-source/.github/scripts/upsert-preview-comment.mjs`,
+            ).href
+            const { upsertPreviewComment } = await import(helperUrl)
             const previewUrl = process.env.PREVIEW_URL || process.env.IMMUTABLE_URL
             if (!previewUrl) throw new Error('Cloudflare did not return a preview URL')
-            const body = `${marker}
-            ## Cloudflare PR preview
+            const content = `## Cloudflare PR preview
 
             [Open the latest preview](${previewUrl}) for commit \`${process.env.HEAD_SHA.slice(0, 12)}\`.
 
@@ -178,26 +161,19 @@ jobs:
 
             > [!WARNING]
             > Pull request previews contain untrusted web and firmware code. Review the changes before granting WebSerial/Bluetooth permissions or flashing a device.`
-            const issue_number = Number(process.env.PR_NUMBER)
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await upsertPreviewComment({
+              github,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number,
+              issueNumber: Number(process.env.PR_NUMBER),
+              content,
             })
-            const existing = comments.find(
-              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
-            )
-            const request = { owner: context.repo.owner, repo: context.repo.repo, body }
-            if (existing) {
-              await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
-            } else {
-              await github.rest.issues.createComment({ ...request, issue_number })
-            }
 
   close:
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Find preview comment
@@ -215,28 +191,20 @@ jobs:
               (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
             )
             core.setOutput('exists', String(exists))
+      - name: Checkout trusted preview scripts
+        if: steps.preview.outputs.exists == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted-source
+          persist-credentials: false
       - name: Validate Cloudflare configuration
         if: steps.preview.outputs.exists == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
-        run: |
-          set -euo pipefail
-          for name in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_PAGES_PROJECT; do
-            if [ -z "${!name:-}" ]; then
-              echo "::error::GitHub Actions setting $name is not configured"
-              exit 1
-            fi
-          done
-          if [[ ! "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-f]{32}$ ]]; then
-            echo '::error::CLOUDFLARE_ACCOUNT_ID must be a 32-character hexadecimal ID'
-            exit 1
-          fi
-          if [[ ! "$CLOUDFLARE_PAGES_PROJECT" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
-            echo '::error::CLOUDFLARE_PAGES_PROJECT contains unsupported characters'
-            exit 1
-          fi
+        run: node ./trusted-source/.github/scripts/validate-cloudflare-config.mjs
       - name: Create closed preview page
         if: steps.preview.outputs.exists == 'true'
         env:
@@ -316,23 +284,18 @@ jobs:
           PREVIEW_URL: ${{ steps.cloudflare.outputs.pages-deployment-alias-url }}
         with:
           script: |
-            const marker = '<!-- stackchan-cloudflare-preview -->'
-            const body = `${marker}
-            ## Cloudflare PR preview
+            const { pathToFileURL } = require('node:url')
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/trusted-source/.github/scripts/upsert-preview-comment.mjs`,
+            ).href
+            const { upsertPreviewComment } = await import(helperUrl)
+            const content = `## Cloudflare PR preview
 
             This pull request is closed. Its preview has been replaced with a closed page${process.env.PREVIEW_URL ? ` at ${process.env.PREVIEW_URL}` : ''}.`
-            const issue_number = Number(process.env.PR_NUMBER)
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await upsertPreviewComment({
+              github,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number,
+              issueNumber: Number(process.env.PR_NUMBER),
+              content,
             })
-            const existing = comments.find(
-              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
-            )
-            const request = { owner: context.repo.owner, repo: context.repo.repo, body }
-            if (existing) {
-              await github.rest.issues.updateComment({ ...request, comment_id: existing.id })
-            } else {
-              await github.rest.issues.createComment({ ...request, issue_number })
-            }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run flash
 
 Generated web assets under `web/flash` and `web/schematics` are published from the `gh-pages` branch by GitHub Actions. Treat them as deployment outputs, not hand-maintained source files.
 
-See [Configure Cloudflare Pages PR previews](./docs/operations/cloudflare-pr-preview.md) to enable a browser preview for each pull request.
+See [Configure Cloudflare Pages PR previews](./docs/operations/cloudflare-pr-preview.md) to enable browser previews for pull requests that change `firmware/**` or `web/**`.
 
 ## Planning
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ npm run flash
 
 Generated web assets under `web/flash` and `web/schematics` are published from the `gh-pages` branch by GitHub Actions. Treat them as deployment outputs, not hand-maintained source files.
 
+See [Configure Cloudflare Pages PR previews](./docs/operations/cloudflare-pr-preview.md) to enable a browser preview for each pull request.
+
 ## Planning
 
 * Development roadmap: [docs/ROADMAP.md](./docs/ROADMAP.md)

--- a/README_ja.md
+++ b/README_ja.md
@@ -58,7 +58,7 @@ npm run flash
 
 `web/flash` と `web/schematics` は GitHub Actions から `gh-pages` ブランチへ配布される生成物です。手作業で保守するソースではなく、デプロイ成果物として扱ってください。
 
-Pull RequestごとのWebプレビューを有効にする方法は [Cloudflare Pages PRプレビューの設定](./docs/operations/cloudflare-pr-preview_ja.md) を参照してください。
+`firmware/**` または `web/**` を変更するPull RequestのWebプレビューを有効にする方法は [Cloudflare Pages PRプレビューの設定](./docs/operations/cloudflare-pr-preview_ja.md) を参照してください。
 
 ## 開発計画
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -58,6 +58,8 @@ npm run flash
 
 `web/flash` と `web/schematics` は GitHub Actions から `gh-pages` ブランチへ配布される生成物です。手作業で保守するソースではなく、デプロイ成果物として扱ってください。
 
+Pull RequestごとのWebプレビューを有効にする方法は [Cloudflare Pages PRプレビューの設定](./docs/operations/cloudflare-pr-preview_ja.md) を参照してください。
+
 ## 開発計画
 
 * 開発ロードマップ: [docs/ROADMAP_ja.md](./docs/ROADMAP_ja.md)

--- a/docs/operations/cloudflare-pr-preview.md
+++ b/docs/operations/cloudflare-pr-preview.md
@@ -1,0 +1,41 @@
+# Configure Cloudflare Pages PR previews
+
+PR previews deploy to a dedicated Cloudflare Pages project, independently of the existing GitHub Pages production site.
+Pull requests that change `firmware/**` or `web/**` are eligible, including pull requests from external forks.
+
+## Cloudflare Pages project
+
+Create a Pages project using Direct Upload from Workers & Pages in the Cloudflare dashboard.
+
+- Project name: `stack-chan-pr-preview`
+- Production branch: `production`
+- Access policy: disabled (public previews)
+
+Do not connect this project to the GitHub repository.
+GitHub Actions uploads the prebuilt static site directly.
+
+## Cloudflare API token
+
+Create a custom token in Cloudflare API Tokens.
+Grant only `Account / Cloudflare Pages / Edit` for the account that owns the preview project.
+
+Add these values under GitHub repository Settings, Secrets and variables, Actions:
+
+| Kind     | Name                       | Value                     |
+| -------- | -------------------------- | ------------------------- |
+| Secret   | `CLOUDFLARE_API_TOKEN`     | The custom API token      |
+| Secret   | `CLOUDFLARE_ACCOUNT_ID`    | The Cloudflare account ID |
+| Variable | `CLOUDFLARE_PAGES_PROJECT` | `stack-chan-pr-preview`   |
+
+## Verify the integration
+
+Open a pull request that changes `web/**` or another watched path, then verify:
+
+1. `Bundle Stack-chan Firmware` succeeds.
+2. `Deploy Cloudflare PR Preview` succeeds afterward.
+3. A `Cloudflare PR preview` comment appears on the pull request.
+4. The web tools and simulator open at `https://pr-<number>.<Pages project subdomain>.pages.dev`.
+5. Closing the pull request replaces that URL with a preview-closed page.
+
+External pull request previews contain untrusted JavaScript and firmware.
+Do not grant WebSerial or Bluetooth permissions or flash a device until the changes have been reviewed.

--- a/docs/operations/cloudflare-pr-preview_ja.md
+++ b/docs/operations/cloudflare-pr-preview_ja.md
@@ -1,0 +1,41 @@
+# Cloudflare Pages PRプレビューの設定
+
+PRプレビューは、既存のGitHub Pages本番サイトとは独立したCloudflare Pagesプロジェクトへ配布されます。
+`firmware/**`または`web/**`を変更するPRが対象で、外部forkのPRにも対応します。
+
+## Cloudflare Pagesプロジェクト
+
+CloudflareダッシュボードのWorkers & Pagesから、Direct Upload方式のPagesプロジェクトを作成します。
+
+- プロジェクト名: `stack-chan-pr-preview`
+- 本番ブランチ: `production`
+- Accessポリシー: 無効（公開プレビュー）
+
+このプロジェクトをGitHubリポジトリへ接続しないでください。
+GitHub Actionsがビルド済みの静的ファイルをDirect Uploadします。
+
+## Cloudflare APIトークン
+
+CloudflareのAPI Tokens画面でカスタムトークンを作成します。
+対象アカウントだけに、`Account / Cloudflare Pages / Edit`権限を付与してください。
+
+GitHubリポジトリのSettings、Secrets and variables、Actionsで次を登録します。
+
+| 種別     | 名前                       | 値                       |
+| -------- | -------------------------- | ------------------------ |
+| Secret   | `CLOUDFLARE_API_TOKEN`     | 作成したAPIトークン      |
+| Secret   | `CLOUDFLARE_ACCOUNT_ID`    | CloudflareのアカウントID |
+| Variable | `CLOUDFLARE_PAGES_PROJECT` | `stack-chan-pr-preview`  |
+
+## 動作確認
+
+`web/**`などを変更するPRを作成し、次を確認します。
+
+1. `Bundle Stack-chan Firmware`が成功する。
+2. `Deploy Cloudflare PR Preview`が続けて成功する。
+3. PRに`Cloudflare PR preview`コメントが作られる。
+4. `https://pr-<PR番号>.<Pagesプロジェクトのサブドメイン>.pages.dev`でWebツールとシミュレーターを開ける。
+5. PRを閉じると、同じURLがプレビュー終了ページへ置き換わる。
+
+外部PRのプレビューには未信頼のJavaScriptとファームウェアが含まれます。
+差分を確認するまでWebSerialやBluetoothの権限を付与したり、実機へ書き込んだりしないでください。


### PR DESCRIPTION
## Summary

- Add Cloudflare Pages previews for pull requests that change firmware or web assets.
- Keep the existing `develop` to `gh-pages` production deployment unchanged.

## What Changed

- Assemble the complete static site, generated firmware bundle, WASM simulator, schema, and published schematics into a short-lived PR artifact.
- Deploy that artifact from a separate privileged `workflow_run` workflow so fork pull requests never receive Cloudflare credentials.
- Publish a stable `pr-<number>` URL as a single updated PR comment, and replace it with a closed page when the PR closes.
- Validate uploaded artifacts as static content and reject Pages Functions, Workers, symlinks, missing generated files, and Cloudflare upload limit violations.
- Document the Cloudflare project, token, and GitHub repository settings in English and Japanese.

## Verification

- [ ] `cd firmware && npm run format`
- [ ] `cd firmware && npm run lint`
- [ ] `cd firmware && npm run test`
- [ ] `cd firmware && npm run check:legacy-names`
- [x] Other checks were run when relevant
  - `cd web && npm test` (203 tests)
  - Preview validator unit tests
  - Preview assembly fixture validation (299 files)
  - YAML parsing, Prettier, `actionlint`, and `git diff --check`

## Affected Areas

- [ ] firmware
- [x] web
- [ ] schematics
- [ ] case
- [x] docs
- [x] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Release Impact

- `none` — this changes CI and operations documentation only. No changeset is needed because production firmware and web behavior are unchanged.

## Related Issues

- Enables PR #578 to be used as the first end-to-end preview after this workflow is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cloudflare Pages PR previews for eligible changes with shareable preview URLs.
  - Automated PR preview status updates via persistent pull request comments.
  - Added CLI tooling to validate preview content and required Cloudflare configuration before deployment.
- **Bug Fixes**
  - Improved safety checks to prevent symlinks, disallowed directories/controls, missing required files, and oversized artifacts from being deployed.
- **Documentation**
  - Added English and Japanese guides for enabling and verifying Cloudflare PR previews, including security notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->