### PR TITLE
fix(ci): allow preview workflow to comment on PRs

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -24,7 +24,7 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Resolve current pull request
         id: pull_request


### PR DESCRIPTION
## Summary

- grant the Cloudflare preview deploy job `pull-requests: write`
- keep the existing least-privilege permissions for all other resources

## Root cause

The first PR #578 deployment reached Cloudflare successfully, but posting the preview link failed with HTTP 403 (`Resource not accessible by integration`). The job had `issues: write` but only `pull-requests: read`; writing a comment to this pull request requires pull-request write access in this repository.

## Impact

- Cloudflare preview links can be posted and updated automatically on pull requests.
- Release impact: `none` — this only changes GitHub Actions permissions and does not alter firmware or web release artifacts.

## Verification

- `node --test .github/scripts/upsert-preview-comment.test.mjs .github/scripts/validate-cloudflare-config.test.mjs .github/scripts/validate-pages-preview.test.mjs`
- `git diff --check`
- The deployed PR #578 preview returns HTTP 200 for `/`, `/simulator/`, `/flash/`, and `/schemas/stackchan-mod.schema.json`.

`actionlint` was not available in the local environment; GitHub Actions will validate the workflow syntax.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment permissions to support writing pull request status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->