### PR TITLE
fix(ci): resolve fork PRs for Cloudflare previews

### DIFF
--- a/.github/scripts/resolve-preview-pull-request.mjs
+++ b/.github/scripts/resolve-preview-pull-request.mjs
@@ -1,0 +1,51 @@
+const ALLOWED_BASE_BRANCHES = new Set(['develop', 'main'])
+
+function repositoryMatches(actual, expected) {
+  return typeof actual === 'string' && typeof expected === 'string' && actual.toLowerCase() === expected.toLowerCase()
+}
+
+export async function resolvePreviewPullRequest({ github, owner, repo, run }) {
+  const targetRepository = `${owner}/${repo}`
+  let number = run.pull_requests?.[0]?.number
+
+  if (!number) {
+    const headOwner = run.head_repository?.owner?.login ?? run.head_repository?.full_name?.split('/', 1)[0]
+    if (headOwner && run.head_branch) {
+      const candidates = await github.paginate(github.rest.pulls.list, {
+        owner,
+        repo,
+        state: 'open',
+        head: `${headOwner}:${run.head_branch}`,
+        per_page: 100,
+      })
+      number = candidates.find(
+        (pull) =>
+          repositoryMatches(pull.base?.repo?.full_name, targetRepository) &&
+          ALLOWED_BASE_BRANCHES.has(pull.base?.ref) &&
+          pull.head?.sha === run.head_sha,
+      )?.number
+    }
+  }
+
+  if (!number) {
+    return { eligible: false }
+  }
+
+  const { data: pull } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: number,
+  })
+  const allowedBase = ALLOWED_BASE_BRANCHES.has(pull.base.ref)
+  const targetBase = repositoryMatches(pull.base.repo?.full_name, targetRepository)
+  const currentCommit = [pull.head.sha, pull.merge_commit_sha].includes(run.head_sha)
+  const currentHead =
+    repositoryMatches(pull.head.repo?.full_name, run.head_repository?.full_name) && pull.head.ref === run.head_branch
+  const eligible = pull.state === 'open' && allowedBase && targetBase && currentCommit && currentHead
+
+  return {
+    eligible,
+    headSha: pull.head.sha,
+    number,
+  }
+}

--- a/.github/scripts/resolve-preview-pull-request.test.mjs
+++ b/.github/scripts/resolve-preview-pull-request.test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { resolvePreviewPullRequest } from './resolve-preview-pull-request.mjs'
+
+const RUN = {
+  head_branch: 'agent/web-react-vite-refactor',
+  head_repository: {
+    full_name: 'sskw-ugo/stack-chan-pr',
+    owner: { login: 'sskw-ugo' },
+  },
+  head_sha: '2a7b74b39e879f27d4a1d99bc351b6d99433dd60',
+  pull_requests: [],
+}
+
+function pull(overrides = {}) {
+  return {
+    base: {
+      ref: 'develop',
+      repo: { full_name: 'stack-chan/stack-chan' },
+    },
+    head: {
+      ref: RUN.head_branch,
+      repo: { full_name: RUN.head_repository.full_name },
+      sha: RUN.head_sha,
+    },
+    merge_commit_sha: 'merge-sha',
+    number: 592,
+    state: 'open',
+    ...overrides,
+  }
+}
+
+function githubStub({ candidates = [], resolvedPull = pull() } = {}) {
+  const calls = []
+  const github = {
+    async paginate(method, request) {
+      calls.push({ operation: 'list', request })
+      assert.equal(method, github.rest.pulls.list)
+      return candidates
+    },
+    rest: {
+      pulls: {
+        list() {},
+        async get(request) {
+          calls.push({ operation: 'get', request })
+          return { data: resolvedPull }
+        },
+      },
+    },
+  }
+  return { calls, github }
+}
+
+test('resolves a fork pull request when workflow_run omits pull_requests', async () => {
+  const { calls, github } = githubStub({ candidates: [pull()] })
+
+  const result = await resolvePreviewPullRequest({
+    github,
+    owner: 'stack-chan',
+    repo: 'stack-chan',
+    run: RUN,
+  })
+
+  assert.deepEqual(result, {
+    eligible: true,
+    headSha: RUN.head_sha,
+    number: 592,
+  })
+  assert.deepEqual(calls, [
+    {
+      operation: 'list',
+      request: {
+        owner: 'stack-chan',
+        repo: 'stack-chan',
+        state: 'open',
+        head: 'sskw-ugo:agent/web-react-vite-refactor',
+        per_page: 100,
+      },
+    },
+    {
+      operation: 'get',
+      request: {
+        owner: 'stack-chan',
+        repo: 'stack-chan',
+        pull_number: 592,
+      },
+    },
+  ])
+})
+
+test('uses the pull request supplied by workflow_run without listing candidates', async () => {
+  const { calls, github } = githubStub()
+
+  const result = await resolvePreviewPullRequest({
+    github,
+    owner: 'stack-chan',
+    repo: 'stack-chan',
+    run: { ...RUN, pull_requests: [{ number: 592 }] },
+  })
+
+  assert.equal(result.eligible, true)
+  assert.deepEqual(
+    calls.map(({ operation }) => operation),
+    ['get'],
+  )
+})
+
+test('does not resolve a candidate from another base repository', async () => {
+  const candidate = pull({
+    base: {
+      ref: 'develop',
+      repo: { full_name: 'another-owner/stack-chan' },
+    },
+  })
+  const { calls, github } = githubStub({ candidates: [candidate] })
+
+  const result = await resolvePreviewPullRequest({
+    github,
+    owner: 'stack-chan',
+    repo: 'stack-chan',
+    run: RUN,
+  })
+
+  assert.deepEqual(result, { eligible: false })
+  assert.deepEqual(
+    calls.map(({ operation }) => operation),
+    ['list'],
+  )
+})
+
+test('rejects a stale workflow run after resolving its pull request', async () => {
+  const { github } = githubStub({
+    candidates: [pull()],
+    resolvedPull: pull({
+      head: {
+        ref: RUN.head_branch,
+        repo: { full_name: RUN.head_repository.full_name },
+        sha: 'newer-sha',
+      },
+    }),
+  })
+
+  const result = await resolvePreviewPullRequest({
+    github,
+    owner: 'stack-chan',
+    repo: 'stack-chan',
+    run: RUN,
+  })
+
+  assert.deepEqual(result, {
+    eligible: false,
+    headSha: 'newer-sha',
+    number: 592,
+  })
+})

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -26,52 +26,42 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Resolve current pull request
-        id: pull_request
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const run = context.payload.workflow_run
-            let number = run.pull_requests?.[0]?.number
-            if (!number) {
-              const associated = await github.paginate(
-                github.rest.repos.listPullRequestsAssociatedWithCommit,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  commit_sha: run.head_sha,
-                },
-              )
-              number = associated.find((pull) => ['develop', 'main'].includes(pull.base.ref))?.number
-            }
-            if (!number) {
-              core.notice('No pull request is associated with this workflow run')
-              core.setOutput('eligible', 'false')
-              return
-            }
-
-            const { data: pull } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: number,
-            })
-            const allowedBase = ['develop', 'main'].includes(pull.base.ref)
-            const currentCommit = [pull.head.sha, pull.merge_commit_sha].includes(run.head_sha)
-            const eligible = pull.state === 'open' && allowedBase && currentCommit
-            core.setOutput('number', String(number))
-            core.setOutput('head_sha', pull.head.sha)
-            core.setOutput('eligible', String(eligible))
-            if (!eligible) {
-              core.notice(`Skipping stale or ineligible preview run for PR #${number}`)
-            }
-
       - name: Checkout trusted preview scripts
-        if: steps.pull_request.outputs.eligible == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: trusted-source
           persist-credentials: false
+
+      - name: Resolve current pull request
+        id: pull_request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { pathToFileURL } = require('node:url')
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/trusted-source/.github/scripts/resolve-preview-pull-request.mjs`,
+            ).href
+            const { resolvePreviewPullRequest } = await import(helperUrl)
+            const run = context.payload.workflow_run
+            const resolution = await resolvePreviewPullRequest({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run,
+            })
+            if (!resolution.number) {
+              core.notice('No pull request is associated with this workflow run')
+              core.setOutput('eligible', 'false')
+              return
+            }
+
+            core.setOutput('number', String(resolution.number))
+            core.setOutput('head_sha', resolution.headSha)
+            core.setOutput('eligible', String(resolution.eligible))
+            if (!resolution.eligible) {
+              core.notice(`Skipping stale or ineligible preview run for PR #${resolution.number}`)
+            }
 
       - name: Report failed preview build
         if: steps.pull_request.outputs.eligible == 'true' && github.event.workflow_run.conclusion != 'success'


### PR DESCRIPTION
## Summary

- resolve fork pull requests when `workflow_run.pull_requests` is empty by looking up open pull requests with the workflow run's head owner and branch
- verify the base repository and branch, head repository and branch, and current SHA before allowing the secret-bearing preview deployment
- move the resolution logic into a tested helper and keep the workflow loading it from the trusted default branch checkout

## Root cause

PR #592 runs from the `sskw-ugo/stack-chan-pr` fork. Its completed Bundle workflow reported an empty `pull_requests` array. The existing fallback queried commit associations in `stack-chan/stack-chan` using the fork commit SHA, returned no pull request, and skipped every Cloudflare deployment step.

## Impact

After this change is merged into `develop`, Cloudflare preview workflows can resolve eligible fork pull requests without trusting code from the fork. Existing stale-run, target-repository, branch, and commit checks remain enforced.

## Verification

- `node --test .github/scripts/*.test.mjs`
- Biome check for the new helper and tests
- `actionlint .github/workflows/cloudflare-preview.yml`
- verified that the GitHub API head query `sskw-ugo:agent/web-react-vite-refactor` resolves PR #592 with the expected base repository, branch, and SHA

## Release impact

- Classification: **none**
- CI-only change; no firmware or web runtime behavior changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare preview deployments by reliably identifying the associated pull request.
  * Added safeguards to prevent previews from deploying for unsupported branches, repositories, or outdated commits.
  * Improved handling of pull requests from forks and workflow runs missing pull request details.
* **Tests**
  * Added coverage for pull request discovery, repository validation, fork workflows, and stale preview runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->