### PR TITLE
fix(ci): harden Cloudflare preview cleanup

### DIFF
--- a/.github/scripts/delete-cloudflare-preview-deployments.mjs
+++ b/.github/scripts/delete-cloudflare-preview-deployments.mjs
@@ -61,7 +61,16 @@ async function cloudflareRequest({
       try {
         payload = JSON.parse(responseText)
       } catch {
-        throw new Error(`Cloudflare API ${method} returned a non-JSON response (HTTP ${response.status})`)
+        const responseError = new Error(
+          `Cloudflare API ${method} returned a non-JSON response (HTTP ${response.status})`
+        )
+        if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === MAX_ATTEMPTS) throw responseError
+
+        logger.warn(
+          `Cloudflare API ${method} returned a non-JSON HTTP ${response.status} response; retrying (${attempt}/${MAX_ATTEMPTS})`
+        )
+        await sleep(250 * 2 ** (attempt - 1))
+        continue
       }
     }
 

--- a/.github/scripts/delete-cloudflare-preview-deployments.mjs
+++ b/.github/scripts/delete-cloudflare-preview-deployments.mjs
@@ -53,6 +53,8 @@ async function cloudflareRequest({
       continue
     }
 
+    if (method === 'DELETE' && response.status === 404) return
+
     const responseText = await response.text()
     let payload
     if (responseText) {
@@ -151,36 +153,60 @@ export async function deleteSupersededPreviewDeployments({
     projectName,
     sleep,
   })
+  const branchDeployments = deployments.filter(
+    (deployment) =>
+      deployment?.environment === 'preview' &&
+      deployment?.deployment_trigger?.metadata?.branch === branchName
+  )
+  const keepDeployment = branchDeployments.find((deployment) => deployment?.id === keepDeploymentId)
+  if (!keepDeployment) {
+    throw new Error('KEEP_DEPLOYMENT_ID does not belong to the requested preview branch')
+  }
+  const branchAlias = `https://${branchName}.${projectName}.pages.dev`
+  if (!Array.isArray(keepDeployment.aliases) || !keepDeployment.aliases.includes(branchAlias)) {
+    throw new Error('KEEP_DEPLOYMENT_ID does not own the active preview branch alias')
+  }
   const deploymentIds = [
     ...new Set(
-      deployments
-        .filter(
-          (deployment) =>
-            deployment?.environment === 'preview' &&
-            deployment?.deployment_trigger?.metadata?.branch === branchName &&
-            deployment?.id !== keepDeploymentId &&
-            typeof deployment?.id === 'string'
-        )
+      branchDeployments
+        .filter((deployment) => deployment?.id !== keepDeploymentId && typeof deployment?.id === 'string')
         .map((deployment) => deployment.id)
     ),
   ]
 
+  const deletedIds = []
+  const failures = []
   for (const deploymentId of deploymentIds) {
     const url =
       `${CLOUDFLARE_API_ROOT}/accounts/${encodeURIComponent(accountId)}` +
       `/pages/projects/${encodeURIComponent(projectName)}` +
       `/deployments/${encodeURIComponent(deploymentId)}?force=true`
-    await cloudflareRequest({
-      apiToken,
-      fetchImpl,
-      logger,
-      method: 'DELETE',
-      sleep,
-      url,
-    })
+    try {
+      await cloudflareRequest({
+        apiToken,
+        fetchImpl,
+        logger,
+        method: 'DELETE',
+        sleep,
+        url,
+      })
+      deletedIds.push(deploymentId)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      failures.push({ error, message: `${deploymentId}: ${message}` })
+    }
   }
 
-  return deploymentIds
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map(({ error }) => error),
+      `Failed to delete ${failures.length} superseded deployment(s): ${failures
+        .map(({ message }) => message)
+        .join('; ')}`
+    )
+  }
+
+  return deletedIds
 }
 
 const isMain = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url

--- a/.github/scripts/delete-cloudflare-preview-deployments.mjs
+++ b/.github/scripts/delete-cloudflare-preview-deployments.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { validateCloudflareConfig } from './validate-cloudflare-config.mjs'
+
+const CLOUDFLARE_API_ROOT = 'https://api.cloudflare.com/client/v4'
+const MAX_ATTEMPTS = 3
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
+}
+
+function errorDetails(payload) {
+  const errors = Array.isArray(payload?.errors) ? payload.errors : []
+  if (errors.length === 0) return 'Cloudflare did not return error details'
+  return errors
+    .map((error) => {
+      const code = error?.code == null ? 'unknown' : error.code
+      const message =
+        typeof error?.message === 'string' ? error.message.replace(/\s+/g, ' ').trim() : 'Unknown error'
+      return `[${code}] ${message}`
+    })
+    .join('; ')
+}
+
+async function cloudflareRequest({
+  apiToken,
+  fetchImpl,
+  logger,
+  method = 'GET',
+  requireEnvelope = false,
+  sleep,
+  url,
+}) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    let response
+    try {
+      response = await fetchImpl(url, {
+        headers: {
+          Authorization: `Bearer ${apiToken}`,
+        },
+        method,
+      })
+    } catch (error) {
+      if (attempt === MAX_ATTEMPTS) {
+        const message = error instanceof Error ? error.message : String(error)
+        throw new Error(`Cloudflare API ${method} request failed before receiving a response: ${message}`)
+      }
+      logger.warn(`Cloudflare API ${method} request failed; retrying (${attempt}/${MAX_ATTEMPTS})`)
+      await sleep(250 * 2 ** (attempt - 1))
+      continue
+    }
+
+    const responseText = await response.text()
+    let payload
+    if (responseText) {
+      try {
+        payload = JSON.parse(responseText)
+      } catch {
+        throw new Error(`Cloudflare API ${method} returned a non-JSON response (HTTP ${response.status})`)
+      }
+    }
+
+    const succeeded = response.ok && payload?.success !== false && (!requireEnvelope || payload?.success === true)
+    if (succeeded) return payload
+
+    const requestError = new Error(
+      `Cloudflare API ${method} failed (HTTP ${response.status}): ${errorDetails(payload)}`
+    )
+    if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === MAX_ATTEMPTS) throw requestError
+
+    logger.warn(`Cloudflare API ${method} returned HTTP ${response.status}; retrying (${attempt}/${MAX_ATTEMPTS})`)
+    await sleep(250 * 2 ** (attempt - 1))
+  }
+
+  throw new Error(`Cloudflare API ${method} exhausted its retry attempts`)
+}
+
+function validateCleanupOptions({ accountId, apiToken, branchName, keepDeploymentId, projectName }) {
+  validateCloudflareConfig({
+    CLOUDFLARE_ACCOUNT_ID: accountId,
+    CLOUDFLARE_API_TOKEN: apiToken,
+    CLOUDFLARE_PAGES_PROJECT: projectName,
+  })
+  if (!/^pr-[1-9]\d*$/.test(branchName)) {
+    throw new Error('BRANCH_NAME must identify a pull request preview branch')
+  }
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(keepDeploymentId)
+  ) {
+    throw new Error('KEEP_DEPLOYMENT_ID must be a Cloudflare deployment UUID')
+  }
+}
+
+async function listDeployments({ accountId, apiToken, fetchImpl, logger, projectName, sleep }) {
+  const deploymentUrl =
+    `${CLOUDFLARE_API_ROOT}/accounts/${encodeURIComponent(accountId)}` +
+    `/pages/projects/${encodeURIComponent(projectName)}/deployments`
+  const deployments = []
+  let page = 1
+  let totalPages = 1
+
+  do {
+    const url = new URL(deploymentUrl)
+    // Keep the first request identical to Cloudflare's documented example.
+    // Filtering locally means cleanup only relies on required API parameters.
+    if (page > 1) url.searchParams.set('page', String(page))
+    const payload = await cloudflareRequest({
+      apiToken,
+      fetchImpl,
+      logger,
+      requireEnvelope: true,
+      sleep,
+      url,
+    })
+    if (!Array.isArray(payload.result)) {
+      throw new Error('Cloudflare deployment list response did not contain a result array')
+    }
+    deployments.push(...payload.result)
+
+    totalPages = payload.result_info?.total_pages ?? 1
+    if (!Number.isSafeInteger(totalPages) || totalPages < 0 || totalPages > 10_000) {
+      throw new Error('Cloudflare deployment list response contained invalid pagination metadata')
+    }
+    page += 1
+  } while (page <= totalPages)
+
+  return deployments
+}
+
+export async function deleteSupersededPreviewDeployments({
+  accountId,
+  apiToken,
+  branchName,
+  fetchImpl = globalThis.fetch,
+  keepDeploymentId,
+  logger = console,
+  projectName,
+  sleep = delay,
+}) {
+  validateCleanupOptions({ accountId, apiToken, branchName, keepDeploymentId, projectName })
+  if (typeof fetchImpl !== 'function') throw new Error('A fetch implementation is required')
+
+  const deployments = await listDeployments({
+    accountId,
+    apiToken,
+    fetchImpl,
+    logger,
+    projectName,
+    sleep,
+  })
+  const deploymentIds = [
+    ...new Set(
+      deployments
+        .filter(
+          (deployment) =>
+            deployment?.environment === 'preview' &&
+            deployment?.deployment_trigger?.metadata?.branch === branchName &&
+            deployment?.id !== keepDeploymentId &&
+            typeof deployment?.id === 'string'
+        )
+        .map((deployment) => deployment.id)
+    ),
+  ]
+
+  for (const deploymentId of deploymentIds) {
+    const url =
+      `${CLOUDFLARE_API_ROOT}/accounts/${encodeURIComponent(accountId)}` +
+      `/pages/projects/${encodeURIComponent(projectName)}` +
+      `/deployments/${encodeURIComponent(deploymentId)}?force=true`
+    await cloudflareRequest({
+      apiToken,
+      fetchImpl,
+      logger,
+      method: 'DELETE',
+      sleep,
+      url,
+    })
+  }
+
+  return deploymentIds
+}
+
+const isMain = process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url
+if (isMain) {
+  try {
+    const deleted = await deleteSupersededPreviewDeployments({
+      accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+      apiToken: process.env.CLOUDFLARE_API_TOKEN,
+      branchName: process.env.BRANCH_NAME,
+      keepDeploymentId: process.env.KEEP_DEPLOYMENT_ID,
+      projectName: process.env.CLOUDFLARE_PAGES_PROJECT,
+    })
+    console.log(`Deleted ${deleted.length} superseded Cloudflare preview deployment(s)`)
+  } catch (error) {
+    console.error(`::error::${error instanceof Error ? error.message : error}`)
+    process.exit(1)
+  }
+}

--- a/.github/scripts/delete-cloudflare-preview-deployments.test.mjs
+++ b/.github/scripts/delete-cloudflare-preview-deployments.test.mjs
@@ -143,6 +143,37 @@ test('retries transient Cloudflare API failures', async () => {
   assert.deepEqual(delays, [250])
 })
 
+test('retries non-JSON responses with transient HTTP status codes', async () => {
+  const delays = []
+  let attempts = 0
+  const fetchImpl = async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return new Response('<html>Service unavailable</html>', {
+        headers: { 'Content-Type': 'text/html' },
+        status: 503,
+      })
+    }
+    return jsonResponse({
+      errors: [],
+      result: [deployment({ aliases: [`https://${BRANCH_NAME}.${PROJECT_NAME}.pages.dev`], id: KEEP_ID })],
+      result_info: { total_pages: 1 },
+      success: true,
+    })
+  }
+
+  const deleted = await deleteSupersededPreviewDeployments(
+    cleanupOptions({
+      fetchImpl,
+      sleep: async (milliseconds) => delays.push(milliseconds),
+    })
+  )
+
+  assert.deepEqual(deleted, [])
+  assert.equal(attempts, 2)
+  assert.deepEqual(delays, [250])
+})
+
 test('treats a 404 after retrying a DELETE as already deleted', async () => {
   const delays = []
   let deleteAttempts = 0

--- a/.github/scripts/delete-cloudflare-preview-deployments.test.mjs
+++ b/.github/scripts/delete-cloudflare-preview-deployments.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { deleteSupersededPreviewDeployments } from './delete-cloudflare-preview-deployments.mjs'
+
+const ACCOUNT_ID = '0123456789abcdef0123456789abcdef'
+const API_TOKEN = 'secret'
+const BRANCH_NAME = 'pr-595'
+const KEEP_ID = '00000000-0000-4000-8000-000000000001'
+const OLD_ID_1 = '00000000-0000-4000-8000-000000000002'
+const OLD_ID_2 = '00000000-0000-4000-8000-000000000003'
+const PROJECT_NAME = 'stack-chan-pr-preview'
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    headers: { 'Content-Type': 'application/json' },
+    status,
+  })
+}
+
+function deployment({ branch = BRANCH_NAME, environment = 'preview', id }) {
+  return {
+    deployment_trigger: {
+      metadata: { branch },
+    },
+    environment,
+    id,
+  }
+}
+
+function cleanupOptions(overrides = {}) {
+  return {
+    accountId: ACCOUNT_ID,
+    apiToken: API_TOKEN,
+    branchName: BRANCH_NAME,
+    keepDeploymentId: KEEP_ID,
+    logger: { warn() {} },
+    projectName: PROJECT_NAME,
+    sleep: async () => {},
+    ...overrides,
+  }
+}
+
+test('lists every page and deletes only superseded deployments from the target preview branch', async () => {
+  const calls = []
+  const fetchImpl = async (url, options) => {
+    const requestUrl = new URL(url)
+    calls.push({ method: options.method, url: requestUrl.href, authorization: options.headers.Authorization })
+
+    if (options.method === 'DELETE') {
+      return jsonResponse({ errors: [], result: null, success: true })
+    }
+    if (requestUrl.searchParams.get('page') === '2') {
+      return jsonResponse({
+        errors: [],
+        result: [deployment({ id: OLD_ID_2 }), deployment({ id: OLD_ID_1 })],
+        result_info: { total_pages: 2 },
+        success: true,
+      })
+    }
+    return jsonResponse({
+      errors: [],
+      result: [
+        deployment({ id: KEEP_ID }),
+        deployment({ id: OLD_ID_1 }),
+        deployment({ branch: 'pr-594', id: '00000000-0000-4000-8000-000000000004' }),
+        deployment({ environment: 'production', id: '00000000-0000-4000-8000-000000000005' }),
+      ],
+      result_info: { total_pages: 2 },
+      success: true,
+    })
+  }
+
+  const deleted = await deleteSupersededPreviewDeployments(cleanupOptions({ fetchImpl }))
+
+  assert.deepEqual(deleted, [OLD_ID_1, OLD_ID_2])
+  assert.deepEqual(
+    calls.map(({ method, url }) => ({ method, url })),
+    [
+      {
+        method: 'GET',
+        url: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/${PROJECT_NAME}/deployments`,
+      },
+      {
+        method: 'GET',
+        url: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/${PROJECT_NAME}/deployments?page=2`,
+      },
+      {
+        method: 'DELETE',
+        url: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/${PROJECT_NAME}/deployments/${OLD_ID_1}?force=true`,
+      },
+      {
+        method: 'DELETE',
+        url: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/${PROJECT_NAME}/deployments/${OLD_ID_2}?force=true`,
+      },
+    ]
+  )
+  assert.ok(calls.every(({ authorization }) => authorization === `Bearer ${API_TOKEN}`))
+})
+
+test('reports Cloudflare API error details instead of hiding the response body', async () => {
+  const fetchImpl = async () =>
+    jsonResponse(
+      {
+        errors: [{ code: 8000034, message: 'Invalid pagination parameter' }],
+        result: null,
+        success: false,
+      },
+      400
+    )
+
+  await assert.rejects(
+    deleteSupersededPreviewDeployments(cleanupOptions({ fetchImpl })),
+    /Cloudflare API GET failed \(HTTP 400\): \[8000034\] Invalid pagination parameter/
+  )
+})
+
+test('retries transient Cloudflare API failures', async () => {
+  const delays = []
+  let attempts = 0
+  const fetchImpl = async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return jsonResponse({ errors: [{ code: 1000, message: 'Temporarily unavailable' }], success: false }, 503)
+    }
+    return jsonResponse({
+      errors: [],
+      result: [],
+      result_info: { total_pages: 1 },
+      success: true,
+    })
+  }
+
+  const deleted = await deleteSupersededPreviewDeployments(
+    cleanupOptions({
+      fetchImpl,
+      sleep: async (milliseconds) => delays.push(milliseconds),
+    })
+  )
+
+  assert.deepEqual(deleted, [])
+  assert.equal(attempts, 2)
+  assert.deepEqual(delays, [250])
+})

--- a/.github/scripts/delete-cloudflare-preview-deployments.test.mjs
+++ b/.github/scripts/delete-cloudflare-preview-deployments.test.mjs
@@ -17,8 +17,9 @@ function jsonResponse(payload, status = 200) {
   })
 }
 
-function deployment({ branch = BRANCH_NAME, environment = 'preview', id }) {
+function deployment({ aliases = [], branch = BRANCH_NAME, environment = 'preview', id }) {
   return {
+    aliases,
     deployment_trigger: {
       metadata: { branch },
     },
@@ -60,7 +61,7 @@ test('lists every page and deletes only superseded deployments from the target p
     return jsonResponse({
       errors: [],
       result: [
-        deployment({ id: KEEP_ID }),
+        deployment({ aliases: [`https://${BRANCH_NAME}.${PROJECT_NAME}.pages.dev`], id: KEEP_ID }),
         deployment({ id: OLD_ID_1 }),
         deployment({ branch: 'pr-594', id: '00000000-0000-4000-8000-000000000004' }),
         deployment({ environment: 'production', id: '00000000-0000-4000-8000-000000000005' }),
@@ -124,7 +125,7 @@ test('retries transient Cloudflare API failures', async () => {
     }
     return jsonResponse({
       errors: [],
-      result: [],
+      result: [deployment({ aliases: [`https://${BRANCH_NAME}.${PROJECT_NAME}.pages.dev`], id: KEEP_ID })],
       result_info: { total_pages: 1 },
       success: true,
     })
@@ -140,4 +141,89 @@ test('retries transient Cloudflare API failures', async () => {
   assert.deepEqual(deleted, [])
   assert.equal(attempts, 2)
   assert.deepEqual(delays, [250])
+})
+
+test('treats a 404 after retrying a DELETE as already deleted', async () => {
+  const delays = []
+  let deleteAttempts = 0
+  const fetchImpl = async (_url, options) => {
+    if (options.method === 'DELETE') {
+      deleteAttempts += 1
+      if (deleteAttempts === 1) throw new Error('Response was lost')
+      return jsonResponse({ errors: [{ code: 8000007, message: 'Deployment not found' }], success: false }, 404)
+    }
+    return jsonResponse({
+      errors: [],
+      result: [
+        deployment({ aliases: [`https://${BRANCH_NAME}.${PROJECT_NAME}.pages.dev`], id: KEEP_ID }),
+        deployment({ id: OLD_ID_1 }),
+      ],
+      result_info: { total_pages: 1 },
+      success: true,
+    })
+  }
+
+  const deleted = await deleteSupersededPreviewDeployments(
+    cleanupOptions({
+      fetchImpl,
+      sleep: async (milliseconds) => delays.push(milliseconds),
+    })
+  )
+
+  assert.deepEqual(deleted, [OLD_ID_1])
+  assert.equal(deleteAttempts, 2)
+  assert.deepEqual(delays, [250])
+})
+
+test('refuses to delete deployments when the retained deployment does not own the branch alias', async () => {
+  let deleteAttempts = 0
+  const fetchImpl = async (_url, options) => {
+    if (options.method === 'DELETE') {
+      deleteAttempts += 1
+      return jsonResponse({ errors: [], result: null, success: true })
+    }
+    return jsonResponse({
+      errors: [],
+      result: [deployment({ id: KEEP_ID }), deployment({ id: OLD_ID_1 })],
+      result_info: { total_pages: 1 },
+      success: true,
+    })
+  }
+
+  await assert.rejects(
+    deleteSupersededPreviewDeployments(cleanupOptions({ fetchImpl })),
+    /KEEP_DEPLOYMENT_ID does not own the active preview branch alias/
+  )
+  assert.equal(deleteAttempts, 0)
+})
+
+test('attempts every deletion before reporting individual API failures', async () => {
+  const attemptedIds = []
+  const fetchImpl = async (url, options) => {
+    const requestUrl = new URL(url)
+    if (options.method === 'DELETE') {
+      const deploymentId = requestUrl.pathname.split('/').at(-1)
+      attemptedIds.push(deploymentId)
+      if (deploymentId === OLD_ID_1) {
+        return jsonResponse({ errors: [{ code: 8000001, message: 'Deletion rejected' }], success: false }, 400)
+      }
+      return jsonResponse({ errors: [], result: null, success: true })
+    }
+    return jsonResponse({
+      errors: [],
+      result: [
+        deployment({ aliases: [`https://${BRANCH_NAME}.${PROJECT_NAME}.pages.dev`], id: KEEP_ID }),
+        deployment({ id: OLD_ID_1 }),
+        deployment({ id: OLD_ID_2 }),
+      ],
+      result_info: { total_pages: 1 },
+      success: true,
+    })
+  }
+
+  await assert.rejects(
+    deleteSupersededPreviewDeployments(cleanupOptions({ fetchImpl })),
+    new RegExp(`Failed to delete 1 superseded deployment.*${OLD_ID_1}.*Deletion rejected`)
+  )
+  assert.deepEqual(attemptedIds, [OLD_ID_1, OLD_ID_2])
 })

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -1,6 +1,16 @@
 name: Deploy Cloudflare PR Preview
 
 on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Closed pull request number to clean up
+        required: true
+        type: number
+      keep_deployment_id:
+        description: Closed-page Cloudflare deployment ID to retain
+        required: true
+        type: string
   workflow_run:
     workflows:
       - Bundle Stack-chan Firmware
@@ -13,7 +23,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: cloudflare-preview-${{ github.event.workflow_run.head_repository.id || github.event.pull_request.head.repo.id || github.repository_id }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref || github.run_id }}
+  group: cloudflare-preview-${{ github.event.workflow_run.head_repository.id || github.event.pull_request.head.repo.id || github.repository_id }}-${{ github.event.workflow_run.head_branch || github.event.pull_request.head.ref || github.event.inputs.pull_request_number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -151,6 +161,83 @@ jobs:
 
             > [!WARNING]
             > Pull request previews contain untrusted web and firmware code. Review the changes before granting WebSerial/Bluetooth permissions or flashing a device.`
+            await upsertPreviewComment({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: Number(process.env.PR_NUMBER),
+              content,
+            })
+
+  recover:
+    name: Retry closed preview cleanup
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Validate closed pull request
+        id: pull_request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ inputs.pull_request_number }}
+        with:
+          script: |
+            if (!/^[1-9]\d*$/.test(process.env.PR_NUMBER)) {
+              throw new Error('pull_request_number must be a positive integer')
+            }
+            const number = Number(process.env.PR_NUMBER)
+            if (!Number.isSafeInteger(number)) {
+              throw new Error('pull_request_number exceeds the supported integer range')
+            }
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+            })
+            if (pull.state !== 'closed') {
+              throw new Error(`Pull request #${number} must be closed before its preview can be cleaned up`)
+            }
+            core.setOutput('number', String(number))
+      - name: Checkout trusted preview scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted-source
+          persist-credentials: false
+      - name: Validate Cloudflare configuration
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+        run: node ./trusted-source/.github/scripts/validate-cloudflare-config.mjs
+      - name: Delete superseded preview deployments
+        env:
+          BRANCH_NAME: pr-${{ steps.pull_request.outputs.number }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
+          KEEP_DEPLOYMENT_ID: ${{ inputs.keep_deployment_id }}
+        run: node ./trusted-source/.github/scripts/delete-cloudflare-preview-deployments.mjs
+      - name: Mark preview as closed
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PREVIEW_URL: https://pr-${{ steps.pull_request.outputs.number }}.${{ vars.CLOUDFLARE_PAGES_PROJECT }}.pages.dev
+          PR_NUMBER: ${{ steps.pull_request.outputs.number }}
+        with:
+          script: |
+            const { pathToFileURL } = require('node:url')
+            const helperUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/trusted-source/.github/scripts/upsert-preview-comment.mjs`,
+            ).href
+            const { upsertPreviewComment } = await import(helperUrl)
+            const content = `## Cloudflare PR preview
+
+            This pull request is closed. Its preview has been replaced with a closed page at ${process.env.PREVIEW_URL}.
+
+            Superseded immutable preview deployments have been removed.`
             await upsertPreviewComment({
               github,
               owner: context.repo.owner,

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -231,43 +231,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
           KEEP_DEPLOYMENT_ID: ${{ steps.cloudflare.outputs.pages-deployment-id }}
-        run: |
-          set -euo pipefail
-          test -n "$KEEP_DEPLOYMENT_ID"
-          page=1
-          while true; do
-            response=$(curl -fsS \
-              --get \
-              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-              --header 'Content-Type: application/json' \
-              --data-urlencode 'env=preview' \
-              --data-urlencode 'per_page=100' \
-              --data-urlencode "page=${page}" \
-              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}/deployments")
-            echo "$response" | jq -e '.success == true' >/dev/null
-            echo "$response" | jq -r \
-              --arg branch "$BRANCH_NAME" \
-              --arg keep "$KEEP_DEPLOYMENT_ID" \
-              '.result[] | select(.deployment_trigger.metadata.branch == $branch and .id != $keep) | .id' \
-              >> deployments-to-delete.txt
-            total_pages=$(echo "$response" | jq -r '.result_info.total_pages // 1')
-            if [ "$page" -ge "$total_pages" ]; then
-              break
-            fi
-            page=$((page + 1))
-          done
-          sort -u deployments-to-delete.txt | while IFS= read -r deployment_id; do
-            if [ -z "$deployment_id" ]; then
-              continue
-            fi
-            curl -fsS \
-              --request DELETE \
-              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}/deployments/${deployment_id}?force=true" \
-              >/dev/null
-          done
+        run: node ./trusted-source/.github/scripts/delete-cloudflare-preview-deployments.mjs
       - name: Mark preview as closed
-        if: steps.preview.outputs.exists == 'true'
+        if: always() && steps.preview.outputs.exists == 'true' && steps.cloudflare.outcome == 'success'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Fix the Cloudflare preview close job that failed while listing deployments for PR #595.
- Preserve the closed-page comment update even when historical deployment cleanup reports an error.
- Add a guarded manual recovery path for previews whose original close workflow failed.

## What Changed

- Replace the inline `curl`/`jq` cleanup loop with a tested Node helper.
- Use Cloudflare's minimal deployment-list request and filter preview branch deployments locally.
- Preserve pagination, deduplicate deployment IDs, retry transient API failures, and surface Cloudflare error codes/messages instead of hiding the response body with `curl -f`.
- Treat `DELETE` 404 responses as an already-completed deletion, including after a lost response and retry.
- Attempt every superseded deployment before reporting aggregated deletion failures.
- Require the retained deployment to belong to the requested preview branch and own its active branch alias before deleting anything.
- Add a `workflow_dispatch` recovery job that only accepts closed PRs, performs the guarded cleanup, and updates the preview comment.
- Run the normal closed-comment step after a successful closed-page deployment even if cleanup fails, while keeping the workflow job failed so cleanup errors remain visible.

## Verification

- [x] `node --test .github/scripts/*.test.mjs` (21 tests)
- [x] `node --check .github/scripts/delete-cloudflare-preview-deployments.mjs`
- [x] `node --check .github/scripts/delete-cloudflare-preview-deployments.test.mjs`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/cloudflare-preview.yml`
- [x] Parsed `.github/workflows/cloudflare-preview.yml` as YAML
- [x] `git diff --check`
- [ ] Cloudflare close-path integration (runs when this PR is closed or merged)

## PR #595 Recovery After Merge

Run the merged workflow from `develop` with the closed-page deployment retained by the original close run:

```sh
gh workflow run cloudflare-preview.yml \
  --repo stack-chan/stack-chan \
  --ref develop \
  -f pull_request_number=595 \
  -f keep_deployment_id=cbeece16-aece-4f90-ae5d-240c1f18a707
```

The recovery job verifies that PR #595 is closed and that the retained deployment owns the active `pr-595` alias before deleting any superseded immutable deployments.

## Affected Areas

- [ ] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [x] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Release Impact

`none` — this only changes GitHub Actions preview cleanup and does not alter released firmware or web artifacts, so no changeset is needed.

## Related Runs

- Failed PR #595 close run: https://github.com/stack-chan/stack-chan/actions/runs/30146433503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow option to clean up preview deployments for closed pull requests.
  * Preview cleanup retains the active deployment while removing superseded previews.
* **Bug Fixes**
  * Improved resilience during preview cleanup with retry behavior for transient API failures.
  * Cleanup safely handles cases where deployments were already deleted (including DELETE 404s).
  * Prevents accidental deletion when the retained deployment doesn’t own the active preview alias.
  * Preview status comments are updated only after successful cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->