### PR TITLE
ci: reduce test workflow duration

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,9 +91,10 @@ runs:
         fi
         MODDABLE_REF=$(echo "$MODDABLE_SHA" | cut -c1-12)
         echo "Moddable ref: $REF ($MODDABLE_REF)"
+        MODDABLE_CACHE_KEY="$RUNNER_OS_NAME-moddable-$MODDABLE_REF"
         echo "MODDABLE_TARGET_REF=$REF" >> "$GITHUB_ENV"
-        echo "moddable_cache_key=$RUNNER_OS_NAME-moddable-$MODDABLE_REF" >> "$GITHUB_ENV"
-        echo "cache-key=$RUNNER_OS_NAME-moddable-$MODDABLE_REF" >> "$GITHUB_OUTPUT"
+        echo "moddable_cache_key=$MODDABLE_CACHE_KEY" >> "$GITHUB_ENV"
+        echo "cache-key=$MODDABLE_CACHE_KEY" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Restore cache of Moddable and ESP32
       id: restore-cache-moddable

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,9 @@
 name: Setup
 description: Setup Node.js, ModdableSDK, ESP-IDF and Emscripten environments
+outputs:
+  moddable-cache-key:
+    description: "Cache key prefix for the resolved Moddable SDK commit"
+    value: ${{ steps.resolve_moddable.outputs.cache-key }}
 inputs:
   target-branch:
     description: "Target branch or tag to setup environment"
@@ -9,6 +13,10 @@ inputs:
     description: "Install Emscripten for WASM builds"
     required: false
     default: "false"
+  install-moddable:
+    description: "Install Moddable SDK, ESP-IDF and Linux simulator dependencies"
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -25,17 +33,29 @@ runs:
     - run: npm ci
       working-directory: ./firmware
       shell: bash
+    - name: Validate setup inputs
+      env:
+        INSTALL_MODDABLE: ${{ inputs.install-moddable }}
+      run: |
+        if [[ "$INSTALL_MODDABLE" != "true" && "$INSTALL_MODDABLE" != "false" ]]; then
+          echo "::error::install-moddable must be true or false"
+          exit 1
+        fi
+      shell: bash
     - name: Setup Emscripten for WASM simulator
       if: inputs.install-emscripten == 'true'
       uses: emscripten-core/setup-emsdk@v16
       with:
         version: 5.0.1
     - name: Install Moddable Linux tool dependencies
+      if: inputs.install-moddable == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y dbus libasound2-dev libfreetype6-dev libglib2.0-dev libgtk-3-dev pkg-config xvfb
       shell: bash
     - name: Resolve Moddable cache key
+      id: resolve_moddable
+      if: inputs.install-moddable == 'true'
       env:
         GITHUB_TOKEN: ${{ github.token }}
         INPUT_TARGET_BRANCH: ${{ inputs.target-branch }}
@@ -73,9 +93,11 @@ runs:
         echo "Moddable ref: $REF ($MODDABLE_REF)"
         echo "MODDABLE_TARGET_REF=$REF" >> "$GITHUB_ENV"
         echo "moddable_cache_key=$RUNNER_OS_NAME-moddable-$MODDABLE_REF" >> "$GITHUB_ENV"
+        echo "cache-key=$RUNNER_OS_NAME-moddable-$MODDABLE_REF" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Restore cache of Moddable and ESP32
       id: restore-cache-moddable
+      if: inputs.install-moddable == 'true'
       uses: actions/cache/restore@v4
       with:
         path: |
@@ -83,7 +105,7 @@ runs:
           /home/runner/.espressif
         key: ${{ env.moddable_cache_key }}-fontbm2
     - name: install Moddable
-      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      if: inputs.install-moddable == 'true' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         npm run setup -- --branch "$MODDABLE_TARGET_REF"
@@ -93,14 +115,14 @@ runs:
       working-directory: ./firmware
       shell: bash
     - name: install ESP32
-      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      if: inputs.install-moddable == 'true' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
         source $HOME/.local/share/xs-dev-export.sh && npm run setup -- --device=esp32
       working-directory: ./firmware
       shell: bash
     - name: install fontbm
-      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      if: inputs.install-moddable == 'true' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
       run: |
         sudo apt-get install -y cmake libfreetype6-dev
         git clone --depth 1 https://github.com/vladimirgamalyan/fontbm.git $HOME/.local/share/fontbm
@@ -109,7 +131,7 @@ runs:
         printf '\nexport FONTBM=%s\n' "$HOME/.local/share/fontbm/build/fontbm" >> $HOME/.local/share/xs-dev-export.sh
       shell: bash
     - name: Save cache of Moddable and ESP32
-      if: steps.restore-cache-moddable.outputs.cache-hit != 'true'
+      if: inputs.install-moddable == 'true' && steps.restore-cache-moddable.outputs.cache-hit != 'true'
       id: save-cache-moddable
       continue-on-error: true
       uses: actions/cache/save@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,26 +31,51 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      firmware: ${{ steps.filter.outputs.firmware }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Detect firmware-related changes
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            firmware:
+              - "firmware/**"
+              - ".github/actions/setup/action.yml"
+              - ".github/workflows/build.yml"
+              - "lefthook.yml"
+
   biome:
+    needs: changes
+    if: needs.changes.outputs.firmware == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
+        with:
+          install-moddable: "false"
       - name: Run Biome
         working-directory: ./firmware
         run: npx biome ci . --error-on-warnings
 
-  test:
+  test-fast:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
+        with:
+          install-moddable: "false"
       - name: Install web dependencies
         working-directory: ./firmware
         run: npm --prefix ../web ci
@@ -63,21 +88,94 @@ jobs:
       - name: Run architecture checks
         working-directory: ./firmware
         run: npm run check:architecture
+      - name: Run web tool tests
+        working-directory: ./firmware
+        run: npm --prefix ../web test && npm --prefix ../web run check:editor-artifacts
+
+  test-moddable:
+    needs: changes
+    if: needs.changes.outputs.firmware == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+        id: setup
+      - name: Restore incremental Linux test builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./firmware/dist/tmp/lin
+            ./firmware/dist/bin/lin
+          key: ${{ steps.setup.outputs.moddable-cache-key }}-lin-tests-v1-shard-${{ matrix.shard }}-${{ github.sha }}
+          restore-keys: |
+            ${{ steps.setup.outputs.moddable-cache-key }}-lin-tests-v1-shard-${{ matrix.shard }}-
       - name: Run manifest preflight
+        if: matrix.shard == 0
         working-directory: ./firmware
         run: source "$HOME/.local/share/xs-dev-export.sh" && npm run check:manifest
       - name: Run Moddable module tests
         working-directory: ./firmware
+        env:
+          STACKCHAN_MODULE_TEST_SHARD_INDEX: ${{ matrix.shard }}
+          STACKCHAN_MODULE_TEST_SHARD_TOTAL: 2
         run: source "$HOME/.local/share/xs-dev-export.sh" && npm run test:moddable
+
+  test-smoke:
+    needs: changes
+    if: needs.changes.outputs.firmware == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      STACKCHAN_LIN_SMOKE_CLEAN: "0"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+        id: setup
+      - name: Restore incremental Linux smoke builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./firmware/dist/tmp/lin
+            ./firmware/dist/bin/lin
+          key: ${{ steps.setup.outputs.moddable-cache-key }}-lin-smoke-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ steps.setup.outputs.moddable-cache-key }}-lin-smoke-v1-
       - name: Smoke test Linux simulator startup
         working-directory: ./firmware
         run: source "$HOME/.local/share/xs-dev-export.sh" && npm run smoke:lin
       - name: Smoke test mini app on Linux simulator
         working-directory: ./firmware
         run: source "$HOME/.local/share/xs-dev-export.sh" && npm run smoke:mini-app:lin
-      - name: Run web tool tests
-        working-directory: ./firmware
-        run: npm --prefix ../web test && npm --prefix ../web run check:editor-artifacts
+
+  test:
+    if: always()
+    needs:
+      - changes
+      - test-fast
+      - test-moddable
+      - test-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify test job results
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          FAST_RESULT: ${{ needs.test-fast.result }}
+          MODDABLE_RESULT: ${{ needs.test-moddable.result }}
+          SMOKE_RESULT: ${{ needs.test-smoke.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" || "$FAST_RESULT" != "success" ]]; then
+            echo "Required test job failed: changes=$CHANGES_RESULT fast=$FAST_RESULT"
+            exit 1
+          fi
+          for result in "$MODDABLE_RESULT" "$SMOKE_RESULT"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "Firmware test job failed: moddable=$MODDABLE_RESULT smoke=$SMOKE_RESULT"
+              exit 1
+            fi
+          done
 
   web-visual:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
       firmware: ${{ steps.filter.outputs.firmware }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Detect firmware-related changes
         if: github.event_name != 'workflow_dispatch'
         id: filter
@@ -62,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         with:
           install-moddable: "false"
@@ -73,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         with:
           install-moddable: "false"
@@ -102,6 +108,8 @@ jobs:
         shard: [0, 1]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         id: setup
       - name: Restore incremental Linux test builds
@@ -132,6 +140,8 @@ jobs:
       STACKCHAN_LIN_SMOKE_CLEAN: "0"
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         id: setup
       - name: Restore incremental Linux smoke builds
@@ -181,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         with:
           target-branch: "8.3.1"

--- a/firmware/package.json
+++ b/firmware/package.json
@@ -19,7 +19,7 @@
     "generate-speech-google": "cross-env GOOGLE_APPLICATION_CREDENTIALS=scripts/key.json node scripts/generate-speech-google.js",
     "generate-apidoc": "typedoc --entryPointStrategy expand --plugin typedoc-plugin-markdown --out docs/api ./host",
     "test": "npm run test:unit",
-    "test:unit": "rm -rf dist-tests && tsc --project tsconfig.test.json && node --test \"dist-tests/host/**/*.test.js\" scripts/lib/build-output.test.mjs scripts/lib/firmware-bundle.test.mjs scripts/lib/firmware-command.test.mjs scripts/lib/idf-dependencies.test.mjs scripts/lib/mod-flash.test.mjs scripts/lib/moddable-version.test.mjs scripts/lib/release-validation.test.mjs",
+    "test:unit": "rm -rf dist-tests && tsc --project tsconfig.test.json && node --test \"dist-tests/host/**/*.test.js\" scripts/lib/build-output.test.mjs scripts/lib/firmware-bundle.test.mjs scripts/lib/firmware-command.test.mjs scripts/lib/idf-dependencies.test.mjs scripts/lib/mod-flash.test.mjs scripts/lib/moddable-version.test.mjs scripts/lib/module-test-sharding.test.mjs scripts/lib/release-validation.test.mjs",
     "test:moddable": "node scripts/run-module-tests.js",
     "test:web-radio-device:build": "node scripts/run-mcconfig.mjs -d -m -p esp32:./host/platforms/m5stackchan_cores3 -t build \"$PWD/host/modules/audio/__tests__/web-radio-device/manifest.json\"",
     "test:web-radio-device:flash": "node scripts/run-mcconfig.mjs -d -m -p esp32:./host/platforms/m5stackchan_cores3 \"$PWD/host/modules/audio/__tests__/web-radio-device/manifest.json\"",

--- a/firmware/scripts/lib/module-test-sharding.mjs
+++ b/firmware/scripts/lib/module-test-sharding.mjs
@@ -1,0 +1,36 @@
+const INDEX_ENV = 'STACKCHAN_MODULE_TEST_SHARD_INDEX'
+const TOTAL_ENV = 'STACKCHAN_MODULE_TEST_SHARD_TOTAL'
+
+function parseNonNegativeInteger(name, value) {
+  if (!/^(0|[1-9]\d*)$/.test(value)) {
+    throw new Error(`${name} must be a non-negative integer`)
+  }
+  return Number.parseInt(value, 10)
+}
+
+export function parseModuleTestShard(environment = process.env) {
+  const indexValue = environment[INDEX_ENV]
+  const totalValue = environment[TOTAL_ENV]
+
+  if (indexValue == null && totalValue == null) {
+    return { index: 0, total: 1, configured: false }
+  }
+  if (indexValue == null || totalValue == null) {
+    throw new Error(`${INDEX_ENV} and ${TOTAL_ENV} must be set together`)
+  }
+
+  const index = parseNonNegativeInteger(INDEX_ENV, indexValue)
+  const total = parseNonNegativeInteger(TOTAL_ENV, totalValue)
+  if (total < 1) {
+    throw new Error(`${TOTAL_ENV} must be at least 1`)
+  }
+  if (index >= total) {
+    throw new Error(`${INDEX_ENV} must be less than ${TOTAL_ENV}`)
+  }
+
+  return { index, total, configured: true }
+}
+
+export function selectModuleTestShard(items, shard) {
+  return items.filter((_, index) => index % shard.total === shard.index)
+}

--- a/firmware/scripts/lib/module-test-sharding.test.mjs
+++ b/firmware/scripts/lib/module-test-sharding.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { parseModuleTestShard, selectModuleTestShard } from './module-test-sharding.mjs'
+
+test('module tests run as one shard when sharding is not configured', () => {
+  const shard = parseModuleTestShard({})
+  assert.deepEqual(shard, { index: 0, total: 1, configured: false })
+  assert.deepEqual(selectModuleTestShard(['a', 'b', 'c'], shard), ['a', 'b', 'c'])
+})
+
+test('two module-test shards cover every manifest exactly once', () => {
+  const manifests = Array.from({ length: 35 }, (_, index) => `manifest-${index}`)
+  const first = selectModuleTestShard(
+    manifests,
+    parseModuleTestShard({
+      STACKCHAN_MODULE_TEST_SHARD_INDEX: '0',
+      STACKCHAN_MODULE_TEST_SHARD_TOTAL: '2',
+    }),
+  )
+  const second = selectModuleTestShard(
+    manifests,
+    parseModuleTestShard({
+      STACKCHAN_MODULE_TEST_SHARD_INDEX: '1',
+      STACKCHAN_MODULE_TEST_SHARD_TOTAL: '2',
+    }),
+  )
+
+  assert.deepEqual(new Set(first).intersection(new Set(second)), new Set())
+  assert.deepEqual([...first, ...second].sort(), manifests.sort())
+  assert.equal(first.length, 18)
+  assert.equal(second.length, 17)
+})
+
+test('module-test shard configuration rejects partial and invalid values', () => {
+  assert.throws(() => parseModuleTestShard({ STACKCHAN_MODULE_TEST_SHARD_INDEX: '0' }), /must be set together/)
+  assert.throws(
+    () =>
+      parseModuleTestShard({
+        STACKCHAN_MODULE_TEST_SHARD_INDEX: '-1',
+        STACKCHAN_MODULE_TEST_SHARD_TOTAL: '2',
+      }),
+    /non-negative integer/,
+  )
+  assert.throws(
+    () =>
+      parseModuleTestShard({
+        STACKCHAN_MODULE_TEST_SHARD_INDEX: '0',
+        STACKCHAN_MODULE_TEST_SHARD_TOTAL: '0',
+      }),
+    /at least 1/,
+  )
+  assert.throws(
+    () =>
+      parseModuleTestShard({
+        STACKCHAN_MODULE_TEST_SHARD_INDEX: '2',
+        STACKCHAN_MODULE_TEST_SHARD_TOTAL: '2',
+      }),
+    /must be less than/,
+  )
+})

--- a/firmware/scripts/run-module-tests.js
+++ b/firmware/scripts/run-module-tests.js
@@ -4,7 +4,9 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } fr
 import { readdir } from 'node:fs/promises'
 import { availableParallelism, tmpdir } from 'node:os'
 import { basename, dirname, join, relative, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
 import { buildOutputDirectory, ensureBuildOutputDirectory, moddableOutputArguments } from './lib/build-output.mjs'
+import { parseModuleTestShard, selectModuleTestShard } from './lib/module-test-sharding.mjs'
 import { startXsbugServer } from './lib/xsbug-log-server.js'
 
 const DEFAULT_ROOTS = ['host/app', 'host/modules', 'mods/examples']
@@ -53,6 +55,10 @@ const okPattern = /<log>ok(?:&#10;|\n)<\/log>/
 
 function relativePath(path) {
   return relative(firmwareRoot, path)
+}
+
+function formatDuration(milliseconds) {
+  return `${(milliseconds / 1000).toFixed(1)}s`
 }
 
 async function walk(root) {
@@ -347,13 +353,17 @@ async function runOne(manifestPath, index) {
   }
 }
 
-const manifestPaths = await collectManifestPaths(process.argv.slice(2))
-if (manifestPaths.length === 0) {
+const allManifestPaths = await collectManifestPaths(process.argv.slice(2))
+if (allManifestPaths.length === 0) {
   console.log('No runnable Moddable test manifests found.')
   process.exit(0)
 }
 
-assertUniqueNames(manifestPaths)
+assertUniqueNames(allManifestPaths)
+const shard = parseModuleTestShard()
+const manifestPaths = selectModuleTestShard(allManifestPaths, shard)
+const shardLabel = `${shard.index + 1}/${shard.total}`
+const suiteStartedAt = performance.now()
 
 let jobs = Math.min(JOBS, manifestPaths.length)
 if (jobs > 1 && !HAS_DBUS_RUN_SESSION) {
@@ -361,7 +371,7 @@ if (jobs > 1 && !HAS_DBUS_RUN_SESSION) {
   jobs = 1
 }
 console.log(
-  `Running ${manifestPaths.length} Moddable test manifest(s) with ${jobs} job(s)${CLEAN ? ', clean build' : ''}`,
+  `Running ${manifestPaths.length}/${allManifestPaths.length} Moddable test manifest(s) in shard ${shardLabel} with ${jobs} job(s)${CLEAN ? ', clean build' : ''}`,
 )
 
 // The XS core objects live in a lib directory shared by every app of the same
@@ -374,6 +384,7 @@ if (jobs > 1) {
     if (!warmups.has(segment)) warmups.set(segment, manifestPath)
   }
   for (const [segment, manifestPath] of warmups) {
+    const startedAt = performance.now()
     process.stdout.write(`- warm-up build [${segment}] ${relativePath(manifestPath)} ... `)
     const output = []
     const ok = await buildManifest({
@@ -383,7 +394,7 @@ if (jobs > 1) {
       name: basename(dirname(manifestPath)),
       output,
     })
-    console.log(ok ? 'ok' : 'failed')
+    console.log(`${ok ? 'ok' : 'failed'} (${formatDuration(performance.now() - startedAt)})`)
     if (!ok && output.length > 0) console.error(output.join('\n'))
   }
 }
@@ -396,6 +407,7 @@ async function worker() {
     const index = cursor++
     if (index >= manifestPaths.length) return
     const manifestPath = manifestPaths[index]
+    const startedAt = performance.now()
     let result
     try {
       result = await runOne(manifestPath, index)
@@ -406,11 +418,12 @@ async function worker() {
         output: [error.stack ?? String(error)],
       }
     }
+    const duration = formatDuration(performance.now() - startedAt)
     if (result.ok) {
-      console.log(`- ${result.label} ... ok`)
+      console.log(`- ${result.label} ... ok (${duration})`)
     } else {
       failures += 1
-      console.log(`- ${result.label} ... failed`)
+      console.log(`- ${result.label} ... failed (${duration})`)
       if (result.output.length > 0) console.error(result.output.join('\n'))
     }
   }
@@ -423,4 +436,6 @@ if (failures > 0) {
   process.exit(1)
 }
 
-console.log('All Moddable test manifests passed')
+console.log(
+  `All Moddable test manifests passed in shard ${shardLabel} (${formatDuration(performance.now() - suiteStartedAt)})`,
+)

--- a/firmware/scripts/smoke-lin.sh
+++ b/firmware/scripts/smoke-lin.sh
@@ -19,6 +19,7 @@ xsbug_port="${STACKCHAN_LIN_XSBUG_PORT:-0}"
 manifest="${STACKCHAN_LIN_SMOKE_MANIFEST:-$firmware_dir/host/app/manifest_local.json}"
 archive_manifest="${STACKCHAN_LIN_SMOKE_ARCHIVE_MANIFEST:-}"
 expected_log="${STACKCHAN_LIN_SMOKE_EXPECT:-[main] app behaviors ready}"
+clean_build="${STACKCHAN_LIN_SMOKE_CLEAN:-1}"
 
 if [[ ! "$app_name" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
   echo "Invalid smoke app name: $app_name" >&2
@@ -26,6 +27,10 @@ if [[ ! "$app_name" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*$ ]]; then
 fi
 if [[ ! "$platform" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]*(/[A-Za-z0-9_][A-Za-z0-9._-]*)*$ ]]; then
   echo "Invalid smoke platform: $platform" >&2
+  exit 1
+fi
+if [[ "$clean_build" != "0" && "$clean_build" != "1" ]]; then
+  echo "STACKCHAN_LIN_SMOKE_CLEAN must be 0 or 1" >&2
   exit 1
 fi
 
@@ -80,7 +85,11 @@ if [[ "$tmp_cleanup_target" != "$output_root/"* || "$bin_cleanup_target" != "$ou
   echo "Smoke cleanup target escapes output directory" >&2
   exit 1
 fi
-rm -rf -- "$tmp_cleanup_target" "$bin_cleanup_target"
+if [[ "$clean_build" == "1" ]]; then
+  rm -rf -- "$tmp_cleanup_target" "$bin_cleanup_target"
+else
+  echo "Reusing incremental Linux smoke build output"
+fi
 mcconfig -dl -x "$xsbug_host:$xsbug_port" -m -p "$platform" -t build -o "$output_dir" "$manifest"
 
 build_dir="$output_dir/tmp/$platform_path/debug/$app_name"


### PR DESCRIPTION
## Summary

- Split the monolithic test job so fast checks, Moddable tests, and Linux smoke tests can run in parallel.
- Shard Moddable manifests across two runners and cache each shard build output.
- Skip the expensive toolchain setup and firmware jobs when a pull request does not affect firmware CI inputs.

## What Changed

- Added path filtering and a final test aggregation job that preserves the existing required check name.
- Added deterministic, validated Moddable test sharding with unit coverage and per-test duration logging.
- Reused incremental Linux smoke build output between smoke variants.
- Exposed a lightweight setup mode and a stable Moddable cache key from the shared setup action.

## Verification

- [x] cd firmware && npm run format
- [x] cd firmware && npm run lint
- [x] cd firmware && npm run test
- [x] cd firmware && npm run check:legacy-names
- [x] Other checks were run when relevant
  - GitHub Actions workflow validation with actionlint
  - Web unit and editor-artifact tests
  - Both Moddable shards (35 manifests total)
  - Standard and mini-app Linux smoke tests

## Affected Areas

- [ ] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [ ] docs
- [x] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Release Impact

- none
- No changeset is needed because this only changes CI execution and test tooling; shipped firmware and web behavior are unchanged.

## Related Issues

- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Moddable installation during setup, including a new setup output for the Moddable cache key.
  * Added shard-based module test splitting using environment-driven sharding.
  * Added optional clean-build control for Linux smoke runs.

* **Improvements**
  * Updated CI to run firmware and web checks conditionally based on detected changes.
  * Introduced faster staged testing and split Moddable vs smoke test coverage.
  * Enhanced test logging with warm-up, per-manifest, and overall shard timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->