### PR TITLE
feat: integrate lazy USB remote session into the standard host

### DIFF
--- a/.changeset/lazy-usb-remote-session.md
+++ b/.changeset/lazy-usb-remote-session.md
@@ -1,0 +1,6 @@
+---
+"stack-chan": minor
+---
+
+M5StackChan CoreS3標準ホストへ、MODから遅延起動できるUSB remote conversation sessionを追加します。
+Codex Voice MODは、会話開始前にremote sessionを有効化して承認要求を受信します。

--- a/docs/architecture/usb-dock-lazy-activation-plan_ja.md
+++ b/docs/architecture/usb-dock-lazy-activation-plan_ja.md
@@ -1,0 +1,432 @@
+# USB dockのMOD駆動遅延起動計画
+
+作成日：2026-07-31
+
+対象：M5StackChan CoreS3向けUSB audio dock、remote conversation capability、Codex Voice MOD。
+
+## 目的
+
+M5StackChan CoreS3の通常hostへUSB dock通信機能を組み込みながら、MODが明示的に要求するまでUSB bridgeを起動しない構成へ変更する。
+
+通常MODではworker、マイク、スピーカー、EVENT transport、USB状態表示を起動しない。
+
+Codex Voice MODでは、`onContextCreated()`から通信を有効化し、音声会話を開始していないstandby状態でも承認要求を受信できるようにする。
+
+既存のAndroid USB audio用hostは、起動直後に通信を開始する互換動作を維持する。
+
+## 実装前提
+
+この計画は、USB dock実装を含む`develop`を作業ブランチへ統合した状態を基準とする。
+
+統合後に、少なくとも次の実装が存在することを確認する。
+
+- `firmware/host/app/docks/android-usb-audio/dock.ts`
+- `firmware/host/app/remote-session/`
+- `firmware/host/modules/usb-audio/`
+- `firmware/host/app/manifest_android_usb_audio.json`
+- `firmware/mods/examples/codex_voice/`
+
+既存のUSB dockは、`usbAudio.enabled=true`のときにhost起動中の`StackchanDock.start()`から`startUsbAudioBridge()`を呼ぶ。
+
+この呼び出しはworkerとUSB transportを開始し、remote sessionを作成するため、モジュールの組み込みと通信開始が同じ段階に置かれている。
+
+Codex Voice MODは既に作成された`robot.conversation.remoteSession`を利用するだけで、dockを起動するAPIを持たない。
+
+## 対象範囲
+
+この変更では、次の動作を実装する。
+
+- 通常hostにUSB dockとremote sessionのモジュールを組み込む。
+- host起動時には、通信開始に必要な軽量な制御オブジェクトだけを作る。
+- MODからの`activate()`でUSB bridgeとremote session runtimeを作る。
+- `deactivate()`またはhost終了時に、作成したリソースを一度だけ解放する。
+- Android USB audio用manifestでは、従来どおり自動的に`activate()`する。
+- Codex Voice MODでは、購読設定より前に`activate()`する。
+
+この変更では、次の項目を扱わない。
+
+- USB CDC v2のwire形式変更。
+- USB接続を使ったMODの自動判定。
+- ESP32-S3のUSB Serial/JTAGデバイス自体を非表示にする処理。
+- 実行中MODを再起動なしで差し替える新しいライフサイクル。
+- 複数種類のdockを同時に選択する汎用レジストリ。
+
+## 守るべき動作
+
+**inactive**は、USB dockモジュールがFirmwareへ組み込まれているが、bridgeを開始していない状態とする。
+
+inactiveでは、次の条件を満たす。
+
+- `stackchan-usb-audio`を実行時importしない。
+- USB audio workerを生成しない。
+- `AudioIn`と共有`AudioOut`を取得しない。
+- HELLOとHELLO_ACKを含むdock protocolを処理しない。
+- 承認画面とUSB状態表示を追加しない。
+- 通常の顔、サーボ、タッチ、音声機能の動作を変えない。
+
+**active**は、USB bridge、remote session runtime、状態表示を作成し、dock protocolを処理できる状態とする。
+
+activeでは、音声会話を開始していないstandby状態でも`approval.request`を受信しなければならない。
+
+`/dev/ttyACM0`の列挙はESP32-S3のUSB Serial/JTAG機能によるため、inactiveの保証対象に含めない。
+
+## 公開API
+
+既存の`RemoteConversationSession`を安定した遅延起動facadeとして維持する。
+
+transport固有の`usbAudio`をMOD公開APIへ出さず、remote conversationのライフサイクルとして有効化する。
+
+APIの候補は次の形とする。
+
+```ts
+export type RemoteConversationActivationState = 'inactive' | 'active'
+
+export type RemoteConversationSession = {
+  readonly activationState: RemoteConversationActivationState
+  readonly state: RemoteConversationState
+  readonly lastError?: string
+  readonly transportState: RemoteConversationTransportState
+
+  activate(): void
+  deactivate(): void
+  requestStart(): string
+  requestStop(): string
+  subscribe(listener: RemoteConversationListener): () => void
+  subscribeTransport(listener: RemoteConversationTransportListener): () => void
+}
+```
+
+`activationState`と`transportState`は区別する。
+
+`activationState='inactive'`では`transportState='disconnected'`を返し、既存のtransport state unionへ新しい値を追加しない。
+
+inactiveで`requestStart()`または`requestStop()`を呼んだ場合は、要求を保留せず、sessionがinactiveであることを示す例外を投げる。
+
+`activate()`と`deactivate()`は冪等にする。
+
+一度`deactivate()`した後の再`activate()`を許可し、USB切断試験とMOD開発時の再試行に利用できるようにする。
+
+## host内部のライフサイクル
+
+`StackchanDock.start()`はUSB bridgeを開始せず、遅延起動facadeを含む`StackchanDockRuntime`を返す。
+
+hostはfacadeを`createStackchanContext()`へ渡すため、MODの`onContextCreated()`から`robot.conversation.remoteSession`を参照できる。
+
+`StackchanDockRuntime.onContextCreated()`は`StackchanContext`とtool providerを保持するが、`autoStart`が無効ならbridgeを開始しない。
+
+`activate()`は次の順序で処理する。
+
+1. `onContextCreated()`が完了し、contextを利用できることを確認する。
+2. `Modules.importNow('stackchan-usb-audio')`でbridge factoryを取得する。
+3. `startUsbAudioBridge()`でbridgeを作る。
+4. `createRemoteSessionRuntime()`でconversationとapprovalのsessionを作る。
+5. remote session runtimeへcontextとtool providerを設定する。
+6. status handlerとpresentationをbridgeへ設定する。
+7. facadeの委譲先をruntimeへ切り替え、`activationState='active'`にする。
+
+手順2から6の途中で失敗した場合は、生成済みのpresentation、remote session runtime、bridgeを逆順で閉じる。
+
+失敗時はfacadeをinactiveへ戻し、呼び出し元へ例外を返す。
+
+このロールバックにより、部分的に起動したworkerやAudioOutが次の再試行を妨げる状態を残さない。
+
+`deactivate()`は次の順序で処理する。
+
+1. facadeをinactiveへ遷移させ、新しい会話要求を拒否する。
+2. status handlerとpresentationをbridgeから外す。
+3. presentationを閉じる。
+4. remote session runtimeを閉じる。
+5. bridgeを閉じる。
+6. active runtimeへの参照を破棄する。
+
+hostの`lifecycle.close()`は、MODが`deactivate()`を呼んでいない場合でも同じ解放処理を一度だけ実行する。
+
+## facadeの委譲規則
+
+facadeはactive runtimeを作り直しても同じオブジェクトを維持する。
+
+この規則により、`StackchanContext`の再生成やMOD側の参照差し替えを不要にする。
+
+inactive中に登録された`subscribe()`と`subscribeTransport()`のlistenerはfacadeが保持する。
+
+activate後はfacadeがactive runtimeを購読し、受け取った状態を既存listenerへ配布する。
+
+deactivate時は、conversation stateを`standby`、transport stateを`disconnected`へ戻してからlistenerへ通知する。
+
+pendingなconversation要求はactive runtimeの`close()`で破棄する。
+
+pendingなCodex承認要求はPC側が所有するため、Firmwareのdeactivateだけで`decline`へ変換しない。
+
+PC側はUSB切断と同様に要求を保持し、再activateまたは別のCodex clientによる解決を待つ。
+
+## manifest構成
+
+通常のM5StackChan CoreS3 manifestへ、dock adapterとUSB audio moduleをincludeする。
+
+通常hostの設定は次の値を基準とする。
+
+```json
+{
+  "config": {
+    "usbAudio": {
+      "enabled": true,
+      "autoStart": false,
+      "speakerVolume": 0.25
+    }
+  }
+}
+```
+
+`enabled`はFirmwareに組み込んだcapabilityを利用可能にする設定として維持する。
+
+`autoStart`はhost起動時にMODの指示を待たずactivateするかを表す。
+
+既存の`manifest_android_usb_audio.json`では`autoStart=true`を指定し、Android dock appの互換動作を維持する。
+
+診断manifestも自動接続を前提とするため、`autoStart=true`を明示する。
+
+USB module manifestの`preload`は削除候補とする。
+
+`Modules.importNow()`だけでworkerを含む全moduleを解決できることをbuildと実機で確認し、起動時preloadが不要なら削除する。
+
+Moddableのmodule解決上preloadが必要な場合でも、module評価によってworkerやAudioInを開始しないことをテストで固定する。
+
+## Codex Voice MOD
+
+Codex Voice MODは`onContextCreated()`の冒頭でremote sessionをactivateする。
+
+activateが成功した後にconversation state、transport state、タッチgestureを購読する。
+
+```js
+export function onContextCreated(robot) {
+  const remoteSession = robot.conversation.remoteSession
+  if (!remoteSession) {
+    trace('[codex-voice] USB remote conversation capability is unavailable\n')
+    return
+  }
+
+  try {
+    remoteSession.activate()
+  } catch (error) {
+    trace(`[codex-voice] activation failed: ${String(error)}\n`)
+    return
+  }
+
+  // 既存のsubscribeとgesture設定を続ける。
+}
+```
+
+Codex MODのロード直後にactivateする理由は、承認要求が音声会話の開始とは独立して届くためである。
+
+最初の前方スワイプまでactivateを遅らせると、standby中の承認UIを表示できない。
+
+## 通常hostのサイズ判定
+
+USB audio worker、event parser、remote session、presentationを通常hostへ追加すると、flashとRAMの使用量が増える。
+
+実装着手時に、機能追加前の通常hostとUSB module組み込み後の通常hostを同じrelease条件でビルドし、次の値を記録する。
+
+- app partitionに対するFirmware binaryの残容量。
+- XS heapの起動直後空き容量。
+- inactive時のworker数。
+- inactive時のAudioInとAudioOutの所有状態。
+- active後とdeactivate後のheap差分。
+
+通常hostがpartitionへ収まらない場合は、機能を削って無理に収めない。
+
+その場合は`manifest_m5stackchan_cores3_dock_capable.json`を追加し、通常動作を保ちながらUSB moduleを組み込んだ配布targetを分ける。
+
+この代替targetでも`autoStart=false`を維持し、Codex MODからのactivateで通信を開始する。
+
+## 実装段階
+
+### 段階1：基準とサイズの固定
+
+- [x] USB dock実装を含む`develop`を作業ブランチへ統合する。
+- [x] 既存の通常hostとAndroid USB audio hostをrelease buildする。
+- [ ] Firmwareサイズと起動時heapを記録する。
+- [ ] Android接続、会話開始、承認表示の既存smoke結果を記録する。
+
+完了条件：機能追加前のサイズと実機動作を、変更後と比較できる。
+
+### 段階2：遅延起動facade
+
+- [x] `RemoteConversationSession`へ`activationState`、`activate()`、`deactivate()`を追加する。
+- [x] inactive時のstate、要求、購読規則を型とテストで固定する。
+- [x] active runtimeを差し替え可能なfacadeをremote-session層へ追加する。
+- [x] activate失敗時の逆順cleanupを実装する。
+- [x] deactivateとhost closeの二重解放を防ぐ。
+
+完了条件：fake transportだけでinactive、activate、deactivate、reactivateの状態遷移を検査できる。
+
+### 段階3：dock runtimeの分割
+
+- [x] `StackchanDock.start()`から`startUsbAudioBridge()`の即時呼び出しを除く。
+- [x] `onContextCreated()`でcontextを保持し、activate可能な状態へ遷移させる。
+- [x] `autoStart=true`の場合だけ`onContextCreated()`からactivateする。
+- [x] presentationとtool providerの生成をactive期間へ限定する。
+- [x] `close()`をfacadeの終了処理へ一本化する。
+
+完了条件：`autoStart=false`でbridge factoryが一度も呼ばれず、`autoStart=true`で従来どおり一度だけ呼ばれる。
+
+### 段階4：manifestとCodex MOD
+
+- [x] 通常のM5StackChan CoreS3 hostへUSB dock moduleをincludeする。
+- [x] 通常hostへ`autoStart=false`を設定する。
+- [x] Android用と診断用manifestへ`autoStart=true`を設定する。
+- [x] 不要であればUSB bridge moduleの`preload`を外す。
+- [x] Codex Voice MODから`activate()`を呼ぶ。
+- [x] MODのactivation失敗をtraceへ残す。
+
+完了条件：同じhost binary上で、通常MODはinactive、Codex Voice MODはactiveになる。
+
+### 段階5：検証と文書更新
+
+- [x] Node.js unit testで遅延起動とcleanupを検査する。
+- [x] architecture checkでmanifestの`autoStart`方針を検査する。
+- [ ] Moddable testでmodule importとworker起動を検査する。
+- [x] 通常host、Android USB audio host、診断host二種、Codex Voice MODをrelease buildする。
+- [ ] CoreS3実機でinactive、Codex接続、Android互換を確認する。
+- [x] Firmware書き込み手順とmanifestの使い分けを更新する。
+- [x] 利用者可視の変更としてrelease impactを判定し、必要ならchangesetまたはrelease noteを追加する。
+
+完了条件：自動テストと実機受入条件をすべて満たし、利用者がhostとMODの組み合わせを選べる。
+
+## テスト計画
+
+### unit test
+
+遅延起動facadeとdock runtimeに、次のケースを追加する。
+
+- `autoStart=false`ではdock作成とcontext設定だけでbridgeをimportしない。
+- 最初の`activate()`でbridgeとruntimeを一度だけ作る。
+- 二回目の`activate()`は新しいworkerを作らない。
+- inactiveの`requestStart()`と`requestStop()`は即座に失敗する。
+- inactiveで登録したlistenerがactivate後の状態を受け取る。
+- `deactivate()`がpresentation、runtime、bridgeを一度ずつ閉じる。
+- 二回目の`deactivate()`は何もしない。
+- deactivate後のactivateで新しいruntimeを作れる。
+- bridge生成失敗とruntime生成失敗で部分リソースを残さない。
+- host closeとdeactivateが重なっても二重closeしない。
+- `autoStart=true`ではcontext作成後にbridgeを開始する。
+
+Codex Voice MODには、fake remote sessionを使って次の動作テストを追加する。
+
+- capabilityが無い場合はactivateしない。
+- activateを購読とgesture登録より先に呼ぶ。
+- activate失敗時はgesture handlerを登録しない。
+- activate成功後は前方スワイプと後方スワイプを既存要求へ変換する。
+
+### buildと静的検査
+
+`firmware/`から次のコマンドを実行する。
+
+```sh
+npm run format
+npm run lint
+npm run test:unit
+npm run check:architecture
+npm run check:manifest
+npm run build:m5stackchan_cores3
+npm run build:android-usb-audio
+npm run mod:build -- mods/examples/codex_voice/manifest.json --mode=release
+```
+
+通常hostがpartition上限へ近づく場合は、release binary sizeをCIで上限検査する。
+
+### CoreS3実機
+
+通常MODを導入した状態で、次の条件を確認する。
+
+- 起動後にUSB bridgeの開始traceが出ない。
+- PCからHELLOを送ってもdock protocolのHELLO_ACKを返さない。
+- マイクとスピーカーをdock workerが取得しない。
+- 顔、サーボ、タッチ、既存音声が従来どおり動作する。
+
+Codex Voice MODを導入した状態で、次の条件を確認する。
+
+- MODロード後にUSB bridgeが一度だけ起動する。
+- Codex dock serviceがHELLO_ACKとEVENT capabilityを受信する。
+- 音声会話を開始していないstandby状態で承認要求を表示する。
+- 画面のOKをCodexの`accept`、NGを`decline`として一度だけ返す。
+- 前方スワイプで会話を開始し、後方スワイプで停止する。
+- USB抜線と再接続後に未解決の承認画面を復元し、会話状態はstandbyから再開する。
+
+Android USB audio用hostで、次の互換条件を確認する。
+
+- MODからactivateしなくても起動直後にHELLO_ACKを返す。
+- Android dock appのマイク、スピーカー、状態表示、承認UIが動作する。
+- `presentationEnabled=false`の診断hostでは画面表示だけを作らない。
+
+## 受入条件
+
+- 通常hostはUSB dock moduleを含むが、通常MODではUSB bridgeを開始しない。
+- Codex Voice MODは明示的なactivateによってUSB bridgeを開始する。
+- Codex承認UIは会話開始前のstandby状態でも利用できる。
+- Android USB audio用manifestの自動開始に回帰がない。
+- activate、deactivate、host closeの全経路でworker、AudioIn、AudioOut、presentationをリークしない。
+- 通常hostがpartitionと起動時heapの許容範囲へ収まる。
+- 通常hostへ収まらない場合は、dock-capable targetを分離し、通常hostの配布を壊さない。
+
+## PRの分割
+
+実装は次の三つのPRへ分ける。
+
+1. remote sessionの遅延起動facade、状態遷移、unit test。
+2. USB dock runtimeの遅延起動、manifest設定、Android互換テスト。
+3. 通常hostへの組み込み、Codex Voice MODのactivate、実機結果、利用者向け文書。
+
+PR 1はhardwareへ依存しない状態機械としてレビューできる。
+
+PR 2は既存Android経路の互換性を固定する。
+
+PR 3はFirmwareサイズと実機結果を確認した後に、通常配布へ含めるかdock-capable targetへ分けるかを確定する。
+
+## 実装結果
+
+実装基点は`origin/develop`の`c25bba5273dbdb23cc0bcc29b7df9494365272c5`である。
+
+作業ブランチは`feat/usb-dock-lazy-activation`である。
+
+通常のM5StackChan CoreS3 hostはUSB dock moduleを含み、`autoStart=false`で起動する構成になった。
+
+Android USB audio hostと診断host二種は`autoStart=true`を明示し、従来の自動開始方針を維持した。
+
+Codex Voice MODはremote sessionの購読とgesture登録より先に`activate()`を呼び、activationに失敗した場合は後続処理を行わない。
+
+### 自動検証
+
+- `npm run format`は631ファイルを検査して成功した。
+- `npm run lint`は成功し、既存の`noUselessConstructor`情報メッセージが一件残った。
+- `npm run check:architecture`は73件すべて成功した。
+- `npm run check:manifest`は6ターゲットすべて成功した。
+- `python -m unittest scripts/test_usb_audio_diagnostics.py`は9件すべて成功した。
+- Moddable test suiteは37 manifestすべて成功した。
+- 通常host、Android USB audio host、診断host二種、Codex Voice MODのrelease buildはすべて成功した。
+
+`npm run test:unit`は77件中76件が成功した。
+
+失敗した`firmware/scripts/lib/firmware-command.test.mjs`の一件は、変更前から同じ実行環境で再現する子プロセスstdout取得の問題である。
+
+今回追加したfacadeとdock runtimeのunit testはすべて成功した。
+
+### Firmwareサイズ
+
+| 対象 | 変更前 | 変更後 | app partition空き |
+| --- | ---: | ---: | ---: |
+| 通常M5StackChan CoreS3 host | `0x5b6530` | `0x5d0830` | `0x9bf7d0`（63%） |
+| Android USB audio host | `0x5d5640` | `0x5d0830` | `0x9bf7d0`（63%） |
+| Android USB audio診断host | 未計測 | `0x5d0840` | `0x9bf7c0`（63%） |
+| Android USB audio診断no-UI host | 未計測 | `0x5d0850` | `0x9bf7b0`（63%） |
+
+通常hostは107,264バイト増加した。
+
+変更後の通常hostは変更前のAndroid USB audio hostより19,984バイト小さく、app partitionには63%の空きがあるため、dock-capable targetは分離しなかった。
+
+### 未実施の受入確認
+
+実機へのFirmware書き込みは実施していない。
+
+このため、起動時heap、inactive時のworkerとAudio入出力の非取得、HELLO_ACKの不応答、Codex承認UI、USB再接続、Android dock appとの実機互換性は未確認である。
+
+Node.jsのfakeを使ったtestではinactive時にUSB module importとbridge factory呼び出しが発生しないことを確認したが、実機workerの未起動は確認していない。

--- a/docs/architecture/usb-dock-lazy-activation-plan_ja.md
+++ b/docs/architecture/usb-dock-lazy-activation-plan_ja.md
@@ -1,6 +1,6 @@
 # USB dockのMOD駆動遅延起動計画
 
-作成日：2026-07-31
+作成日：2026-07-31（Asia/Tokyo）
 
 対象：M5StackChan CoreS3向けUSB audio dock、remote conversation capability、Codex Voice MOD。
 

--- a/firmware/docs/android-usb-audio.md
+++ b/firmware/docs/android-usb-audio.md
@@ -18,9 +18,9 @@ npm run flash:android-usb-audio
 ```
 
 専用manifestは`host/app/manifest_android_usb_audio.json`である。
-このmanifestはCoreS3構成を読み込み、`config.usbAudio.enabled`を有効にする。
+このmanifestは標準CoreS3構成を読み込み、`config.usbAudio.autoStart=true`でUSB dockを自動起動する。
 通常再生時の`AudioOut.volume`は`0.25`に固定する。
-通常manifestではUSB音声ブリッジを起動しない。
+標準CoreS3 manifestにもUSB dockは組み込まれるが、`autoStart=false`であるためMODが`activate()`するまでUSB音声ブリッジを起動しない。
 `flash:android-usb-audio`は書き込み後にserial monitorを起動せず、CDCポートをAndroid向けに解放する。
 ビルドコマンドは、通常版と診断版のmanifestを切り替えた場合に同じtargetの生成物を自動消去してから再構築する。
 これにより、直前に使ったmanifestの音量や診断capabilityが残らない。
@@ -30,8 +30,14 @@ npm run flash:android-usb-audio
 ## Dockの構成
 
 共通の`main.ts`は`stackchan-dock`が登録されている場合だけDockを開始する。
-Android USB Audio用manifestは、このモジュール名をUSB Dock実装へ割り当てる。
-通常版とWASM版はUSB transport、remote session、承認画面をbundleしない。
+M5StackChan CoreS3用manifestは、このモジュール名をUSB Dock実装へ割り当てる。
+共有host manifestとWASM版はUSB transport、remote session、承認画面をbundleしない。
+
+標準CoreS3 hostの`robot.conversation.remoteSession`は、USB bridgeをまだ起動していないinactive状態から始まる。
+USB機能を使うMODは、状態購読や会話要求より前に`remoteSession.activate()`を呼ぶ。
+`activate()`は冪等であり、成功後の`activationState`は`active`になる。
+`deactivate()`はWorker、音声入出力、remote session runtime、状態表示を解放し、同じfacadeを再びactivateできる状態へ戻す。
+inactive時の`requestStart()`と`requestStop()`は要求を保留せず例外を投げる。
 
 Dock内部は次の三つの契約に分かれる。
 
@@ -49,6 +55,7 @@ raw CDC、frame、application eventはMODとmini-appへ公開しない。
 - `ready`：双方がEVENT bit 10を広告し、application eventを送受信できる。
 
 `remoteSession.subscribeTransport()`は、この三値が変化した場合に通知する。
+`activationState='inactive'`の間、`transportState`は`disconnected`である。
 EVENT非対応時の会話要求はrequest IDを返したうえで即座に`blocked`となり、EVENT frameもretry timerも作らない。
 USB未接続時の会話要求は同じrequest IDを最大10秒間保持し、`ready`へ遷移した時点で送信する。
 
@@ -209,6 +216,7 @@ npm run check:architecture
 npm run check:manifest
 npm run test:moddable
 python -m unittest scripts/test_usb_audio_diagnostics.py
+npm run build:m5stackchan_cores3 -- --mode=release
 npm run build:android-usb-audio
 ```
 

--- a/firmware/host/app/capabilities.ts
+++ b/firmware/host/app/capabilities.ts
@@ -177,15 +177,24 @@ export type CameraCapability = {
 
 export type RemoteConversationState = 'standby' | 'connecting' | 'listening' | 'recognizing' | 'speaking' | 'blocked'
 export type RemoteConversationTransportState = 'disconnected' | 'unsupported' | 'ready'
+export type RemoteConversationActivationState = 'inactive' | 'active'
+export type RemoteConversationListener = (state: RemoteConversationState, error?: string) => void
+export type RemoteConversationTransportListener = (state: RemoteConversationTransportState) => void
 
-export type RemoteConversationSession = {
+export type RemoteConversationSessionDelegate = {
   readonly state: RemoteConversationState
   readonly lastError?: string
   readonly transportState: RemoteConversationTransportState
   requestStart(): string
   requestStop(): string
-  subscribe(listener: (state: RemoteConversationState, error?: string) => void): () => void
-  subscribeTransport(listener: (state: RemoteConversationTransportState) => void): () => void
+  subscribe(listener: RemoteConversationListener): () => void
+  subscribeTransport(listener: RemoteConversationTransportListener): () => void
+}
+
+export type RemoteConversationSession = RemoteConversationSessionDelegate & {
+  readonly activationState: RemoteConversationActivationState
+  activate(): void
+  deactivate(): void
 }
 
 export type ConversationCapability = {

--- a/firmware/host/app/docks/android-usb-audio/dock.ts
+++ b/firmware/host/app/docks/android-usb-audio/dock.ts
@@ -1,99 +1,36 @@
 import type { StackchanContext } from 'capabilities'
-import type { StackchanDock, StackchanDockRuntime } from 'dock'
+import type { StackchanDock } from 'dock'
 import config from 'mc/config'
 import Modules from 'modules'
 import type { RealtimeToolProvider } from 'stackchan-realtime-session'
-import {
-  createRemoteSessionRuntime,
-  type RemoteSessionRuntime,
-  type RemoteSessionTransport,
-} from 'stackchan-remote-session-runtime'
-import { createUsbAudioPresentation, type UsbAudioPresentation } from 'stackchan-usb-dock-presentation'
+import { createRemoteSessionRuntime } from 'stackchan-remote-session-runtime'
+import type { UsbAudioPresentation } from 'stackchan-usb-dock-presentation'
 import { usbAudioConversationState } from 'stackchan-usb-dock-presentation-model'
+import { createUsbAudioDockRuntime, type UsbAudioBridgeControl, type UsbAudioConfig } from 'stackchan-usb-dock-runtime'
 import type { StackChanStatus } from 'stackchan-usb-media-session'
 import Timer from 'timer'
 
-type UsbAudioBridgeControl = RemoteSessionTransport & {
-  setPresentation(presentation?: UsbAudioPresentation): void
-  setStatusHandler(handler?: (status: StackChanStatus) => void): void
-}
-
-type UsbAudioBridgeOptions = {
-  speakerVolume?: number
-  diagnostics?: boolean
-}
-
-type UsbAudioConfig = UsbAudioBridgeOptions & {
-  enabled?: boolean
-  presentationEnabled?: boolean
-}
-
-type StartUsbAudioBridge = (options?: UsbAudioBridgeOptions) => UsbAudioBridgeControl
-
 const stackchanUsbDock: StackchanDock = {
-  start(): StackchanDockRuntime | undefined {
+  start() {
     const usbAudio = (config as { usbAudio?: UsbAudioConfig }).usbAudio
     if (!usbAudio?.enabled) return
-    if (!Modules.has('stackchan-usb-audio')) {
-      throw new Error('USB audio Dock is enabled, but the stackchan-usb-audio module is unavailable')
-    }
-    const startUsbAudioBridge = Modules.importNow('stackchan-usb-audio') as StartUsbAudioBridge | undefined
-    if (typeof startUsbAudioBridge !== 'function') {
-      throw new Error('stackchan-usb-audio does not export a bridge starter')
-    }
-
-    const bridge = startUsbAudioBridge({
-      speakerVolume: usbAudio.speakerVolume,
-      diagnostics: usbAudio.diagnostics,
+    return createUsbAudioDockRuntime(usbAudio, {
+      hasUsbAudioModule() {
+        return Modules.has('stackchan-usb-audio')
+      },
+      importUsbAudioModule() {
+        return Modules.importNow('stackchan-usb-audio')
+      },
+      createRemoteRuntime(bridge: UsbAudioBridgeControl<StackChanStatus>) {
+        return createRemoteSessionRuntime(bridge, {
+          set: (callback, milliseconds) => Timer.set(callback, milliseconds),
+          clear: (handle) => Timer.clear(handle as Timer),
+        })
+      },
+      createRealtimeToolProvider,
+      createPresentation: createUsbAudioDockPresentation,
+      conversationState: usbAudioConversationState,
     })
-    let remoteRuntime: RemoteSessionRuntime
-    try {
-      remoteRuntime = createRemoteSessionRuntime(bridge, {
-        set: (callback, milliseconds) => Timer.set(callback, milliseconds),
-        clear: (handle) => Timer.clear(handle as Timer),
-      })
-    } catch (error) {
-      try {
-        bridge.close()
-      } catch (closeError) {
-        trace(`[dock] bridge close failed during startup cleanup: ${String(closeError)}\n`)
-      }
-      throw error
-    }
-
-    let closed = false
-    let presentation: UsbAudioPresentation | undefined
-    return {
-      remoteConversationSession: remoteRuntime.remoteConversationSession,
-      onContextCreated(context) {
-        remoteRuntime.onContextCreated(context, createRealtimeToolProvider(context))
-        bridge.setStatusHandler((status) => remoteRuntime.updateConversationState(usbAudioConversationState(status)))
-        if (usbAudio.presentationEnabled !== false) {
-          presentation = createUsbAudioPresentation(context)
-          bridge.setPresentation(presentation)
-        }
-      },
-      close() {
-        if (closed) return
-        closed = true
-        let firstError: unknown
-        let failed = false
-        const attempt = (operation: () => void) => {
-          try {
-            operation()
-          } catch (error) {
-            if (!failed) firstError = error
-            failed = true
-          }
-        }
-        attempt(() => bridge.setStatusHandler(undefined))
-        attempt(() => bridge.setPresentation(undefined))
-        attempt(() => presentation?.close())
-        presentation = undefined
-        attempt(() => remoteRuntime.close())
-        if (failed) throw firstError
-      },
-    }
   },
 }
 
@@ -109,6 +46,19 @@ function createRealtimeToolProvider(context: StackchanContext): RealtimeToolProv
     throw new TypeError('stackchan-realtime-tools does not export a provider factory')
   }
   return createProvider(context)
+}
+
+function createUsbAudioDockPresentation(context: StackchanContext): UsbAudioPresentation {
+  if (!Modules.has('stackchan-usb-dock-presentation')) {
+    throw new Error('stackchan-usb-dock-presentation is unavailable')
+  }
+  const createPresentation = Modules.importNow('stackchan-usb-dock-presentation') as
+    | ((context: StackchanContext) => UsbAudioPresentation)
+    | undefined
+  if (typeof createPresentation !== 'function') {
+    throw new TypeError('stackchan-usb-dock-presentation does not export a presentation factory')
+  }
+  return createPresentation(context)
 }
 
 export default stackchanUsbDock

--- a/firmware/host/app/docks/android-usb-audio/manifest.json
+++ b/firmware/host/app/docks/android-usb-audio/manifest.json
@@ -6,8 +6,10 @@
     "stackchan-approval-session": "../../remote-session/approval-session",
     "stackchan-conversation-session": "../../remote-session/conversation-session",
     "stackchan-realtime-session": "../../remote-session/realtime-session",
+    "stackchan-remote-session-facade": "../../remote-session/facade",
     "stackchan-remote-session-runtime": "../../remote-session/runtime",
     "stackchan-usb-dock-presentation": "./presentation",
-    "stackchan-usb-dock-presentation-model": "./presentation-model"
+    "stackchan-usb-dock-presentation-model": "./presentation-model",
+    "stackchan-usb-dock-runtime": "./runtime"
   }
 }

--- a/firmware/host/app/docks/android-usb-audio/runtime.test.ts
+++ b/firmware/host/app/docks/android-usb-audio/runtime.test.ts
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type {
+  RemoteConversationListener,
+  RemoteConversationSessionDelegate,
+  RemoteConversationState,
+  RemoteConversationTransportListener,
+  RemoteConversationTransportState,
+  StackchanContext,
+} from 'capabilities'
+import { installRemoteSessionTestAliases } from '../../remote-session/__tests__/node-aliases.js'
+import type { RealtimeToolProvider } from '../../remote-session/realtime-session.js'
+import type {
+  UsbAudioBridgeControl,
+  UsbAudioConfig,
+  UsbAudioDockDependencies,
+  UsbAudioPresentationControl,
+  UsbAudioRemoteRuntime,
+} from './runtime.js'
+
+installRemoteSessionTestAliases()
+
+const { createUsbAudioDockRuntime } = await import('./runtime.js')
+
+class FakeRemoteSession implements RemoteConversationSessionDelegate {
+  state: RemoteConversationState = 'standby'
+  lastError: string | undefined
+  transportState: RemoteConversationTransportState = 'disconnected'
+  readonly stateListeners = new Set<RemoteConversationListener>()
+  readonly transportListeners = new Set<RemoteConversationTransportListener>()
+
+  requestStart(): string {
+    return 'start'
+  }
+
+  requestStop(): string {
+    return 'stop'
+  }
+
+  subscribe(listener: RemoteConversationListener): () => void {
+    this.stateListeners.add(listener)
+    return () => this.stateListeners.delete(listener)
+  }
+
+  subscribeTransport(listener: RemoteConversationTransportListener): () => void {
+    this.transportListeners.add(listener)
+    return () => this.transportListeners.delete(listener)
+  }
+
+  updateState(state: RemoteConversationState, error?: string): void {
+    this.state = state
+    this.lastError = error
+    for (const listener of this.stateListeners) listener(state, error)
+  }
+}
+
+class FakeBridge implements UsbAudioBridgeControl<number> {
+  statusHandler: ((status: number) => void) | undefined
+  presentation: UsbAudioPresentationControl | undefined
+
+  constructor(
+    readonly id: number,
+    private readonly events: string[],
+  ) {}
+
+  setEventHandler(): void {}
+
+  setTransportStateHandler(): void {}
+
+  sendEvent(): Promise<'queued'> {
+    return Promise.resolve('queued')
+  }
+
+  setStatusHandler(handler?: (status: number) => void): void {
+    this.statusHandler = handler
+    this.events.push(`bridge-${this.id}:status:${handler ? 'attach' : 'detach'}`)
+  }
+
+  setPresentation(presentation?: UsbAudioPresentationControl): void {
+    this.presentation = presentation
+    this.events.push(`bridge-${this.id}:presentation:${presentation ? 'attach' : 'detach'}`)
+  }
+
+  close(): void {
+    this.events.push(`bridge-${this.id}:close`)
+  }
+}
+
+function createHarness(config: UsbAudioConfig = {}) {
+  const events: string[] = []
+  const bridges: FakeBridge[] = []
+  const sessions: FakeRemoteSession[] = []
+  let imports = 0
+  let moduleChecks = 0
+  let failRemoteRuntime = false
+  let failPresentation = false
+  const dependencies: UsbAudioDockDependencies<number> = {
+    hasUsbAudioModule() {
+      moduleChecks += 1
+      return true
+    },
+    importUsbAudioModule() {
+      imports += 1
+      return () => {
+        const bridge = new FakeBridge(bridges.length + 1, events)
+        bridges.push(bridge)
+        events.push(`bridge-${bridge.id}:create`)
+        return bridge
+      }
+    },
+    createRemoteRuntime(bridge) {
+      events.push(`runtime-${(bridge as FakeBridge).id}:create`)
+      if (failRemoteRuntime) throw new Error('runtime failed')
+      const session = new FakeRemoteSession()
+      sessions.push(session)
+      const id = sessions.length
+      return {
+        remoteConversationSession: session,
+        onContextCreated() {
+          events.push(`runtime-${id}:attach`)
+        },
+        updateConversationState(state, error) {
+          session.updateState(state, error)
+        },
+        close() {
+          events.push(`runtime-${id}:close`)
+        },
+      } satisfies UsbAudioRemoteRuntime
+    },
+    createRealtimeToolProvider() {
+      events.push('provider:create')
+      return { tools: [] } satisfies RealtimeToolProvider
+    },
+    createPresentation() {
+      events.push('presentation:create')
+      if (failPresentation) throw new Error('presentation failed')
+      const id = bridges.length
+      return {
+        onStatusChanged() {},
+        onPlaybackStarted() {},
+        onPlaybackPower() {},
+        onPlaybackText() {},
+        onPlaybackStopped() {},
+        close() {
+          events.push(`presentation-${id}:close`)
+        },
+      }
+    },
+    conversationState() {
+      return 'listening'
+    },
+  }
+  const runtime = createUsbAudioDockRuntime(config, dependencies)
+  return {
+    bridges,
+    events,
+    runtime,
+    sessions,
+    get imports() {
+      return imports
+    },
+    get moduleChecks() {
+      return moduleChecks
+    },
+    set failRemoteRuntime(value: boolean) {
+      failRemoteRuntime = value
+    },
+    set failPresentation(value: boolean) {
+      failPresentation = value
+    },
+  }
+}
+
+test('manual mode attaches context without importing or starting the bridge', () => {
+  const harness = createHarness({ autoStart: false })
+
+  harness.runtime.onContextCreated({} as StackchanContext)
+
+  assert.equal(harness.runtime.remoteConversationSession?.activationState, 'inactive')
+  assert.equal(harness.moduleChecks, 0)
+  assert.equal(harness.imports, 0)
+  assert.deepEqual(harness.events, [])
+})
+
+test('activate is idempotent and deactivate releases resources in reverse ownership order', () => {
+  const harness = createHarness({ speakerVolume: 0.25 })
+  const remoteSession = harness.runtime.remoteConversationSession
+  assert.ok(remoteSession)
+  harness.runtime.onContextCreated({} as StackchanContext)
+  const states: RemoteConversationState[] = []
+  remoteSession.subscribe((state) => states.push(state))
+
+  remoteSession.activate()
+  remoteSession.activate()
+  harness.bridges[0].statusHandler?.(0)
+
+  assert.equal(harness.imports, 1)
+  assert.equal(remoteSession.activationState, 'active')
+  assert.equal(remoteSession.state, 'listening')
+  assert.deepEqual(states, ['listening'])
+
+  remoteSession.deactivate()
+  remoteSession.deactivate()
+
+  assert.equal(remoteSession.activationState, 'inactive')
+  assert.equal(remoteSession.state, 'standby')
+  assert.deepEqual(harness.events.slice(-5), [
+    'bridge-1:status:detach',
+    'bridge-1:presentation:detach',
+    'presentation-1:close',
+    'runtime-1:close',
+    'bridge-1:close',
+  ])
+
+  remoteSession.activate()
+  assert.equal(harness.imports, 2)
+  assert.equal(harness.bridges.length, 2)
+})
+
+test('activation failure rolls back created resources and can be retried', () => {
+  const harness = createHarness()
+  const remoteSession = harness.runtime.remoteConversationSession
+  assert.ok(remoteSession)
+  harness.runtime.onContextCreated({} as StackchanContext)
+  harness.failPresentation = true
+
+  assert.throws(() => remoteSession.activate(), /presentation failed/)
+  assert.equal(remoteSession.activationState, 'inactive')
+  assert.deepEqual(harness.events.slice(-4), [
+    'bridge-1:status:detach',
+    'bridge-1:presentation:detach',
+    'runtime-1:close',
+    'bridge-1:close',
+  ])
+
+  harness.failPresentation = false
+  remoteSession.activate()
+  assert.equal(remoteSession.activationState, 'active')
+  assert.equal(harness.imports, 2)
+})
+
+test('runtime creation failure closes the bridge without leaving an active facade', () => {
+  const harness = createHarness()
+  const remoteSession = harness.runtime.remoteConversationSession
+  assert.ok(remoteSession)
+  harness.runtime.onContextCreated({} as StackchanContext)
+  harness.failRemoteRuntime = true
+
+  assert.throws(() => remoteSession.activate(), /runtime failed/)
+  assert.equal(remoteSession.activationState, 'inactive')
+  assert.deepEqual(harness.events, [
+    'bridge-1:create',
+    'runtime-1:create',
+    'bridge-1:status:detach',
+    'bridge-1:presentation:detach',
+    'bridge-1:close',
+  ])
+})
+
+test('auto-start activates after context attachment and host close is idempotent', () => {
+  const harness = createHarness({ autoStart: true })
+  const remoteSession = harness.runtime.remoteConversationSession
+  assert.ok(remoteSession)
+
+  harness.runtime.onContextCreated({} as StackchanContext)
+  assert.equal(remoteSession.activationState, 'active')
+  assert.equal(harness.imports, 1)
+
+  harness.runtime.close()
+  harness.runtime.close()
+  remoteSession.deactivate()
+
+  assert.equal(remoteSession.activationState, 'inactive')
+  assert.equal(harness.events.filter((event) => event === 'runtime-1:close').length, 1)
+  assert.equal(harness.events.filter((event) => event === 'bridge-1:close').length, 1)
+  assert.throws(() => remoteSession.activate(), /closed/)
+})
+
+test('activation before context attachment fails without touching the USB module', () => {
+  const harness = createHarness()
+  const remoteSession = harness.runtime.remoteConversationSession
+  assert.ok(remoteSession)
+
+  assert.throws(() => remoteSession.activate(), /before the Stack-chan context/)
+  assert.equal(harness.moduleChecks, 0)
+  assert.equal(harness.imports, 0)
+})

--- a/firmware/host/app/docks/android-usb-audio/runtime.test.ts
+++ b/firmware/host/app/docks/android-usb-audio/runtime.test.ts
@@ -276,6 +276,31 @@ test('auto-start activates after context attachment and host close is idempotent
   assert.throws(() => remoteSession.activate(), /closed/)
 })
 
+test('auto-start failure is logged and leaves the attached context available for retry', () => {
+  const harness = createHarness({ autoStart: true })
+  const remoteSession = harness.runtime.remoteConversationSession
+  assert.ok(remoteSession)
+  harness.failPresentation = true
+  const messages: string[] = []
+  const testGlobal = globalThis as typeof globalThis & { trace?: (message: string) => void }
+  const previousTrace = testGlobal.trace
+  testGlobal.trace = (message) => messages.push(message)
+
+  try {
+    assert.doesNotThrow(() => harness.runtime.onContextCreated({} as StackchanContext))
+  } finally {
+    testGlobal.trace = previousTrace
+  }
+
+  assert.equal(remoteSession.activationState, 'inactive')
+  assert.match(messages.join(''), /\[dock\] auto-start activation failed: presentation failed/)
+
+  harness.failPresentation = false
+  remoteSession.activate()
+  assert.equal(remoteSession.activationState, 'active')
+  assert.equal(harness.imports, 2)
+})
+
 test('activation before context attachment fails without touching the USB module', () => {
   const harness = createHarness()
   const remoteSession = harness.runtime.remoteConversationSession

--- a/firmware/host/app/docks/android-usb-audio/runtime.ts
+++ b/firmware/host/app/docks/android-usb-audio/runtime.ts
@@ -1,0 +1,177 @@
+import type {
+  RemoteConversationSession,
+  RemoteConversationSessionDelegate,
+  RemoteConversationState,
+  StackchanContext,
+} from 'capabilities'
+import type { RealtimeToolProvider } from 'stackchan-realtime-session'
+import {
+  createRemoteConversationSessionFacade,
+  type RemoteConversationSessionBinding,
+} from 'stackchan-remote-session-facade'
+
+export type UsbAudioPresentationControl = {
+  onStatusChanged(status: number): void
+  onPlaybackStarted(): void
+  onPlaybackPower(power: number): void
+  onPlaybackText(text: string): void
+  onPlaybackStopped(): void
+  close(): void
+}
+
+export type UsbAudioBridgeControl<Status> = {
+  setEventHandler(handler?: (event: string) => void): void
+  setTransportStateHandler(handler?: (state: 'disconnected' | 'unsupported' | 'ready') => void): void
+  sendEvent(event: string): Promise<'queued' | 'overflow' | 'disconnected' | 'unsupported'>
+  close(): void
+  setPresentation(presentation?: UsbAudioPresentationControl): void
+  setStatusHandler(handler?: (status: Status) => void): void
+}
+
+export type UsbAudioBridgeOptions = {
+  speakerVolume?: number
+  diagnostics?: boolean
+}
+
+export type UsbAudioConfig = UsbAudioBridgeOptions & {
+  enabled?: boolean
+  autoStart?: boolean
+  presentationEnabled?: boolean
+}
+
+type StartUsbAudioBridge<Status> = (options?: UsbAudioBridgeOptions) => UsbAudioBridgeControl<Status>
+
+export type UsbAudioRemoteRuntime = {
+  readonly remoteConversationSession: RemoteConversationSessionDelegate
+  onContextCreated(context: StackchanContext, provider: RealtimeToolProvider): void
+  updateConversationState(state: RemoteConversationState, error?: string): void
+  close(): void
+}
+
+export type UsbAudioDockRuntime = {
+  readonly remoteConversationSession?: RemoteConversationSession
+  onContextCreated(context: StackchanContext): void
+  close(): void
+}
+
+export type UsbAudioDockDependencies<Status> = {
+  hasUsbAudioModule(): boolean
+  importUsbAudioModule(): unknown
+  createRemoteRuntime(bridge: UsbAudioBridgeControl<Status>): UsbAudioRemoteRuntime
+  createRealtimeToolProvider(context: StackchanContext): RealtimeToolProvider
+  createPresentation(context: StackchanContext): UsbAudioPresentationControl
+  conversationState(status: Status): RemoteConversationState
+}
+
+export function createUsbAudioDockRuntime<Status>(
+  usbAudio: UsbAudioConfig,
+  dependencies: UsbAudioDockDependencies<Status>,
+): UsbAudioDockRuntime {
+  let context: StackchanContext | undefined
+  let contextAttached = false
+  let closed = false
+  const facade = createRemoteConversationSessionFacade(createActiveBinding)
+
+  function createActiveBinding(): RemoteConversationSessionBinding {
+    if (!contextAttached || !context) {
+      throw new Error('USB audio Dock cannot activate before the Stack-chan context is attached')
+    }
+    if (!dependencies.hasUsbAudioModule()) {
+      throw new Error('USB audio Dock is enabled, but the stackchan-usb-audio module is unavailable')
+    }
+    const startUsbAudioBridge = dependencies.importUsbAudioModule()
+    if (typeof startUsbAudioBridge !== 'function') {
+      throw new Error('stackchan-usb-audio does not export a bridge starter')
+    }
+
+    let bridge: UsbAudioBridgeControl<Status> | undefined
+    let remoteRuntime: UsbAudioRemoteRuntime | undefined
+    let presentation: UsbAudioPresentationControl | undefined
+    try {
+      bridge = (startUsbAudioBridge as StartUsbAudioBridge<Status>)({
+        speakerVolume: usbAudio.speakerVolume,
+        diagnostics: usbAudio.diagnostics,
+      })
+      remoteRuntime = dependencies.createRemoteRuntime(bridge)
+      remoteRuntime.onContextCreated(context, dependencies.createRealtimeToolProvider(context))
+      bridge.setStatusHandler((status) =>
+        remoteRuntime?.updateConversationState(dependencies.conversationState(status)),
+      )
+      if (usbAudio.presentationEnabled !== false) {
+        presentation = dependencies.createPresentation(context)
+        bridge.setPresentation(presentation)
+      }
+    } catch (error) {
+      try {
+        closeActiveResources(bridge, remoteRuntime, presentation)
+      } catch (closeError) {
+        log(`[dock] activation cleanup failed: ${errorMessage(closeError)}\n`)
+      }
+      throw error
+    }
+
+    const activeBridge = bridge
+    const activeRemoteRuntime = remoteRuntime
+    const activePresentation = presentation
+    let activeClosed = false
+    return {
+      remoteSession: activeRemoteRuntime.remoteConversationSession,
+      close() {
+        if (activeClosed) return
+        activeClosed = true
+        closeActiveResources(activeBridge, activeRemoteRuntime, activePresentation)
+      },
+    }
+  }
+
+  return {
+    remoteConversationSession: facade.remoteSession,
+    onContextCreated(nextContext) {
+      if (closed) throw new Error('USB audio Dock runtime is closed')
+      if (contextAttached) throw new Error('USB audio Dock context is already attached')
+      context = nextContext
+      contextAttached = true
+      if (usbAudio.autoStart) facade.remoteSession.activate()
+    },
+    close() {
+      if (closed) return
+      closed = true
+      context = undefined
+      facade.close()
+    },
+  }
+}
+
+function closeActiveResources<Status>(
+  bridge: UsbAudioBridgeControl<Status> | undefined,
+  remoteRuntime: UsbAudioRemoteRuntime | undefined,
+  presentation: UsbAudioPresentationControl | undefined,
+): void {
+  let firstError: unknown
+  let failed = false
+  const attempt = (operation: () => void) => {
+    try {
+      operation()
+    } catch (error) {
+      if (!failed) firstError = error
+      failed = true
+    }
+  }
+
+  if (bridge) {
+    attempt(() => bridge.setStatusHandler(undefined))
+    attempt(() => bridge.setPresentation(undefined))
+  }
+  if (presentation) attempt(() => presentation.close())
+  if (remoteRuntime) attempt(() => remoteRuntime.close())
+  if (bridge) attempt(() => bridge.close())
+  if (failed) throw firstError
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function log(message: string): void {
+  if (typeof trace === 'function') trace(message)
+}

--- a/firmware/host/app/docks/android-usb-audio/runtime.ts
+++ b/firmware/host/app/docks/android-usb-audio/runtime.ts
@@ -131,7 +131,13 @@ export function createUsbAudioDockRuntime<Status>(
       if (contextAttached) throw new Error('USB audio Dock context is already attached')
       context = nextContext
       contextAttached = true
-      if (usbAudio.autoStart) facade.remoteSession.activate()
+      if (usbAudio.autoStart) {
+        try {
+          facade.remoteSession.activate()
+        } catch (error) {
+          log(`[dock] auto-start activation failed: ${errorMessage(error)}\n`)
+        }
+      }
     },
     close() {
       if (closed) return

--- a/firmware/host/app/manifest_android_usb_audio.json
+++ b/firmware/host/app/manifest_android_usb_audio.json
@@ -1,12 +1,9 @@
 {
-  "include": [
-    "./manifest_m5stackchan_cores3.json",
-    "./docks/android-usb-audio/manifest.json",
-    "../modules/usb-audio/manifest.json"
-  ],
+  "include": ["./manifest_m5stackchan_cores3.json"],
   "config": {
     "usbAudio": {
       "enabled": true,
+      "autoStart": true,
       "speakerVolume": 0.25
     }
   }

--- a/firmware/host/app/manifest_android_usb_audio_diagnostics.json
+++ b/firmware/host/app/manifest_android_usb_audio_diagnostics.json
@@ -3,6 +3,7 @@
   "config": {
     "usbAudio": {
       "enabled": true,
+      "autoStart": true,
       "diagnostics": true,
       "speakerVolume": 0
     }

--- a/firmware/host/app/manifest_android_usb_audio_diagnostics_no_ui.json
+++ b/firmware/host/app/manifest_android_usb_audio_diagnostics_no_ui.json
@@ -3,6 +3,7 @@
   "config": {
     "usbAudio": {
       "enabled": true,
+      "autoStart": true,
       "diagnostics": true,
       "speakerVolume": 0,
       "presentationEnabled": false

--- a/firmware/host/app/manifest_m5stackchan_cores3.json
+++ b/firmware/host/app/manifest_m5stackchan_cores3.json
@@ -1,6 +1,15 @@
 {
-  "include": ["./manifest.json"],
+  "include": [
+    "./manifest.json",
+    "./docks/android-usb-audio/manifest.json",
+    "../modules/usb-audio/manifest.json"
+  ],
   "config": {
-    "enablePowerButton": false
+    "enablePowerButton": false,
+    "usbAudio": {
+      "enabled": true,
+      "autoStart": false,
+      "speakerVolume": 0.25
+    }
   }
 }

--- a/firmware/host/app/remote-session/__tests__/node-aliases.ts
+++ b/firmware/host/app/remote-session/__tests__/node-aliases.ts
@@ -6,4 +6,5 @@ export function installRemoteSessionTestAliases(): void {
   const hostRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
   const remoteSessionRoot = resolve(hostRoot, 'app/remote-session')
   writeAliasPackage(hostRoot, 'stackchan-application-event', resolve(remoteSessionRoot, 'application-event.js'))
+  writeAliasPackage(hostRoot, 'stackchan-remote-session-facade', resolve(remoteSessionRoot, 'facade.js'))
 }

--- a/firmware/host/app/remote-session/conversation-session.ts
+++ b/firmware/host/app/remote-session/conversation-session.ts
@@ -1,4 +1,8 @@
-import type { RemoteConversationSession, RemoteConversationState, RemoteConversationTransportState } from 'capabilities'
+import type {
+  RemoteConversationSessionDelegate,
+  RemoteConversationState,
+  RemoteConversationTransportState,
+} from 'capabilities'
 import {
   conversationRequest,
   type StackchanInboundApplicationEvent,
@@ -30,7 +34,7 @@ export type ConversationSessionOptions = {
 }
 
 export type ConversationSession = {
-  readonly remoteSession: RemoteConversationSession
+  readonly remoteSession: RemoteConversationSessionDelegate
   handleEvent(event: StackchanInboundApplicationEvent): boolean
   updateState(state: RemoteConversationState, error?: string): void
   close(): void
@@ -175,7 +179,7 @@ export function createConversationSession(
 
   const unsubscribeTransport = transport.subscribeTransport(updateTransportState)
 
-  const remoteSession: RemoteConversationSession = {
+  const remoteSession: RemoteConversationSessionDelegate = {
     get state() {
       return state
     },

--- a/firmware/host/app/remote-session/facade.test.ts
+++ b/firmware/host/app/remote-session/facade.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type {
+  RemoteConversationListener,
+  RemoteConversationSessionDelegate,
+  RemoteConversationState,
+  RemoteConversationTransportListener,
+  RemoteConversationTransportState,
+} from 'capabilities'
+import { createRemoteConversationSessionFacade } from './facade.js'
+
+class FakeRemoteSession implements RemoteConversationSessionDelegate {
+  state: RemoteConversationState = 'standby'
+  lastError: string | undefined
+  transportState: RemoteConversationTransportState = 'disconnected'
+  readonly stateListeners = new Set<RemoteConversationListener>()
+  readonly transportListeners = new Set<RemoteConversationTransportListener>()
+  startRequests = 0
+  stopRequests = 0
+
+  requestStart(): string {
+    this.startRequests += 1
+    return `start-${this.startRequests}`
+  }
+
+  requestStop(): string {
+    this.stopRequests += 1
+    return `stop-${this.stopRequests}`
+  }
+
+  subscribe(listener: RemoteConversationListener): () => void {
+    this.stateListeners.add(listener)
+    return () => this.stateListeners.delete(listener)
+  }
+
+  subscribeTransport(listener: RemoteConversationTransportListener): () => void {
+    this.transportListeners.add(listener)
+    return () => this.transportListeners.delete(listener)
+  }
+
+  updateState(state: RemoteConversationState, error?: string): void {
+    this.state = state
+    this.lastError = error
+    for (const listener of this.stateListeners) listener(state, error)
+  }
+
+  updateTransport(state: RemoteConversationTransportState): void {
+    this.transportState = state
+    for (const listener of this.transportListeners) listener(state)
+  }
+}
+
+test('inactive facade rejects requests and activates one binding idempotently', () => {
+  const delegate = new FakeRemoteSession()
+  let creates = 0
+  let closes = 0
+  const facade = createRemoteConversationSessionFacade(() => {
+    creates += 1
+    return {
+      remoteSession: delegate,
+      close() {
+        closes += 1
+      },
+    }
+  })
+
+  assert.equal(facade.remoteSession.activationState, 'inactive')
+  assert.equal(facade.remoteSession.state, 'standby')
+  assert.equal(facade.remoteSession.lastError, undefined)
+  assert.equal(facade.remoteSession.transportState, 'disconnected')
+  assert.throws(() => facade.remoteSession.requestStart(), /inactive/)
+  assert.throws(() => facade.remoteSession.requestStop(), /inactive/)
+
+  facade.remoteSession.activate()
+  facade.remoteSession.activate()
+
+  assert.equal(creates, 1)
+  assert.equal(facade.remoteSession.activationState, 'active')
+  assert.equal(facade.remoteSession.requestStart(), 'start-1')
+  assert.equal(facade.remoteSession.requestStop(), 'stop-1')
+  assert.equal(closes, 0)
+})
+
+test('listeners survive deactivate and receive updates after reactivation', () => {
+  const delegates = [new FakeRemoteSession(), new FakeRemoteSession()]
+  let creates = 0
+  let closes = 0
+  const facade = createRemoteConversationSessionFacade(() => {
+    const delegate = delegates[creates++]
+    return {
+      remoteSession: delegate,
+      close() {
+        closes += 1
+      },
+    }
+  })
+  const states: Array<[RemoteConversationState, string | undefined]> = []
+  const transports: RemoteConversationTransportState[] = []
+  facade.remoteSession.subscribe((state, error) => states.push([state, error]))
+  facade.remoteSession.subscribeTransport((state) => transports.push(state))
+
+  facade.remoteSession.activate()
+  delegates[0].updateState('listening')
+  delegates[0].updateTransport('ready')
+  facade.remoteSession.deactivate()
+  facade.remoteSession.deactivate()
+
+  assert.equal(facade.remoteSession.activationState, 'inactive')
+  assert.equal(closes, 1)
+  assert.deepEqual(states, [
+    ['listening', undefined],
+    ['standby', undefined],
+  ])
+  assert.deepEqual(transports, ['ready', 'disconnected'])
+  assert.equal(delegates[0].stateListeners.size, 0)
+  assert.equal(delegates[0].transportListeners.size, 0)
+
+  facade.remoteSession.activate()
+  delegates[1].updateState('blocked', 'retry failed')
+  delegates[1].updateTransport('unsupported')
+
+  assert.equal(creates, 2)
+  assert.equal(facade.remoteSession.activationState, 'active')
+  assert.equal(facade.remoteSession.lastError, 'retry failed')
+  assert.deepEqual(states.at(-1), ['blocked', 'retry failed'])
+  assert.equal(transports.at(-1), 'unsupported')
+})
+
+test('activation failure cleans a returned binding and remains retryable', () => {
+  const invalidDelegate = new FakeRemoteSession()
+  invalidDelegate.subscribeTransport = () => {
+    throw new Error('subscribe failed')
+  }
+  const validDelegate = new FakeRemoteSession()
+  let creates = 0
+  let closes = 0
+  const facade = createRemoteConversationSessionFacade(() => ({
+    remoteSession: creates++ === 0 ? invalidDelegate : validDelegate,
+    close() {
+      closes += 1
+    },
+  }))
+
+  assert.throws(() => facade.remoteSession.activate(), /subscribe failed/)
+  assert.equal(facade.remoteSession.activationState, 'inactive')
+  assert.equal(invalidDelegate.stateListeners.size, 0)
+  assert.equal(closes, 1)
+
+  facade.remoteSession.activate()
+  assert.equal(facade.remoteSession.activationState, 'active')
+  assert.equal(creates, 2)
+})
+
+test('deactivation attempts all cleanup and leaves the facade inactive', () => {
+  const delegate = new FakeRemoteSession()
+  delegate.subscribe = (listener) => {
+    delegate.stateListeners.add(listener)
+    return () => {
+      delegate.stateListeners.delete(listener)
+      throw new Error('unsubscribe failed')
+    }
+  }
+  let closed = false
+  const facade = createRemoteConversationSessionFacade(() => ({
+    remoteSession: delegate,
+    close() {
+      closed = true
+      throw new Error('binding close failed')
+    },
+  }))
+
+  facade.remoteSession.activate()
+  assert.throws(() => facade.remoteSession.deactivate(), /unsubscribe failed/)
+
+  assert.equal(closed, true)
+  assert.equal(facade.remoteSession.activationState, 'inactive')
+  assert.equal(facade.remoteSession.state, 'standby')
+  assert.equal(facade.remoteSession.transportState, 'disconnected')
+})
+
+test('final close is idempotent and prevents reactivation', () => {
+  const delegate = new FakeRemoteSession()
+  let closes = 0
+  const facade = createRemoteConversationSessionFacade(() => ({
+    remoteSession: delegate,
+    close() {
+      closes += 1
+    },
+  }))
+
+  facade.remoteSession.activate()
+  facade.close()
+  facade.close()
+
+  assert.equal(closes, 1)
+  assert.equal(facade.remoteSession.activationState, 'inactive')
+  assert.throws(() => facade.remoteSession.activate(), /closed/)
+})

--- a/firmware/host/app/remote-session/facade.ts
+++ b/firmware/host/app/remote-session/facade.ts
@@ -1,0 +1,211 @@
+import type {
+  RemoteConversationActivationState,
+  RemoteConversationListener,
+  RemoteConversationSession,
+  RemoteConversationSessionDelegate,
+  RemoteConversationState,
+  RemoteConversationTransportListener,
+  RemoteConversationTransportState,
+} from 'capabilities'
+
+export type RemoteConversationSessionBinding = {
+  readonly remoteSession: RemoteConversationSessionDelegate
+  close(): void
+}
+
+export type RemoteConversationSessionFacade = {
+  readonly remoteSession: RemoteConversationSession
+  close(): void
+}
+
+type ActiveBinding = {
+  binding: RemoteConversationSessionBinding
+  removeStateListener: () => void
+  removeTransportListener: () => void
+}
+
+export function createRemoteConversationSessionFacade(
+  createBinding: () => RemoteConversationSessionBinding,
+): RemoteConversationSessionFacade {
+  let activationState: RemoteConversationActivationState = 'inactive'
+  let state: RemoteConversationState = 'standby'
+  let lastError: string | undefined
+  let transportState: RemoteConversationTransportState = 'disconnected'
+  let active: ActiveBinding | undefined
+  let transitioning = false
+  let closed = false
+  const listeners = new Set<RemoteConversationListener>()
+  const transportListeners = new Set<RemoteConversationTransportListener>()
+
+  const notifyState = () => {
+    for (const listener of listeners) {
+      try {
+        listener(state, lastError)
+      } catch (error) {
+        log(`[remote-conversation] state listener failed: ${errorMessage(error)}\n`)
+      }
+    }
+  }
+
+  const notifyTransport = () => {
+    for (const listener of transportListeners) {
+      try {
+        listener(transportState)
+      } catch (error) {
+        log(`[remote-conversation] transport listener failed: ${errorMessage(error)}\n`)
+      }
+    }
+  }
+
+  const deactivateActiveBinding = () => {
+    const current = active
+    if (!current) return
+    active = undefined
+    activationState = 'inactive'
+    state = 'standby'
+    lastError = undefined
+    transportState = 'disconnected'
+
+    let firstError: unknown
+    let failed = false
+    const attempt = (operation: () => void) => {
+      try {
+        operation()
+      } catch (error) {
+        if (!failed) firstError = error
+        failed = true
+      }
+    }
+
+    attempt(current.removeStateListener)
+    attempt(current.removeTransportListener)
+    notifyState()
+    notifyTransport()
+    attempt(() => current.binding.close())
+    if (failed) throw firstError
+  }
+
+  const remoteSession: RemoteConversationSession = {
+    get activationState() {
+      return activationState
+    },
+    get state() {
+      return state
+    },
+    get lastError() {
+      return lastError
+    },
+    get transportState() {
+      return transportState
+    },
+    activate() {
+      if (closed) throw new Error('USB remote conversation session is closed')
+      if (active) return
+      if (transitioning) throw new Error('USB remote conversation session lifecycle transition is in progress')
+      transitioning = true
+      let binding: RemoteConversationSessionBinding | undefined
+      let removeStateListener: (() => void) | undefined
+      let removeTransportListener: (() => void) | undefined
+      try {
+        binding = createBinding()
+        const previousState = state
+        const previousError = lastError
+        const previousTransportState = transportState
+        removeStateListener = binding.remoteSession.subscribe((nextState, error) => {
+          if (active?.binding !== binding) return
+          if (state === nextState && lastError === error) return
+          state = nextState
+          lastError = error
+          notifyState()
+        })
+        removeTransportListener = binding.remoteSession.subscribeTransport((nextState) => {
+          if (active?.binding !== binding || transportState === nextState) return
+          transportState = nextState
+          notifyTransport()
+        })
+        state = binding.remoteSession.state
+        lastError = binding.remoteSession.lastError
+        transportState = binding.remoteSession.transportState
+        active = {
+          binding,
+          removeStateListener,
+          removeTransportListener,
+        }
+        activationState = 'active'
+        if (state !== previousState || lastError !== previousError) notifyState()
+        if (transportState !== previousTransportState) notifyTransport()
+      } catch (error) {
+        tryCleanup(removeStateListener)
+        tryCleanup(removeTransportListener)
+        tryCleanup(binding ? () => binding.close() : undefined)
+        state = 'standby'
+        lastError = undefined
+        transportState = 'disconnected'
+        activationState = 'inactive'
+        active = undefined
+        throw error
+      } finally {
+        transitioning = false
+      }
+    },
+    deactivate() {
+      if (closed || !active) return
+      if (transitioning) throw new Error('USB remote conversation session lifecycle transition is in progress')
+      transitioning = true
+      try {
+        deactivateActiveBinding()
+      } finally {
+        transitioning = false
+      }
+    },
+    requestStart() {
+      if (!active) throw new Error('USB remote conversation session is inactive')
+      return active.binding.remoteSession.requestStart()
+    },
+    requestStop() {
+      if (!active) throw new Error('USB remote conversation session is inactive')
+      return active.binding.remoteSession.requestStop()
+    },
+    subscribe(listener) {
+      if (closed) return () => undefined
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    subscribeTransport(listener) {
+      if (closed) return () => undefined
+      transportListeners.add(listener)
+      return () => transportListeners.delete(listener)
+    },
+  }
+
+  return {
+    remoteSession,
+    close() {
+      if (closed) return
+      closed = true
+      try {
+        deactivateActiveBinding()
+      } finally {
+        listeners.clear()
+        transportListeners.clear()
+      }
+    },
+  }
+}
+
+function tryCleanup(operation?: () => void): void {
+  if (!operation) return
+  try {
+    operation()
+  } catch (error) {
+    log(`[remote-conversation] activation cleanup failed: ${errorMessage(error)}\n`)
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function log(message: string): void {
+  if (typeof trace === 'function') trace(message)
+}

--- a/firmware/host/app/remote-session/runtime.ts
+++ b/firmware/host/app/remote-session/runtime.ts
@@ -1,4 +1,4 @@
-import type { RemoteConversationSession, RemoteConversationState, StackchanContext } from 'capabilities'
+import type { RemoteConversationSessionDelegate, RemoteConversationState, StackchanContext } from 'capabilities'
 import { type ApprovalSession, createApprovalSession } from 'stackchan-approval-session'
 import { type ConversationRetryScheduler, createConversationSession } from 'stackchan-conversation-session'
 import {
@@ -8,12 +8,10 @@ import {
   type RealtimeToolProvider,
 } from 'stackchan-realtime-session'
 
-export type RemoteSessionTransport = RealtimeEventBridge & {
-  close(): void
-}
+export type RemoteSessionTransport = RealtimeEventBridge
 
 export type RemoteSessionRuntime = {
-  readonly remoteConversationSession: RemoteConversationSession
+  readonly remoteConversationSession: RemoteConversationSessionDelegate
   onContextCreated(context: StackchanContext, provider: RealtimeToolProvider): void
   updateConversationState(state: RemoteConversationState, error?: string): void
   close(): void
@@ -65,7 +63,6 @@ export function createRemoteSessionRuntime(
       close(() => approvalSession?.close())
       close(() => conversationSession.close())
       close(() => realtimeSession.close())
-      close(() => transport.close())
       removeApprovalHandler = undefined
       removeConversationHandler = undefined
       approvalSession = undefined

--- a/firmware/host/modules/testing/fakes/capabilities.ts
+++ b/firmware/host/modules/testing/fakes/capabilities.ts
@@ -26,15 +26,24 @@ export type WebRadioCapability = {
 
 export type RemoteConversationState = 'standby' | 'connecting' | 'listening' | 'recognizing' | 'speaking' | 'blocked'
 export type RemoteConversationTransportState = 'disconnected' | 'unsupported' | 'ready'
+export type RemoteConversationActivationState = 'inactive' | 'active'
+export type RemoteConversationListener = (state: RemoteConversationState, error?: string) => void
+export type RemoteConversationTransportListener = (state: RemoteConversationTransportState) => void
 
-export type RemoteConversationSession = {
+export type RemoteConversationSessionDelegate = {
   readonly state: RemoteConversationState
   readonly lastError?: string
   readonly transportState: RemoteConversationTransportState
   requestStart(): string
   requestStop(): string
-  subscribe(listener: (state: RemoteConversationState, error?: string) => void): () => void
-  subscribeTransport(listener: (state: RemoteConversationTransportState) => void): () => void
+  subscribe(listener: RemoteConversationListener): () => void
+  subscribeTransport(listener: RemoteConversationTransportListener): () => void
+}
+
+export type RemoteConversationSession = RemoteConversationSessionDelegate & {
+  readonly activationState: RemoteConversationActivationState
+  activate(): void
+  deactivate(): void
 }
 
 export type StackchanContext = unknown

--- a/firmware/host/modules/usb-audio/manifest.json
+++ b/firmware/host/modules/usb-audio/manifest.json
@@ -27,7 +27,6 @@
     "stackchan-usb-stream-gate": "./stream-gate",
     "stackchan-usb-stream-tx-queue": "./stream-tx-queue"
   },
-  "preload": ["stackchan-usb-audio"],
   "platforms": {
     "esp32/m5stackchan_cores3": {
       "build": {

--- a/firmware/host/modules/usb-audio/usb-audio.architecture.ts
+++ b/firmware/host/modules/usb-audio/usb-audio.architecture.ts
@@ -8,11 +8,20 @@ type Manifest = {
   modules?: Record<string, string | string[]>
   preload?: string[]
   platforms?: Record<string, { modules?: Record<string, string> }>
-  config?: { usbAudio?: { enabled?: boolean; diagnostics?: boolean; presentationEnabled?: boolean } }
+  config?: {
+    usbAudio?: {
+      enabled?: boolean
+      autoStart?: boolean
+      diagnostics?: boolean
+      presentationEnabled?: boolean
+      speakerVolume?: number
+    }
+  }
 }
 
 const appManifest = readManifest('host/app/manifest.json')
 const wasmManifest = readManifest('host/platforms/wasm/manifest.json')
+const coreS3Manifest = readManifest('host/app/manifest_m5stackchan_cores3.json')
 const usbAppManifest = readManifest('host/app/manifest_android_usb_audio.json')
 const diagnosticAppManifest = readManifest('host/app/manifest_android_usb_audio_diagnostics.json')
 const diagnosticNoUiAppManifest = readManifest('host/app/manifest_android_usb_audio_diagnostics_no_ui.json')
@@ -22,7 +31,7 @@ const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
   scripts?: Record<string, string>
 }
 
-test('Stackchan Dock keeps USB application integration out of the shared host graph', () => {
+test('CoreS3 composes the USB Dock without leaking it into shared or WASM graphs', () => {
   const sharedModules = asModuleList(appManifest)
   const wasmModules = asModuleList(wasmManifest)
 
@@ -31,11 +40,14 @@ test('Stackchan Dock keeps USB application integration out of the shared host gr
   for (const specifier of [...sharedModules, ...wasmModules]) {
     assert.doesNotMatch(specifier, /usb|remote-session|approval/)
   }
-  assert.ok(usbAppManifest.include?.includes('./docks/android-usb-audio/manifest.json'))
-  assert.ok(usbAppManifest.include?.includes('../modules/usb-audio/manifest.json'))
+  assert.ok(coreS3Manifest.include?.includes('./docks/android-usb-audio/manifest.json'))
+  assert.ok(coreS3Manifest.include?.includes('../modules/usb-audio/manifest.json'))
+  assert.deepEqual(usbAppManifest.include, ['./manifest_m5stackchan_cores3.json'])
   assert.equal(dockManifest.modules?.['stackchan-dock'], './dock')
+  assert.equal(dockManifest.modules?.['stackchan-remote-session-facade'], '../../remote-session/facade')
   assert.equal(dockManifest.modules?.['stackchan-remote-session-runtime'], '../../remote-session/runtime')
   assert.equal(dockManifest.modules?.['stackchan-usb-dock-presentation'], './presentation')
+  assert.equal(dockManifest.modules?.['stackchan-usb-dock-runtime'], './runtime')
 })
 
 test('USB transport stays platform-specific while physical audio remains on the main VM', () => {
@@ -60,7 +72,7 @@ test('USB transport stays platform-specific while physical audio remains on the 
   assert.equal(usbModuleManifest.modules?.['stackchan-usb-audio-worker'], './worker')
   assert.equal(usbModuleManifest.modules?.['stackchan-usb-media-session'], './media-session')
   assert.equal(usbModuleManifest.modules?.['stackchan-usb-serial-types'], './usb-serial-types')
-  assert.deepEqual(usbModuleManifest.preload, ['stackchan-usb-audio'])
+  assert.equal(usbModuleManifest.preload, undefined)
   assert.deepEqual(Object.keys(usbModuleManifest.platforms ?? {}), ['esp32/m5stackchan_cores3'])
   assert.equal(usbModuleManifest.modules?.['stackchan-usb-serial'], undefined)
   assert.equal(usbModuleManifest.modules?.['stackchan-usb-crc32'], undefined)
@@ -75,10 +87,16 @@ test('USB transport stays platform-specific while physical audio remains on the 
 })
 
 test('release and diagnostic manifests compose the same USB Dock in layers', () => {
+  assert.equal(coreS3Manifest.config?.usbAudio?.enabled, true)
+  assert.equal(coreS3Manifest.config?.usbAudio?.autoStart, false)
+  assert.equal(coreS3Manifest.config?.usbAudio?.speakerVolume, 0.25)
   assert.equal(usbAppManifest.config?.usbAudio?.enabled, true)
+  assert.equal(usbAppManifest.config?.usbAudio?.autoStart, true)
   assert.ok(diagnosticAppManifest.include?.includes('./manifest_android_usb_audio.json'))
+  assert.equal(diagnosticAppManifest.config?.usbAudio?.autoStart, true)
   assert.equal(diagnosticAppManifest.config?.usbAudio?.diagnostics, true)
   assert.ok(diagnosticNoUiAppManifest.include?.includes('./manifest_android_usb_audio_diagnostics.json'))
+  assert.equal(diagnosticNoUiAppManifest.config?.usbAudio?.autoStart, true)
   assert.equal(diagnosticNoUiAppManifest.config?.usbAudio?.presentationEnabled, false)
 
   for (const script of ['build:android-usb-audio', 'flash:android-usb-audio']) {

--- a/firmware/mods/examples/codex_voice/__tests__/codex-voice/codex-voice.test.js
+++ b/firmware/mods/examples/codex_voice/__tests__/codex-voice/codex-voice.test.js
@@ -1,0 +1,95 @@
+import { onContextCreated } from 'mod'
+import { equal } from 'testing/assert'
+
+function createTouchPanel(events) {
+  let handler
+  const touchPanel = {}
+  Object.defineProperty(touchPanel, 'onEvent', {
+    get() {
+      return handler
+    },
+    set(value) {
+      events.push('gesture')
+      handler = value
+    },
+  })
+  return touchPanel
+}
+
+function createRemoteSession(events, activationError) {
+  return {
+    transportState: 'disconnected',
+    activate() {
+      events.push('activate')
+      if (activationError) throw activationError
+    },
+    subscribe() {
+      events.push('subscribe')
+      return () => {}
+    },
+    subscribeTransport() {
+      events.push('subscribeTransport')
+      return () => {}
+    },
+    requestStart() {
+      events.push('start')
+      return 'start-1'
+    },
+    requestStop() {
+      events.push('stop')
+      return 'stop-1'
+    },
+  }
+}
+
+{
+  const events = []
+  const touchPanel = createTouchPanel(events)
+  onContextCreated({
+    conversation: {},
+    input: { touchPanel },
+  })
+  equal(events.length, 0, 'missing capability should not activate or install a gesture handler')
+}
+
+{
+  const events = []
+  const touchPanel = createTouchPanel(events)
+  const remoteSession = createRemoteSession(events)
+  onContextCreated({
+    conversation: { remoteSession },
+    input: { touchPanel },
+  })
+
+  equal(events.join(','), 'activate,subscribe,subscribeTransport,gesture', 'activation should precede subscriptions')
+  touchPanel.onEvent({ gesture: 'forwardSwipe' })
+  touchPanel.onEvent({ gesture: 'backwardSwipe' })
+  equal(events.slice(-2).join(','), 'start,stop', 'swipes should request conversation start and stop')
+}
+
+{
+  const events = []
+  const touchPanel = createTouchPanel(events)
+  const remoteSession = createRemoteSession(events, new Error('USB unavailable'))
+  onContextCreated({
+    conversation: { remoteSession },
+    input: { touchPanel },
+  })
+  equal(events.join(','), 'activate', 'activation failure should not subscribe or install a gesture handler')
+}
+
+{
+  const events = []
+  const remoteSession = createRemoteSession(events)
+  onContextCreated({
+    conversation: { remoteSession },
+    input: {},
+  })
+  equal(
+    events.join(','),
+    'activate,subscribe,subscribeTransport',
+    'missing touch should leave remote approval handling active',
+  )
+}
+
+trace('ok\n')

--- a/firmware/mods/examples/codex_voice/__tests__/codex-voice/manifest.test.json
+++ b/firmware/mods/examples/codex_voice/__tests__/codex-voice/manifest.test.json
@@ -1,0 +1,10 @@
+{
+  "include": [
+    "$(MODDABLE)/examples/manifest_base.json",
+    "../../manifest.json",
+    "../../../../../host/modules/testing/manifest.json"
+  ],
+  "modules": {
+    "main": "./codex-voice.test"
+  }
+}

--- a/firmware/mods/examples/codex_voice/mod.js
+++ b/firmware/mods/examples/codex_voice/mod.js
@@ -1,12 +1,14 @@
 export function onContextCreated(robot) {
   const remoteSession = robot.conversation.remoteSession
-  const touchPanel = robot.input.touchPanel
   if (!remoteSession) {
     trace('[codex-voice] USB remote conversation capability is unavailable\n')
     return
   }
-  if (!touchPanel) {
-    trace('[codex-voice] top touch panel is unavailable\n')
+
+  try {
+    remoteSession.activate()
+  } catch (error) {
+    trace(`[codex-voice] activation failed: ${String(error)}\n`)
     return
   }
 
@@ -16,6 +18,12 @@ export function onContextCreated(robot) {
   remoteSession.subscribeTransport((state) => {
     trace(`[codex-voice] transport=${state}\n`)
   })
+
+  const touchPanel = robot.input.touchPanel
+  if (!touchPanel) {
+    trace('[codex-voice] top touch panel is unavailable; approval handling remains active\n')
+    return
+  }
   touchPanel.onEvent = (event) => {
     if (event.gesture === 'forwardSwipe') {
       const requestId = remoteSession.requestStart()

--- a/firmware/tsconfig.test.json
+++ b/firmware/tsconfig.test.json
@@ -235,6 +235,9 @@
       "stackchan-remote-session-runtime": [
         "host/app/remote-session/runtime.ts"
       ],
+      "stackchan-remote-session-facade": [
+        "host/app/remote-session/facade.ts"
+      ],
       "stackchan-owned-resources": [
         "host/app/owned-resources.ts"
       ],


### PR DESCRIPTION
## Summary

- Add the USB remote conversation session to the standard M5StackChan CoreS3 host without starting its Worker or audio resources until a MOD explicitly activates it.
- Let Codex Voice activate the session during context creation while preserving Android USB Audio hosts' existing automatic startup behavior.

## What Changed

- Added a stable `RemoteConversationSession` facade with idempotent activation, deactivation, retry, listener retention, and partial-startup cleanup.
- Moved USB bridge, remote runtime, tool provider, presentation, and status-handler creation into the active lifetime.
- Enabled the dock in the standard CoreS3 manifest with `autoStart=false`; Android and diagnostic manifests use `autoStart=true`.
- Updated Codex Voice to activate before subscribing or installing gesture handlers.
- Added unit, Moddable, architecture, manifest, and diagnostic coverage plus implementation and user documentation.

## Verification

- [x] `cd firmware && npm run format`
- [x] `cd firmware && npm run lint`
- [ ] `cd firmware && npm run test`
- [x] `cd firmware && npm run check:legacy-names`
- [x] Other checks were run when relevant

Local `npm run test:unit` passed 76 of 77 top-level tests.
The remaining `firmware-command.test.mjs` failure also reproduces before this change in the current execution environment; the newly added facade and dock runtime tests pass.

Additional successful checks:

- `npm run check:architecture` — 73 tests
- `npm run check:manifest` — 6 targets
- `npm run test:moddable` — 37 manifests
- `python -m unittest scripts/test_usb_audio_diagnostics.py` — 9 tests
- Release builds for the standard host, Android host, both diagnostic hosts, and Codex Voice MOD

The standard host image uses `0x5d0830` bytes and leaves 63% of the app partition free.
No firmware was flashed, so heap usage and hardware USB/Android acceptance checks remain unverified.

## Affected Areas

- [x] firmware
- [ ] web
- [ ] schematics
- [ ] case
- [x] docs
- [ ] ci/github-actions

## Breaking Changes

- [x] none
- [ ] yes, described below

## Release Impact

- `minor`
- Included `.changeset/lazy-usb-remote-session.md`

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delayed-start “USB remote conversation” sessions for M5StackChan CoreS3.
  * Android USB audio dock now supports explicit and automatic activation of remote-session approval handling.
  * Enabled USB audio auto-start in the Android USB audio and diagnostics variants (configuration-driven).
* **Bug Fixes**
  * Auto-start activation failures are now logged and won’t break the dock; activation remains retryable.
  * Improved listener lifecycle, idempotent activation/deactivation, and startup/shutdown rollback behavior.
* **Documentation**
  * Added/updated Japanese architecture and Android USB audio documentation for lazy activation and validation.
* **Tests**
  * Added extensive coverage for remote-session facade and Android USB audio runtime lifecycle and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->